### PR TITLE
Resolve tool versions from Galaxy (Sprint 1b)

### DIFF
--- a/extensions/loom/galaxy-api.ts
+++ b/extensions/loom/galaxy-api.ts
@@ -50,6 +50,18 @@ export interface GalaxyInvocationResponse {
   steps: GalaxyInvocationStep[];
 }
 
+/**
+ * Subset of GET /api/jobs/{jobId} we actually read.
+ * tool_version lives at the top level per Galaxy's Job.to_dict().
+ */
+export interface GalaxyJobDetailsResponse {
+  id: string;
+  state: string;
+  tool_id: string;
+  tool_version: string;
+  params?: Record<string, unknown>;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Config
 // ─────────────────────────────────────────────────────────────────────────────
@@ -104,6 +116,17 @@ function shortToolName(toolId: string): string {
     return parts[parts.length - 2];
   }
   return toolId;
+}
+
+/**
+ * Fetch job details from Galaxy. Returns the full response; callers typically
+ * only need `tool_version`.
+ */
+export async function galaxyGetJobDetails(
+  jobId: string,
+  signal?: AbortSignal,
+): Promise<GalaxyJobDetailsResponse> {
+  return galaxyGet<GalaxyJobDetailsResponse>(`/jobs/${encodeURIComponent(jobId)}`, signal);
 }
 
 export function extractWorkflowStructure(wf: GalaxyWorkflowResponse): WorkflowStructure {

--- a/extensions/loom/state.ts
+++ b/extensions/loom/state.ts
@@ -794,6 +794,55 @@ export function initPublication(targetJournal?: string): PublicationMaterials {
 }
 
 /**
+ * Fetcher signature for resolving tool versions from Galaxy. Pulled out of
+ * resolveToolVersions so tests can inject a mock without touching fetch().
+ */
+export type JobDetailsFetcher = (jobId: string) => Promise<{ tool_version?: string }>;
+
+/**
+ * Resolve tool versions for every completed step on the current plan that has
+ * a jobId but no toolVersion yet. Returns the number of steps whose version
+ * was updated. Failures to fetch are swallowed per-step so one bad jobId
+ * doesn't block the rest.
+ */
+export async function resolveToolVersions(
+  fetchJobDetails: JobDetailsFetcher,
+  opts: { stepId?: string } = {},
+): Promise<number> {
+  if (!state.currentPlan) {
+    throw new Error("No active plan");
+  }
+
+  let updated = 0;
+  const candidates = state.currentPlan.steps.filter((s) => {
+    if (opts.stepId && s.id !== opts.stepId) return false;
+    if (!s.result?.jobId) return false;
+    if (!s.execution.toolId) return false;
+    if (s.execution.toolVersion) return false;
+    return true;
+  });
+
+  for (const step of candidates) {
+    try {
+      const details = await fetchJobDetails(step.result!.jobId!);
+      if (details.tool_version) {
+        step.execution.toolVersion = details.tool_version;
+        updated += 1;
+      }
+    } catch (err) {
+      console.warn(`resolveToolVersions: failed for step ${step.id}:`, err);
+    }
+  }
+
+  if (updated > 0) {
+    state.currentPlan.updated = new Date().toISOString();
+    notifyPlanChange();
+  }
+
+  return updated;
+}
+
+/**
  * Generate methods section from plan execution
  */
 export function generateMethods(): MethodsSection {
@@ -803,13 +852,15 @@ export function generateMethods(): MethodsSection {
 
   const now = new Date().toISOString();
 
-  // Extract tool versions from completed steps
+  // Extract tool versions from completed steps. Unresolved versions appear
+  // as 'unresolved' so the methods section makes the gap visible rather than
+  // silently claiming a placeholder string is a real version.
   const toolVersions: ToolVersionInfo[] = state.currentPlan.steps
     .filter(s => s.status === 'completed' && s.execution.toolId)
     .map(s => ({
       toolId: s.execution.toolId!,
       toolName: s.name,
-      version: 'version_to_be_fetched', // Will be updated by tool call
+      version: s.execution.toolVersion || 'unresolved',
       stepId: s.id,
       parameters: s.execution.parameters,
     }));

--- a/extensions/loom/tools.ts
+++ b/extensions/loom/tools.ts
@@ -53,6 +53,8 @@ import {
   setBRCAssembly,
   setBRCWorkflow,
   getBRCContext,
+  // Tool version resolution
+  resolveToolVersions,
 } from "./state";
 import type {
   StepStatus,
@@ -71,6 +73,7 @@ import { ensureGitRepo } from "./git";
 import {
   getGalaxyConfig,
   galaxyGet,
+  galaxyGetJobDetails,
   extractWorkflowStructure,
   type GalaxyWorkflowResponse,
   type GalaxyInvocationResponse,
@@ -301,6 +304,21 @@ in_progress when starting, completed when done, or failed if issues occur.`,
           params.status as StepStatus,
           result
         );
+
+        // Opportunistically resolve tool version for tool steps that just
+        // completed with a jobId. Best-effort; failures are non-fatal.
+        if (
+          params.status === 'completed' &&
+          params.jobId &&
+          step?.execution.type === 'tool' &&
+          step.execution.toolId
+        ) {
+          try {
+            await resolveToolVersions(galaxyGetJobDetails, { stepId: params.stepId });
+          } catch (err) {
+            console.warn('Tool version resolution failed (non-fatal):', err);
+          }
+        }
 
         // Sync to notebook
         await syncToNotebook('step_updated', {
@@ -2671,6 +2689,54 @@ analyses in Galaxy.`,
         return new Text("❌ GTN fetch failed");
       }
       return new Text(`📖 Fetched GTN tutorial (${d?.length || 0} chars)`);
+    },
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Tool version resolution
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  pi.registerTool({
+    name: "analysis_resolve_versions",
+    label: "Resolve tool versions",
+    description:
+      "Fetch tool versions from Galaxy for completed tool steps that have a jobId but " +
+      "no resolved version yet. Versions come from the actual job records, not agent " +
+      "memory, and land on AnalysisStep.execution.toolVersion -- which feeds the " +
+      "publication methods section.",
+    parameters: Type.Object({
+      stepId: Type.Optional(Type.String({
+        description: "Resolve a single step's version. Omit to resolve all eligible steps.",
+      })),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+      if (!getCurrentPlan()) {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ success: false, error: "No active plan" }) }],
+          details: { updated: 0, error: "no_active_plan" },
+        };
+      }
+
+      try {
+        const updated = await resolveToolVersions(galaxyGetJobDetails, { stepId: params.stepId });
+        if (updated > 0) {
+          await syncToNotebook('frontmatter', { updated: new Date().toISOString() });
+        }
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ success: true, updated }) }],
+          details: { updated },
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ success: false, error: msg }) }],
+          details: { updated: 0, error: msg },
+        };
+      }
+    },
+    renderResult: (result) => {
+      const d = result.details as { updated?: number } | undefined;
+      return new Text(`🔖 Resolved versions for ${d?.updated ?? 0} step(s)`);
     },
   });
 

--- a/extensions/loom/types.ts
+++ b/extensions/loom/types.ts
@@ -305,6 +305,7 @@ export interface AnalysisStep {
   execution: {
     type: ExecutionType;
     toolId?: string;
+    toolVersion?: string;   // resolved from Galaxy job details after completion
     workflowId?: string;
     trsId?: string;         // IWC TRS ID if from IWC
     parameters?: Record<string, unknown>;

--- a/tests/extension-integration.test.ts
+++ b/tests/extension-integration.test.ts
@@ -131,6 +131,9 @@ const EXPECTED_TOOLS = [
   "gtn_search",
   "gtn_fetch",
 
+  // Tool Version Resolution
+  "analysis_resolve_versions",
+
   // Shell-facing tools (structured widget emitters)
   "report_result",
   "analyze_plan_parameters",

--- a/tests/version-resolution.test.ts
+++ b/tests/version-resolution.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  createPlan,
+  resetState,
+  addStep,
+  updateStepStatus,
+  resolveToolVersions,
+  generateMethods,
+  getCurrentPlan,
+} from "../extensions/loom/state";
+
+describe("tool version resolution", () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  function buildCompletedToolStep() {
+    const plan = createPlan({
+      title: "Version resolution",
+      researchQuestion: "Q",
+      dataDescription: "D",
+      expectedOutcomes: [],
+      constraints: [],
+    });
+    addStep({
+      name: "Run HISAT2",
+      description: "Align reads",
+      executionType: "tool",
+      toolId: "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.2.1",
+      inputs: [],
+      expectedOutputs: [],
+      dependsOn: [],
+    });
+    updateStepStatus("1", "completed", {
+      completedAt: "2026-03-01T00:00:00Z",
+      jobId: "job-42",
+      summary: "Alignment completed",
+      qcPassed: true,
+    });
+    return plan;
+  }
+
+  it("fetches tool_version from the injected fetcher and stores it on the step", async () => {
+    buildCompletedToolStep();
+
+    let seenJobId = "";
+    const mockFetcher = async (jobId: string) => {
+      seenJobId = jobId;
+      return { tool_version: "2.2.1+galaxy1" };
+    };
+
+    const updated = await resolveToolVersions(mockFetcher);
+
+    expect(updated).toBe(1);
+    expect(seenJobId).toBe("job-42");
+    expect(getCurrentPlan()!.steps[0].execution.toolVersion).toBe("2.2.1+galaxy1");
+  });
+
+  it("skips steps that already have a toolVersion", async () => {
+    buildCompletedToolStep();
+    getCurrentPlan()!.steps[0].execution.toolVersion = "2.2.1";
+
+    let calls = 0;
+    const mockFetcher = async () => {
+      calls += 1;
+      return { tool_version: "should-not-be-set" };
+    };
+
+    const updated = await resolveToolVersions(mockFetcher);
+    expect(updated).toBe(0);
+    expect(calls).toBe(0);
+  });
+
+  it("skips steps without a jobId", async () => {
+    createPlan({
+      title: "No Job",
+      researchQuestion: "Q",
+      dataDescription: "D",
+      expectedOutcomes: [],
+      constraints: [],
+    });
+    addStep({
+      name: "Manual step",
+      description: "Manually do a thing",
+      executionType: "tool",
+      toolId: "manual-tool",
+      inputs: [],
+      expectedOutputs: [],
+      dependsOn: [],
+    });
+
+    const updated = await resolveToolVersions(async () => ({
+      tool_version: "unused",
+    }));
+
+    expect(updated).toBe(0);
+  });
+
+  it("swallows per-step fetch errors and keeps going", async () => {
+    buildCompletedToolStep();
+    // Add a second completed step to test that the failure on the first
+    // doesn't prevent the second from being resolved.
+    addStep({
+      name: "Run FastQC",
+      description: "QC",
+      executionType: "tool",
+      toolId: "fastqc",
+      inputs: [],
+      expectedOutputs: [],
+      dependsOn: [],
+    });
+    updateStepStatus("2", "completed", {
+      completedAt: "2026-03-01T00:10:00Z",
+      jobId: "job-43",
+      summary: "QC done",
+      qcPassed: true,
+    });
+
+    const mockFetcher = async (jobId: string) => {
+      if (jobId === "job-42") throw new Error("transient Galaxy 503");
+      return { tool_version: "0.74" };
+    };
+
+    const updated = await resolveToolVersions(mockFetcher);
+    expect(updated).toBe(1);
+    expect(getCurrentPlan()!.steps[0].execution.toolVersion).toBeUndefined();
+    expect(getCurrentPlan()!.steps[1].execution.toolVersion).toBe("0.74");
+  });
+
+  it("feeds resolved versions into publication_generate_methods", async () => {
+    buildCompletedToolStep();
+
+    await resolveToolVersions(async () => ({ tool_version: "2.2.1+galaxy1" }));
+    const methods = generateMethods();
+
+    expect(methods.toolVersions).toHaveLength(1);
+    expect(methods.toolVersions[0]).toMatchObject({
+      toolId: "toolshed.g2.bx.psu.edu/repos/iuc/hisat2/hisat2/2.2.1",
+      version: "2.2.1+galaxy1",
+      stepId: "1",
+    });
+  });
+
+  it("marks unresolved tool versions as 'unresolved' rather than silently filling a placeholder", () => {
+    buildCompletedToolStep();
+    // Skip the resolution step entirely
+
+    const methods = generateMethods();
+    expect(methods.toolVersions[0].version).toBe("unresolved");
+  });
+
+  it("respects stepId scope", async () => {
+    buildCompletedToolStep();
+    addStep({
+      name: "Run FastQC",
+      description: "QC",
+      executionType: "tool",
+      toolId: "fastqc",
+      inputs: [],
+      expectedOutputs: [],
+      dependsOn: [],
+    });
+    updateStepStatus("2", "completed", {
+      completedAt: "2026-03-01T00:10:00Z",
+      jobId: "job-43",
+      summary: "QC done",
+      qcPassed: true,
+    });
+
+    await resolveToolVersions(async () => ({ tool_version: "SHOULD_ONLY_APPEAR_ON_STEP_2" }), {
+      stepId: "2",
+    });
+    expect(getCurrentPlan()!.steps[0].execution.toolVersion).toBeUndefined();
+    expect(getCurrentPlan()!.steps[1].execution.toolVersion).toBe(
+      "SHOULD_ONLY_APPEAR_ON_STEP_2"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Replaces the \`'version_to_be_fetched'\` placeholder in \`generateMethods\` with real tool versions sourced from Galaxy's \`/api/jobs/{jobId}\`. Versions land on \`AnalysisStep.execution.toolVersion\` and feed into the methods section.

New \`resolveToolVersions(fetchJobDetails, {stepId?})\` iterates completed tool steps with a jobId but no resolved version yet and calls the injected fetcher (\`galaxyGetJobDetails\` in prod, a mock in tests). Errors are per-step and swallowed so one bad jobId doesn't kill the batch. The \`analysis_plan_update_step\` tool fires an opportunistic resolve after marking a tool step completed, and a standalone \`analysis_resolve_versions\` tool is available for retry/batch.

Unresolved versions render as \`unresolved\` rather than a placeholder string so the methods section makes the gap visible.

## Test plan
- [x] \`npm test\` -- 140 tests passing (was 133)
- [x] \`tsc --noEmit\` -- clean
- [x] New \`tests/version-resolution.test.ts\` covers the fetcher, skip-logic, per-step error tolerance, the \`unresolved\` fallback, and the methods-generation integration
- [ ] Manual: run a workflow, confirm methods section renders real versions

## Open Question 2 (from the plan) -- answered
\`GET /api/jobs/{jobId}\` returns \`tool_version\` at the top level (confirmed against Galaxy source \`Job.to_dict\`). No \`/details\` endpoint needed.

## Workflow steps
Workflow steps don't hold individual jobIds on the Loom step, so this sprint only resolves tool steps. Per-invocation-job version rollup for workflow steps is a good follow-up.