### PR TITLE
Load gxy-sketches corpus for plan grounding (Sprint 3b)

### DIFF
--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -8,6 +8,11 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { getCurrentPlan, getState, formatPlanSummary, getWorkflowSteps, getBRCContext } from "./state";
 import { loadConfig } from "./config";
+import {
+  loadSketchCorpus,
+  matchSketchesForPlan,
+  renderSketchForPrompt,
+} from "./sketches";
 
 /** Build the execution-mode block injected into every system prompt. */
 function buildExecutionModeContext(): string {
@@ -112,6 +117,24 @@ ${buildExecutionModeContext()}
     // Active plan - inject summary
     const planSummary = formatPlanSummary(plan);
 
+    // Sketch corpus matching (gxy-sketches analysis scaffolding)
+    let sketchSection = "";
+    try {
+      const cfg = loadConfig();
+      if (cfg.sketchCorpusPath) {
+        const corpus = loadSketchCorpus(cfg.sketchCorpusPath);
+        const matches = matchSketchesForPlan(plan, corpus).slice(0, 2);
+        if (matches.length > 0) {
+          sketchSection =
+            "\n" +
+            matches.map((m) => renderSketchForPrompt(m)).join("\n---\n\n") +
+            "\n";
+        }
+      }
+    } catch (err) {
+      console.warn("[sketches] context injection failed:", err);
+    }
+
     // Workflow guidance if plan has workflow steps
     const workflowSteps = plan.steps.filter(s => s.execution.type === 'workflow');
     const activeInvocations = getWorkflowSteps();
@@ -172,7 +195,7 @@ ${planSummary}
 - One sentence when one sentence suffices. Never repeat what the user said.
 - Do NOT use exclamation marks, "Great!", "Excellent!", "Sure!", or similar.
 - Minimize emoji usage. Plain text is preferred.
-${workflowContext}${brcSection}
+${workflowContext}${brcSection}${sketchSection}
 ${galaxyContext}
 ${buildExecutionModeContext()}
 `

--- a/extensions/loom/sketches.ts
+++ b/extensions/loom/sketches.ts
@@ -1,0 +1,253 @@
+/**
+ * Loader for gxy-sketches corpus -- Anton's static analysis-scaffolding
+ * sketches authored at github.com/nekrut/gxy-sketches.
+ *
+ * Loom treats sketches as a knowledge layer: when an active plan's tools,
+ * workflow, or tags match a sketch, its body is injected into the system
+ * prompt so the agent has domain grounding for that class of analysis.
+ *
+ * We only parse the subset of the SketchFrontmatter schema we actually
+ * need for matching and rendering. Unknown fields are tolerated so schema
+ * drift upstream doesn't break sketch loading here.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { parse as parseYaml } from "yaml";
+import type { AnalysisPlan } from "./types";
+
+/** Cap on a single sketch's size on disk. Oversized files are skipped. */
+const MAX_SKETCH_BYTES = 200 * 1024;
+
+export interface SketchToolRef {
+  name: string;
+  version?: string;
+}
+
+export interface SketchExpectedOutput {
+  role?: string;
+  description?: string;
+  assertions?: string[];
+}
+
+export interface SketchFrontmatter {
+  name: string;
+  description?: string;
+  domain?: string;
+  tags?: string[];
+  tools?: SketchToolRef[];
+  source?: {
+    ecosystem?: string;
+    workflow?: string;
+    url?: string;
+    version?: string;
+  };
+  expected_output?: SketchExpectedOutput[];
+}
+
+export interface LoadedSketch {
+  filePath: string;
+  frontmatter: SketchFrontmatter;
+  body: string;
+}
+
+export interface MatchedSketch extends LoadedSketch {
+  score: number;
+  reason: string;
+}
+
+/**
+ * Walk the corpus directory and return every sketch we could load.
+ * Malformed files emit a warning and are skipped rather than throwing.
+ */
+export function loadSketchCorpus(corpusRoot: string): LoadedSketch[] {
+  if (!corpusRoot) return [];
+  if (!fs.existsSync(corpusRoot) || !fs.statSync(corpusRoot).isDirectory()) {
+    return [];
+  }
+
+  const sketches: LoadedSketch[] = [];
+  const sketchesRoot = path.join(corpusRoot, "sketches");
+  const scanRoot = fs.existsSync(sketchesRoot) ? sketchesRoot : corpusRoot;
+
+  for (const filePath of walkForSketchFiles(scanRoot)) {
+    try {
+      const stat = fs.statSync(filePath);
+      if (stat.size > MAX_SKETCH_BYTES) {
+        console.warn(`[sketches] skipping ${filePath}: exceeds ${MAX_SKETCH_BYTES} bytes`);
+        continue;
+      }
+
+      const raw = fs.readFileSync(filePath, "utf-8");
+      const parsed = parseSketch(raw);
+      if (!parsed) {
+        console.warn(`[sketches] skipping ${filePath}: missing or malformed frontmatter`);
+        continue;
+      }
+
+      sketches.push({ filePath, ...parsed });
+    } catch (err) {
+      console.warn(`[sketches] failed to read ${filePath}:`, err);
+    }
+  }
+
+  return sketches;
+}
+
+/**
+ * Parse a sketch markdown file into its frontmatter + body.
+ * Returns null if the frontmatter is missing or lacks the required `name`.
+ */
+export function parseSketch(
+  raw: string,
+): { frontmatter: SketchFrontmatter; body: string } | null {
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) return null;
+
+  const frontmatter = parseYamlFrontmatter(match[1]);
+  if (!frontmatter || !frontmatter.name) return null;
+
+  return { frontmatter, body: match[2].trim() };
+}
+
+/**
+ * Rank loaded sketches against a plan. Returns matches sorted strongest-first;
+ * the caller can slice to top-N. Empty array if no signal.
+ *
+ * Priority signal: exact source.workflow id match > tool-id overlap > tag overlap.
+ */
+export function matchSketchesForPlan(
+  plan: AnalysisPlan,
+  sketches: LoadedSketch[],
+): MatchedSketch[] {
+  const planToolIds = new Set<string>();
+  const planToolShortNames = new Set<string>();
+  for (const step of plan.steps) {
+    const id = step.execution.toolId;
+    if (!id) continue;
+    planToolIds.add(id);
+    planToolShortNames.add(shortToolName(id));
+  }
+
+  const planWorkflowId = plan.steps
+    .map((s) => s.execution.workflowId)
+    .find((id): id is string => Boolean(id));
+
+  const planTags = new Set<string>();
+  if (plan.brcContext?.analysisCategory) {
+    planTags.add(plan.brcContext.analysisCategory.toLowerCase());
+  }
+
+  const matched: MatchedSketch[] = [];
+  for (const sketch of sketches) {
+    const { frontmatter } = sketch;
+
+    let score = 0;
+    const reasons: string[] = [];
+
+    if (planWorkflowId && frontmatter.source?.workflow === planWorkflowId) {
+      score += 100;
+      reasons.push("exact workflow match");
+    }
+
+    const toolHits = (frontmatter.tools || []).filter((t) => {
+      return planToolIds.has(t.name) || planToolShortNames.has(t.name);
+    });
+    if (toolHits.length > 0) {
+      score += toolHits.length * 10;
+      reasons.push(`${toolHits.length} tool match(es)`);
+    }
+
+    const tagHits = (frontmatter.tags || []).filter((tag) =>
+      planTags.has(tag.toLowerCase()),
+    );
+    if (tagHits.length > 0) {
+      score += tagHits.length;
+      reasons.push(`${tagHits.length} tag match(es)`);
+    }
+
+    if (score > 0) {
+      matched.push({ ...sketch, score, reason: reasons.join("; ") });
+    }
+  }
+
+  matched.sort((a, b) => b.score - a.score);
+  return matched;
+}
+
+/**
+ * Format a matched sketch as a markdown system-prompt fragment.
+ */
+export function renderSketchForPrompt(sketch: MatchedSketch): string {
+  const lines: string[] = [];
+  lines.push(`## Analysis Sketch: ${sketch.frontmatter.name}`);
+  lines.push(`*(matched via ${sketch.reason})*`);
+  lines.push("");
+
+  if (sketch.frontmatter.description) {
+    lines.push(sketch.frontmatter.description);
+    lines.push("");
+  }
+
+  const assertions = (sketch.frontmatter.expected_output || [])
+    .flatMap((eo) => eo.assertions || [])
+    .filter(Boolean);
+  if (assertions.length > 0) {
+    lines.push("**Expected outputs (ground-truth checks):**");
+    for (const a of assertions) {
+      lines.push(`- ${a}`);
+    }
+    lines.push("");
+  }
+
+  lines.push(sketch.body);
+  lines.push("");
+  return lines.join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internals
+// ─────────────────────────────────────────────────────────────────────────────
+
+function* walkForSketchFiles(dir: string): Generator<string> {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const ent of entries) {
+    if (ent.name.startsWith(".")) continue;
+    const full = path.join(dir, ent.name);
+    if (ent.isDirectory()) {
+      yield* walkForSketchFiles(full);
+    } else if (ent.isFile() && (ent.name === "SKETCH.md" || ent.name.endsWith(".sketch.md"))) {
+      yield full;
+    }
+  }
+}
+
+/**
+ * Parse the YAML frontmatter block via the `yaml` library. Any parse or
+ * schema failure returns null so malformed sketches skip cleanly.
+ */
+function parseYamlFrontmatter(src: string): SketchFrontmatter | null {
+  try {
+    const parsed = parseYaml(src) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const fm = parsed as SketchFrontmatter;
+    if (!fm.name || typeof fm.name !== "string") return null;
+    return fm;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Short tool name for matcher: "toolshed.../repos/iuc/hisat2/hisat2/2.2.1" -> "hisat2"
+ */
+function shortToolName(toolId: string): string {
+  const parts = toolId.split("/");
+  if (parts.length >= 2) return parts[parts.length - 2];
+  return toolId;
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "@sinclair/typebox": "^0.34.49",
     "pi-mcp-adapter": "^2.4.0",
     "pi-web-access": "^0.10.6",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "yaml": "^2.8.2"
   },
   "scripts": {
     "test": "vitest run",

--- a/shared/loom-config.d.ts
+++ b/shared/loom-config.d.ts
@@ -10,6 +10,12 @@ export interface LoomConfig {
   };
   executionMode?: "local" | "remote";
   defaultCwd?: string;
+  /**
+   * Absolute path to a gxy-sketches checkout. When set, Loom scans the
+   * corpus for sketches matching the active plan (by tool IDs, workflow
+   * ID, or tags) and injects the content into the system prompt.
+   */
+  sketchCorpusPath?: string;
 }
 
 export function getConfigDir(): string;

--- a/tests/sketch-loading.test.ts
+++ b/tests/sketch-loading.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  loadSketchCorpus,
+  parseSketch,
+  matchSketchesForPlan,
+  renderSketchForPrompt,
+} from "../extensions/loom/sketches";
+import {
+  createPlan,
+  resetState,
+  addStep,
+  getCurrentPlan,
+} from "../extensions/loom/state";
+
+function makeCorpus(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "loom-sketches-"));
+  const sketchesRoot = path.join(root, "sketches");
+  fs.mkdirSync(sketchesRoot, { recursive: true });
+  for (const [rel, content] of Object.entries(files)) {
+    const dest = path.join(sketchesRoot, rel);
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, content);
+  }
+  return root;
+}
+
+const ALPHAGENOME_SKETCH = `---
+name: alphagenome-gwas-regulatory
+description: AlphaGenome GWAS regulatory interpretation
+domain: variant-calling
+tags:
+  - alphagenome
+  - gwas
+  - regulatory
+tools:
+  - name: alphagenome_ism_scanner
+    version: 0.6.1+galaxy0
+  - name: alphagenome_variant_scorer
+    version: 0.6.1+galaxy0
+source:
+  ecosystem: iwc
+  workflow: 417e33144b294c21
+expected_output:
+  - role: ranked_positions_ism
+    assertions:
+      - Top ISM position scored above 3.0 for validated loci
+      - Peak co-localizes with lead SNP within 500bp
+---
+
+# Body
+
+Run ISM scanner, then rank variants.
+`;
+
+const UNRELATED_SKETCH = `---
+name: rna-seq-deseq2
+tags:
+  - rna-seq
+  - deseq2
+tools:
+  - name: deseq2
+---
+
+Body text.
+`;
+
+const MALFORMED_SKETCH = `---
+not valid frontmatter at all
+---
+
+Body.
+`;
+
+describe("sketch parsing", () => {
+  it("extracts frontmatter and body from a valid SKETCH.md", () => {
+    const parsed = parseSketch(ALPHAGENOME_SKETCH);
+    expect(parsed).toBeTruthy();
+    expect(parsed!.frontmatter.name).toBe("alphagenome-gwas-regulatory");
+    expect(parsed!.frontmatter.tags).toContain("alphagenome");
+    expect(parsed!.frontmatter.tools?.[0].name).toBe("alphagenome_ism_scanner");
+    expect(parsed!.frontmatter.source?.workflow).toBe("417e33144b294c21");
+    expect(parsed!.frontmatter.expected_output?.[0].assertions).toHaveLength(2);
+    expect(parsed!.body).toContain("Run ISM scanner");
+  });
+
+  it("returns null for malformed frontmatter", () => {
+    expect(parseSketch(MALFORMED_SKETCH)).toBeNull();
+    expect(parseSketch("no frontmatter here")).toBeNull();
+  });
+});
+
+describe("sketch corpus loading", () => {
+  let root: string;
+
+  afterEach(() => {
+    if (root) fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("loads multiple sketches from a corpus directory", () => {
+    root = makeCorpus({
+      "alphagenome/SKETCH.md": ALPHAGENOME_SKETCH,
+      "rna-seq/SKETCH.md": UNRELATED_SKETCH,
+    });
+
+    const loaded = loadSketchCorpus(root);
+    const names = loaded.map((s) => s.frontmatter.name).sort();
+    expect(names).toEqual(["alphagenome-gwas-regulatory", "rna-seq-deseq2"]);
+  });
+
+  it("skips malformed sketches without crashing", () => {
+    root = makeCorpus({
+      "good/SKETCH.md": ALPHAGENOME_SKETCH,
+      "broken/SKETCH.md": MALFORMED_SKETCH,
+    });
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const loaded = loadSketchCorpus(root);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].frontmatter.name).toBe("alphagenome-gwas-regulatory");
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("returns an empty array for missing corpus path", () => {
+    expect(loadSketchCorpus("/nonexistent/path")).toEqual([]);
+    expect(loadSketchCorpus("")).toEqual([]);
+  });
+});
+
+describe("sketch matching against a plan", () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  it("matches on tool id overlap for an alphagenome plan", () => {
+    createPlan({
+      title: "AG Plan",
+      researchQuestion: "Q",
+      dataDescription: "D",
+      expectedOutcomes: [],
+      constraints: [],
+    });
+    addStep({
+      name: "ISM",
+      description: "ISM scan",
+      executionType: "tool",
+      toolId: "alphagenome_ism_scanner",
+      inputs: [],
+      expectedOutputs: [],
+      dependsOn: [],
+    });
+
+    const corpus = [parseSketch(ALPHAGENOME_SKETCH)!, parseSketch(UNRELATED_SKETCH)!].map(
+      (s, i) => ({ ...s, filePath: `/tmp/${i}/SKETCH.md` }),
+    );
+
+    const matches = matchSketchesForPlan(getCurrentPlan()!, corpus);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].frontmatter.name).toBe("alphagenome-gwas-regulatory");
+    expect(matches[0].reason).toContain("tool match");
+  });
+
+  it("returns an empty array when no signal matches", () => {
+    createPlan({
+      title: "Unrelated",
+      researchQuestion: "Q",
+      dataDescription: "D",
+      expectedOutcomes: [],
+      constraints: [],
+    });
+    addStep({
+      name: "Something else entirely",
+      description: "",
+      executionType: "tool",
+      toolId: "completely-unrelated-tool",
+      inputs: [],
+      expectedOutputs: [],
+      dependsOn: [],
+    });
+
+    const corpus = [parseSketch(ALPHAGENOME_SKETCH)!].map((s, i) => ({
+      ...s,
+      filePath: `/tmp/${i}/SKETCH.md`,
+    }));
+
+    expect(matchSketchesForPlan(getCurrentPlan()!, corpus)).toEqual([]);
+  });
+
+  it("ranks exact workflow id match above tool-id overlap", () => {
+    const exact = parseSketch(ALPHAGENOME_SKETCH)!;
+    const toolOnly = parseSketch(
+      ALPHAGENOME_SKETCH.replace("417e33144b294c21", "other-workflow-id"),
+    )!;
+    toolOnly.frontmatter.name = "alphagenome-variant";
+
+    createPlan({
+      title: "AG Workflow",
+      researchQuestion: "Q",
+      dataDescription: "D",
+      expectedOutcomes: [],
+      constraints: [],
+    });
+    // Add a workflow step with matching workflow ID
+    addStep({
+      name: "AG Workflow",
+      description: "",
+      executionType: "workflow",
+      workflowId: "417e33144b294c21",
+      inputs: [],
+      expectedOutputs: [],
+      dependsOn: [],
+    });
+
+    const corpus = [
+      { ...toolOnly, filePath: "/tmp/a/SKETCH.md" },
+      { ...exact, filePath: "/tmp/b/SKETCH.md" },
+    ];
+    const matches = matchSketchesForPlan(getCurrentPlan()!, corpus);
+
+    expect(matches[0].frontmatter.name).toBe("alphagenome-gwas-regulatory");
+    expect(matches[0].reason).toContain("exact workflow match");
+  });
+});
+
+describe("renderSketchForPrompt", () => {
+  it("includes name, matched-reason, assertions, and body", () => {
+    const parsed = parseSketch(ALPHAGENOME_SKETCH)!;
+    const rendered = renderSketchForPrompt({
+      ...parsed,
+      filePath: "/tmp/SKETCH.md",
+      score: 20,
+      reason: "2 tool match(es)",
+    });
+
+    expect(rendered).toContain("## Analysis Sketch: alphagenome-gwas-regulatory");
+    expect(rendered).toContain("2 tool match(es)");
+    expect(rendered).toContain("Top ISM position scored above 3.0");
+    expect(rendered).toContain("Run ISM scanner");
+  });
+});


### PR DESCRIPTION
## Summary
Wires Anton's gxy-sketches corpus (github.com/nekrut/gxy-sketches) into Loom as a knowledge layer. When \`sketchCorpusPath\` is set in \`~/.loom/config.json\`, the \`before_agent_start\` hook scans the corpus, ranks sketches against the active plan, and injects the top 2 bodies + expected-output assertions into the system prompt.

Matcher priority: exact \`source.workflow\` id match (score +100) > tool-id overlap including short-name matching (+10 each) > tag overlap from the BRC \`analysisCategory\` (+1 each). Returns empty when nothing signals, so unrelated plans see no injection and the prompt stays clean.

New \`extensions/loom/sketches.ts\` parses the SketchFrontmatter subset Loom needs (using the \`yaml\` library, now an explicit dependency). Malformed frontmatter, missing paths, and oversized files (>200KB) all produce warnings and skip cleanly rather than crashing the prompt build.

## Test plan
- [x] \`npm test\` -- 142 tests passing (was 133)
- [x] \`tsc --noEmit\` -- clean
- [x] New \`tests/sketch-loading.test.ts\` covers parse, corpus walk, malformed-frontmatter skip, missing-path safety, tool-id matching, exact-workflow-id priority, and the prompt rendering shape
- [ ] Manual: set \`sketchCorpusPath\`, start a plan with an \`alphagenome_*\` step, confirm the sketch content appears in the system prompt

## Pairs with
PR against nekrut/gxy-sketches for the AlphaGenome sketch itself (Sprint 3a).