### PR TITLE
Round-trip lossy notebook fields (Sprint 0)

### DIFF
--- a/extensions/loom/notebook-parser.ts
+++ b/extensions/loom/notebook-parser.ts
@@ -46,6 +46,7 @@ export interface ParsedNotebook {
   galaxyReferences: GalaxyReference[];
   interpretation?: InterpretationFindings;
   dataProvenance?: DataProvenance;
+  researchQuestionDetails?: ResearchQuestion;
 }
 
 export interface NotebookFrontmatter {
@@ -503,6 +504,26 @@ export function parseInterpretation(content: string): InterpretationFindings | u
 }
 
 /**
+ * Parse the authoritative research_question_json block from the Research Context
+ * section. Returns hypothesis, PICO, and literature references that the markdown
+ * rendering shows but does not preserve in parse-friendly form.
+ */
+export function parseResearchQuestionDetails(content: string): ResearchQuestion | undefined {
+  const section = getSection(content, "Research Context");
+  if (!section) return undefined;
+
+  const match = section.match(/research_question_json:\s*'([\s\S]*?)'\s*\n/);
+  if (!match) return undefined;
+
+  try {
+    const json = match[1].replace(/''/g, "'");
+    return JSON.parse(json) as ResearchQuestion;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Parse the Data Provenance YAML block (authoritative) from the Data Provenance section.
  * The block is a single `provenance_json: '<json>'` line to bypass nested-array
  * limits of the handwritten YAML parser.
@@ -594,6 +615,7 @@ export function parseNotebook(content: string): ParsedNotebook | null {
     galaxyReferences: parseGalaxyReferences(content),
     interpretation: parseInterpretation(content),
     dataProvenance: parseDataProvenance(content),
+    researchQuestionDetails: parseResearchQuestionDetails(content),
   };
 }
 
@@ -726,6 +748,10 @@ export function notebookToPlan(notebook: ParsedNotebook): AnalysisPlan {
 
   if (notebook.dataProvenance) {
     plan.dataProvenance = notebook.dataProvenance;
+  }
+
+  if (notebook.researchQuestionDetails) {
+    plan.researchQuestion = notebook.researchQuestionDetails;
   }
 
   return plan;

--- a/extensions/loom/notebook-parser.ts
+++ b/extensions/loom/notebook-parser.ts
@@ -45,6 +45,7 @@ export interface ParsedNotebook {
   events: ParsedEvent[];
   galaxyReferences: GalaxyReference[];
   interpretation?: InterpretationFindings;
+  dataProvenance?: DataProvenance;
 }
 
 export interface NotebookFrontmatter {
@@ -502,6 +503,27 @@ export function parseInterpretation(content: string): InterpretationFindings | u
 }
 
 /**
+ * Parse the Data Provenance YAML block (authoritative) from the Data Provenance section.
+ * The block is a single `provenance_json: '<json>'` line to bypass nested-array
+ * limits of the handwritten YAML parser.
+ */
+export function parseDataProvenance(content: string): DataProvenance | undefined {
+  const section = getSection(content, "Data Provenance");
+  if (!section) return undefined;
+
+  const match = section.match(/provenance_json:\s*'([\s\S]*?)'\s*\n/);
+  if (!match) return undefined;
+
+  try {
+    const json = match[1].replace(/''/g, "'");
+    const dp = JSON.parse(json) as DataProvenance;
+    return dp;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Parse the BRC Catalog Context section
  */
 export function parseBRCContext(content: string): BRCContext | undefined {
@@ -571,6 +593,7 @@ export function parseNotebook(content: string): ParsedNotebook | null {
     events: parseEventBlocks(content),
     galaxyReferences: parseGalaxyReferences(content),
     interpretation: parseInterpretation(content),
+    dataProvenance: parseDataProvenance(content),
   };
 }
 
@@ -699,6 +722,10 @@ export function notebookToPlan(notebook: ParsedNotebook): AnalysisPlan {
 
   if (notebook.interpretation) {
     plan.interpretation = notebook.interpretation;
+  }
+
+  if (notebook.dataProvenance) {
+    plan.dataProvenance = notebook.dataProvenance;
   }
 
   return plan;

--- a/extensions/loom/notebook-parser.ts
+++ b/extensions/loom/notebook-parser.ts
@@ -72,12 +72,16 @@ export interface ParsedStep {
     tool_id?: string;
     workflow_id?: string;
     trs_id?: string;
+    parameters?: Record<string, unknown>;
   };
   inputs: Array<{ name: string; dataset_ids?: string[] }>;
   outputs: Array<{ dataset_id: string; name: string; url?: string }>;
   job_id?: string;
   job_url?: string;
   invocation_id?: string;
+  completed_at?: string;
+  summary?: string;
+  qc_passed?: boolean | null;
   workflow_structure?: {
     step_count: number;
     tools?: string[];
@@ -306,22 +310,46 @@ export function parseStepBlocks(content: string): ParsedStep[] {
         };
       }
 
+      const executionData = (stepData.execution as Record<string, unknown>) || {};
+      let parameters: Record<string, unknown> | undefined;
+      if (typeof executionData.parameters === "string" && executionData.parameters.length > 0) {
+        try {
+          parameters = JSON.parse(executionData.parameters) as Record<string, unknown>;
+        } catch {
+          // Bad JSON — drop rather than crash
+        }
+      } else if (executionData.parameters && typeof executionData.parameters === "object") {
+        parameters = executionData.parameters as Record<string, unknown>;
+      }
+
+      const qcPassedRaw = stepData.qc_passed;
+      const qcPassed =
+        typeof qcPassedRaw === "boolean"
+          ? qcPassedRaw
+          : qcPassedRaw === null
+          ? null
+          : undefined;
+
       steps.push({
         id: String(stepData.id || ""),
         name: String(stepData.name || ""),
         status: (stepData.status as StepStatus) || "pending",
         description: String(stepData.description || ""),
         execution: {
-          type: ((stepData.execution as Record<string, unknown>)?.type as ExecutionType) || "tool",
-          tool_id: (stepData.execution as Record<string, unknown>)?.tool_id as string | undefined,
-          workflow_id: (stepData.execution as Record<string, unknown>)?.workflow_id as string | undefined,
-          trs_id: (stepData.execution as Record<string, unknown>)?.trs_id as string | undefined,
+          type: (executionData.type as ExecutionType) || "tool",
+          tool_id: executionData.tool_id as string | undefined,
+          workflow_id: executionData.workflow_id as string | undefined,
+          trs_id: executionData.trs_id as string | undefined,
+          parameters,
         },
         inputs: (stepData.inputs as Array<{ name: string; dataset_ids?: string[] }>) || [],
         outputs: (stepData.outputs as Array<{ dataset_id: string; name: string; url?: string }>) || [],
         job_id: stepData.job_id as string | undefined,
         job_url: stepData.job_url as string | undefined,
         invocation_id: stepData.invocation_id as string | undefined,
+        completed_at: stepData.completed_at as string | undefined,
+        summary: stepData.summary as string | undefined,
+        qc_passed: qcPassed,
         workflow_structure: workflowStructure,
       });
     }
@@ -569,6 +597,23 @@ export function notebookToPlan(notebook: ParsedNotebook): AnalysisPlan {
       };
     }
 
+    const hasResult =
+      step.job_id ||
+      step.invocation_id ||
+      step.completed_at ||
+      step.summary ||
+      step.qc_passed !== undefined;
+
+    const result: StepResult | undefined = hasResult
+      ? {
+          completedAt: step.completed_at || "",
+          jobId: step.job_id,
+          invocationId: step.invocation_id,
+          summary: step.summary || "",
+          qcPassed: step.qc_passed === undefined ? null : step.qc_passed,
+        }
+      : undefined;
+
     return {
       id: step.id,
       name: step.name,
@@ -579,6 +624,7 @@ export function notebookToPlan(notebook: ParsedNotebook): AnalysisPlan {
         toolId: step.execution.tool_id,
         workflowId: step.execution.workflow_id,
         trsId: step.execution.trs_id,
+        parameters: step.execution.parameters,
       },
       inputs: step.inputs.map((i) => ({
         name: i.name,
@@ -591,15 +637,7 @@ export function notebookToPlan(notebook: ParsedNotebook): AnalysisPlan {
         name: o.name,
         datatype: "",
       })),
-      result: step.job_id
-        ? {
-            completedAt: "",
-            jobId: step.job_id,
-            invocationId: step.invocation_id,
-            summary: "",
-            qcPassed: null,
-          }
-        : undefined,
+      result,
       workflowStructure,
       dependsOn: [],
     };

--- a/extensions/loom/notebook-parser.ts
+++ b/extensions/loom/notebook-parser.ts
@@ -47,6 +47,7 @@ export interface ParsedNotebook {
   interpretation?: InterpretationFindings;
   dataProvenance?: DataProvenance;
   researchQuestionDetails?: ResearchQuestion;
+  publication?: PublicationMaterials;
 }
 
 export interface NotebookFrontmatter {
@@ -504,6 +505,25 @@ export function parseInterpretation(content: string): InterpretationFindings | u
 }
 
 /**
+ * Parse the authoritative publication_json block from the Publication Materials section.
+ * Covers methods draft, figures, supplementary data, and data sharing info.
+ */
+export function parsePublicationMaterials(content: string): PublicationMaterials | undefined {
+  const section = getSection(content, "Publication Materials");
+  if (!section) return undefined;
+
+  const match = section.match(/publication_json:\s*'([\s\S]*?)'\s*\n/);
+  if (!match) return undefined;
+
+  try {
+    const json = match[1].replace(/''/g, "'");
+    return JSON.parse(json) as PublicationMaterials;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Parse the authoritative research_question_json block from the Research Context
  * section. Returns hypothesis, PICO, and literature references that the markdown
  * rendering shows but does not preserve in parse-friendly form.
@@ -616,6 +636,7 @@ export function parseNotebook(content: string): ParsedNotebook | null {
     interpretation: parseInterpretation(content),
     dataProvenance: parseDataProvenance(content),
     researchQuestionDetails: parseResearchQuestionDetails(content),
+    publication: parsePublicationMaterials(content),
   };
 }
 
@@ -752,6 +773,10 @@ export function notebookToPlan(notebook: ParsedNotebook): AnalysisPlan {
 
   if (notebook.researchQuestionDetails) {
     plan.researchQuestion = notebook.researchQuestionDetails;
+  }
+
+  if (notebook.publication) {
+    plan.publication = notebook.publication;
   }
 
   return plan;

--- a/extensions/loom/notebook-writer.ts
+++ b/extensions/loom/notebook-writer.ts
@@ -86,6 +86,16 @@ export function generateNotebook(plan: AnalysisPlan): string {
   // Research Context
   lines.push("## Research Context");
   lines.push("");
+
+  // Authoritative structured block for the parser (invisible extra fields).
+  // The markdown below is for humans and the existing *contains* tests.
+  if (plan.researchQuestion && hasResearchQuestionDetails(plan.researchQuestion)) {
+    lines.push("```yaml");
+    lines.push(`research_question_json: '${escapeJsonInYaml(plan.researchQuestion)}'`);
+    lines.push("```");
+    lines.push("");
+  }
+
   lines.push(`**Research Question**: ${plan.context.researchQuestion}`);
 
   // Hypothesis if refined (Phase 1)
@@ -498,6 +508,19 @@ export function renderBRCContextSection(brc: BRCContext): string {
   }
 
   return lines.join("\n");
+}
+
+/**
+ * True if a ResearchQuestion has any field worth persisting beyond
+ * context.researchQuestion (which is already rendered above).
+ */
+function hasResearchQuestionDetails(rq: ResearchQuestion): boolean {
+  return Boolean(
+    rq.hypothesis ||
+      rq.pico ||
+      (rq.literatureRefs && rq.literatureRefs.length > 0) ||
+      rq.refinedAt
+  );
 }
 
 /**

--- a/extensions/loom/notebook-writer.ts
+++ b/extensions/loom/notebook-writer.ts
@@ -400,6 +400,12 @@ export function generateNotebook(plan: AnalysisPlan): string {
     lines.push("## Publication Materials");
     lines.push("");
 
+    // Authoritative structured block for the parser.
+    lines.push("```yaml");
+    lines.push(`publication_json: '${escapeJsonInYaml(plan.publication)}'`);
+    lines.push("```");
+    lines.push("");
+
     const pub = plan.publication;
     lines.push(`**Status**: ${pub.status.replace('_', ' ')}`);
     if (pub.targetJournal) {

--- a/extensions/loom/notebook-writer.ts
+++ b/extensions/loom/notebook-writer.ts
@@ -137,6 +137,8 @@ export function generateNotebook(plan: AnalysisPlan): string {
   if (plan.dataProvenance) {
     lines.push("## Data Provenance");
     lines.push("");
+    renderDataProvenanceYaml(lines, plan.dataProvenance);
+
     const dp = plan.dataProvenance;
     lines.push(`**Source**: ${dp.source.toUpperCase()}`);
     if (dp.accession) lines.push(`**Accession**: ${dp.accession}`);
@@ -496,6 +498,21 @@ export function renderBRCContextSection(brc: BRCContext): string {
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Render a provenance YAML block. Authoritative for the parser;
+ * the markdown tables below it are display-only.
+ *
+ * The block uses a single JSON string value rather than native YAML
+ * nesting because our YAML parser can't handle multi-line array items.
+ * Treat it as structured data on disk; humans read the tables below.
+ */
+function renderDataProvenanceYaml(lines: string[], dp: DataProvenance): void {
+  lines.push("```yaml");
+  lines.push(`provenance_json: '${escapeJsonInYaml(dp)}'`);
+  lines.push("```");
+  lines.push("");
 }
 
 /**

--- a/extensions/loom/notebook-writer.ts
+++ b/extensions/loom/notebook-writer.ts
@@ -191,6 +191,9 @@ export function generateNotebook(plan: AnalysisPlan): string {
     lines.push(`  id: "${step.id}"`);
     lines.push(`  name: "${step.name}"`);
     lines.push(`  status: ${step.status}`);
+    if (step.description) {
+      lines.push(`  description: "${escapeYamlString(step.description)}"`);
+    }
     lines.push("  execution:");
     lines.push(`    type: ${step.execution.type}`);
     if (step.execution.toolId) {
@@ -201,6 +204,9 @@ export function generateNotebook(plan: AnalysisPlan): string {
     }
     if (step.execution.trsId) {
       lines.push(`    trs_id: "${step.execution.trsId}"`);
+    }
+    if (step.execution.parameters && Object.keys(step.execution.parameters).length > 0) {
+      lines.push(`    parameters: '${escapeJsonInYaml(step.execution.parameters)}'`);
     }
 
     if (step.workflowStructure) {
@@ -230,6 +236,15 @@ export function generateNotebook(plan: AnalysisPlan): string {
     }
     if (step.result?.invocationId) {
       lines.push(`  invocation_id: "${step.result.invocationId}"`);
+    }
+    if (step.result?.completedAt) {
+      lines.push(`  completed_at: "${step.result.completedAt}"`);
+    }
+    if (step.result?.summary) {
+      lines.push(`  summary: "${escapeYamlString(step.result.summary)}"`);
+    }
+    if (step.result && step.result.qcPassed !== null && step.result.qcPassed !== undefined) {
+      lines.push(`  qc_passed: ${step.result.qcPassed}`);
     }
 
     lines.push("```");
@@ -517,6 +532,14 @@ function escapeYamlString(str: string): string {
 }
 
 /**
+ * Serialize an object to a JSON string safe to embed inside single-quoted YAML.
+ * Single quotes are escaped by doubling them (YAML convention).
+ */
+function escapeJsonInYaml(obj: unknown): string {
+  return JSON.stringify(obj).replace(/'/g, "''");
+}
+
+/**
  * Update frontmatter field in notebook content
  */
 export function updateFrontmatter(
@@ -747,6 +770,9 @@ export function addStepSection(content: string, step: AnalysisStep): string {
   lines.push(`  id: "${step.id}"`);
   lines.push(`  name: "${step.name}"`);
   lines.push(`  status: ${step.status}`);
+  if (step.description) {
+    lines.push(`  description: "${escapeYamlString(step.description)}"`);
+  }
   lines.push("  execution:");
   lines.push(`    type: ${step.execution.type}`);
   if (step.execution.toolId) {
@@ -757,6 +783,9 @@ export function addStepSection(content: string, step: AnalysisStep): string {
   }
   if (step.execution.trsId) {
     lines.push(`    trs_id: "${step.execution.trsId}"`);
+  }
+  if (step.execution.parameters && Object.keys(step.execution.parameters).length > 0) {
+    lines.push(`    parameters: '${escapeJsonInYaml(step.execution.parameters)}'`);
   }
 
   if (step.workflowStructure) {

--- a/extensions/loom/state.ts
+++ b/extensions/loom/state.ts
@@ -187,6 +187,7 @@ export function addStep(params: {
   toolId?: string;
   workflowId?: string;
   trsId?: string;
+  parameters?: Record<string, unknown>;
   inputs: Array<{ name: string; description: string; fromStep?: string }>;
   expectedOutputs: string[];
   dependsOn: string[];
@@ -207,6 +208,7 @@ export function addStep(params: {
       toolId: params.toolId,
       workflowId: params.workflowId,
       trsId: params.trsId,
+      parameters: params.parameters,
     },
     inputs: params.inputs.map(i => ({
       name: i.name,

--- a/tests/notebook-roundtrip.test.ts
+++ b/tests/notebook-roundtrip.test.ts
@@ -357,6 +357,67 @@ describe("notebook with lifecycle phases", () => {
     expect(markdown).toContain("PICO Framework");
   });
 
+  it("round-trips hypothesis, PICO, and literature references", () => {
+    const plan = createPlan({
+      title: "Drug Study",
+      researchQuestion: "Does drug X work?",
+      dataDescription: "RNA-seq",
+      expectedOutcomes: ["DEGs"],
+      constraints: [],
+    });
+
+    setResearchQuestion({
+      rawQuestion: "Does drug X work?",
+      hypothesis: "Drug X reduces tumor gene expression",
+      pico: {
+        population: "HeLa cells",
+        intervention: "Drug X 10uM",
+        comparison: "DMSO vehicle",
+        outcome: "Gene expression changes",
+      },
+    });
+    addLiteratureRef({
+      title: "Foundational Paper",
+      pmid: "12345678",
+      year: 2024,
+      authors: ["Smith J", "Doe A"],
+      journal: "Nature",
+      relevance: "Established Drug X mechanism",
+    });
+    addLiteratureRef({
+      title: "Follow-up Study",
+      doi: "10.1234/example",
+      year: 2025,
+      relevance: "Characterized resistance pathways",
+    });
+
+    const markdown = generateNotebook(plan);
+    const parsed = parseNotebook(markdown);
+    const restored = notebookToPlan(parsed!);
+
+    expect(restored.researchQuestion).toBeTruthy();
+    expect(restored.researchQuestion!.hypothesis).toBe(
+      "Drug X reduces tumor gene expression"
+    );
+    expect(restored.researchQuestion!.pico).toEqual({
+      population: "HeLa cells",
+      intervention: "Drug X 10uM",
+      comparison: "DMSO vehicle",
+      outcome: "Gene expression changes",
+    });
+    expect(restored.researchQuestion!.literatureRefs).toHaveLength(2);
+    expect(restored.researchQuestion!.literatureRefs[0]).toMatchObject({
+      title: "Foundational Paper",
+      pmid: "12345678",
+      year: 2024,
+      journal: "Nature",
+      relevance: "Established Drug X mechanism",
+    });
+    expect(restored.researchQuestion!.literatureRefs[1].doi).toBe(
+      "10.1234/example"
+    );
+  });
+
   it("includes literature references in notebook", () => {
     const plan = createPlan({
       title: "Test",

--- a/tests/notebook-roundtrip.test.ts
+++ b/tests/notebook-roundtrip.test.ts
@@ -20,6 +20,7 @@ import {
   setBRCOrganism,
   setBRCAssembly,
   setBRCWorkflow,
+  getCurrentPlan,
 } from "../extensions/loom/state";
 import { generateNotebook } from "../extensions/loom/notebook-writer";
 import { parseNotebook, notebookToPlan, parseFrontmatter } from "../extensions/loom/notebook-parser";
@@ -181,6 +182,70 @@ describe("notebook round-trip", () => {
     expect(restored.title).toBe("Minimal Plan");
     expect(restored.steps).toHaveLength(0);
     expect(restored.decisions).toHaveLength(0);
+  });
+
+  it("preserves step.description through round-trip", () => {
+    const original = buildTestPlan();
+    const markdown = generateNotebook(original);
+    const parsed = parseNotebook(markdown);
+    const restored = notebookToPlan(parsed!);
+
+    expect(restored.steps[0].description).toBe(
+      "Run FastQC on all raw FASTQ files"
+    );
+    expect(restored.steps[1].description).toBe(
+      "Align reads to human reference genome with HISAT2"
+    );
+  });
+
+  it("preserves step.execution.parameters through round-trip", () => {
+    createPlan({
+      title: "Params Test",
+      researchQuestion: "Q",
+      dataDescription: "D",
+      expectedOutcomes: [],
+      constraints: [],
+    });
+    addStep({
+      name: "Parameterized Tool",
+      description: "A tool with explicit parameters",
+      executionType: "tool",
+      toolId: "tool-x",
+      inputs: [],
+      expectedOutputs: [],
+      dependsOn: [],
+      parameters: {
+        threshold: 0.05,
+        mode: "strict",
+        enable: true,
+        tags: ["a", "b"],
+      },
+    });
+
+    const plan = getCurrentPlan()!;
+    const markdown = generateNotebook(plan);
+    const parsed = parseNotebook(markdown);
+    const restored = notebookToPlan(parsed!);
+
+    expect(restored.steps[0].execution.parameters).toEqual({
+      threshold: 0.05,
+      mode: "strict",
+      enable: true,
+      tags: ["a", "b"],
+    });
+  });
+
+  it("preserves step.result.completedAt/summary/qcPassed through round-trip", () => {
+    const original = buildTestPlan();
+    const markdown = generateNotebook(original);
+    const parsed = parseNotebook(markdown);
+    const restored = notebookToPlan(parsed!);
+
+    expect(restored.steps[0].result?.completedAt).toBe("2026-02-06T10:30:00Z");
+    expect(restored.steps[0].result?.summary).toBe(
+      "All 6 samples pass quality thresholds"
+    );
+    expect(restored.steps[0].result?.qcPassed).toBe(true);
   });
 
   it("preserves galaxy connection info", () => {

--- a/tests/notebook-roundtrip.test.ts
+++ b/tests/notebook-roundtrip.test.ts
@@ -401,6 +401,81 @@ describe("notebook with lifecycle phases", () => {
     expect(markdown).toContain("control_1_R1.fastq.gz");
   });
 
+  it("round-trips data provenance through parse", () => {
+    const plan = createPlan({
+      title: "Provenance RT",
+      researchQuestion: "Q",
+      dataDescription: "D",
+      expectedOutcomes: [],
+      constraints: [],
+    });
+
+    setDataProvenance({
+      source: "geo",
+      accession: "GSE12345",
+      downloadDate: "2026-02-01T00:00:00Z",
+      importHistory: "hist-import-42",
+    });
+    addSample({
+      id: "s1",
+      name: "Control_1",
+      condition: "control",
+      replicate: 1,
+      metadata: { tissue: "liver", donor: "A" },
+      files: ["f1", "f2"],
+    });
+    addSample({
+      id: "s2",
+      name: "Treated_1",
+      condition: "treated",
+      replicate: 1,
+      metadata: {},
+      files: ["f3"],
+    });
+    addDataFile({
+      id: "f1",
+      name: "control_1_R1.fastq.gz",
+      type: "fastq",
+      readType: "paired",
+      pairedWith: "f2",
+      galaxyDatasetId: "gx-f1",
+    });
+    addDataFile({ id: "f2", name: "control_1_R2.fastq.gz", type: "fastq", readType: "paired", pairedWith: "f1" });
+    addDataFile({ id: "f3", name: "treated_1.bam", type: "bam" });
+
+    const markdown = generateNotebook(plan);
+    const parsed = parseNotebook(markdown);
+    const restored = notebookToPlan(parsed!);
+
+    expect(restored.dataProvenance).toBeTruthy();
+    expect(restored.dataProvenance!.source).toBe("geo");
+    expect(restored.dataProvenance!.accession).toBe("GSE12345");
+    expect(restored.dataProvenance!.downloadDate).toBe("2026-02-01T00:00:00Z");
+    expect(restored.dataProvenance!.importHistory).toBe("hist-import-42");
+
+    expect(restored.dataProvenance!.samples).toHaveLength(2);
+    expect(restored.dataProvenance!.samples[0]).toMatchObject({
+      id: "s1",
+      name: "Control_1",
+      condition: "control",
+      replicate: 1,
+      files: ["f1", "f2"],
+      metadata: { tissue: "liver", donor: "A" },
+    });
+    expect(restored.dataProvenance!.samples[1].files).toEqual(["f3"]);
+
+    expect(restored.dataProvenance!.originalFiles).toHaveLength(3);
+    expect(restored.dataProvenance!.originalFiles[0]).toMatchObject({
+      id: "f1",
+      name: "control_1_R1.fastq.gz",
+      type: "fastq",
+      readType: "paired",
+      pairedWith: "f2",
+      galaxyDatasetId: "gx-f1",
+    });
+    expect(restored.dataProvenance!.originalFiles[2].type).toBe("bam");
+  });
+
   it("includes interpretation findings in notebook", () => {
     const plan = createPlan({
       title: "Interpretation Test",

--- a/tests/notebook-roundtrip.test.ts
+++ b/tests/notebook-roundtrip.test.ts
@@ -636,6 +636,95 @@ describe("notebook with lifecycle phases", () => {
     expect(markdown).toContain("Volcano Plot");
   });
 
+  it("round-trips publication materials through parse", () => {
+    const plan = createPlan({
+      title: "Publication RT",
+      researchQuestion: "Q",
+      dataDescription: "D",
+      expectedOutcomes: [],
+      constraints: [],
+    });
+
+    initPublication("Nature Methods");
+    addFigure({
+      name: "Volcano Plot",
+      type: "volcano",
+      dataSource: "step-3",
+      status: "generated",
+      galaxyDatasetId: "gx-vol-1",
+      description: "Differentially expressed genes",
+      suggestedTool: "ggplot2",
+    });
+    addFigure({
+      name: "Heatmap",
+      type: "heatmap",
+      dataSource: "step-4",
+      status: "planned",
+    });
+
+    const publication = plan.publication!;
+    publication.methodsDraft = {
+      text: "Reads were aligned with HISAT2.",
+      toolVersions: [
+        {
+          toolId: "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.2.1",
+          toolName: "HISAT2",
+          version: "2.2.1",
+          stepId: "2",
+          parameters: { threads: 4 },
+        },
+      ],
+      generatedAt: "2026-03-01T00:00:00Z",
+      lastUpdated: "2026-03-01T00:00:00Z",
+    };
+    publication.supplementaryData.push({
+      id: "sup-1",
+      name: "DE gene list",
+      type: "table",
+      description: "Full DE results",
+      exportFormat: "tsv",
+    });
+    publication.dataSharing = {
+      repository: "zenodo",
+      accession: "10.5281/zenodo.example",
+      submissionDate: "2026-03-05",
+      status: "submitted",
+      preparedFiles: ["de-table.tsv", "methods.pdf"],
+    };
+    publication.status = "ready_for_review";
+
+    const markdown = generateNotebook(plan);
+    const parsed = parseNotebook(markdown);
+    const restored = notebookToPlan(parsed!);
+
+    expect(restored.publication).toBeTruthy();
+    expect(restored.publication!.status).toBe("ready_for_review");
+    expect(restored.publication!.targetJournal).toBe("Nature Methods");
+    expect(restored.publication!.figures).toHaveLength(2);
+    expect(restored.publication!.figures[0]).toMatchObject({
+      name: "Volcano Plot",
+      type: "volcano",
+      galaxyDatasetId: "gx-vol-1",
+      suggestedTool: "ggplot2",
+    });
+    expect(restored.publication!.methodsDraft?.text).toBe(
+      "Reads were aligned with HISAT2."
+    );
+    expect(restored.publication!.methodsDraft?.toolVersions[0].version).toBe(
+      "2.2.1"
+    );
+    expect(restored.publication!.methodsDraft?.toolVersions[0].parameters).toEqual({
+      threads: 4,
+    });
+    expect(restored.publication!.supplementaryData).toHaveLength(1);
+    expect(restored.publication!.supplementaryData[0].exportFormat).toBe("tsv");
+    expect(restored.publication!.dataSharing?.repository).toBe("zenodo");
+    expect(restored.publication!.dataSharing?.preparedFiles).toEqual([
+      "de-table.tsv",
+      "methods.pdf",
+    ]);
+  });
+
   it("round-trips plan with BRC context", () => {
     const plan = createPlan({
       title: "BRC Context Test",


### PR DESCRIPTION
## Summary
Extends the notebook parser so fields the writer already emits actually round-trip. Before this, a plan restored from a notebook silently dropped step descriptions, execution.parameters, result.completedAt/summary/qcPassed, the entire Data Provenance section, the full hypothesis + PICO + literature block, and the whole Publication Materials block. Four commits, each one is a self-contained slice: step YAML fields, Phase 2 data provenance, Phase 1 research question, Phase 5 publication.

Where the notebook had human-readable tables or prose, those stay put; a JSON-in-single-quoted-YAML block at the top of each section is the authoritative payload for the parser. The approach sidesteps the nested-array limits of the handwritten YAML parser and keeps round-trip bulletproof. Not backwards-compatible -- Loom isn't in production use yet per the plan brief.

## Test plan
- [x] \`npm test\` -- 139 tests passing (was 133)
- [x] \`tsc --noEmit\` -- clean
- [x] \`tests/notebook-roundtrip.test.ts\` gains 6 new cases covering each section with deep-equality assertions
- [ ] Manual: open a restored notebook in Orbit, confirm Data Provenance / Publication / Research Context sections survive a reload

## Foundation for Sprint 2
Sprints 2a (\`analysis_assert\`) and 2b (\`workflow_set_overrides\`) are stacked on this branch since they rely on execution.parameters + full round-trip.