### PR TITLE
Record per-step parameter overrides (Sprint 2b)

### DIFF
--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -121,6 +121,7 @@ ${buildExecutionModeContext()}
       workflowContext += '- Use `workflow_to_plan` to add Galaxy workflows as plan steps\n';
       workflowContext += '- Use `workflow_invocation_link` after invoking a workflow via Galaxy MCP\n';
       workflowContext += '- Use `workflow_invocation_check` to poll invocation status\n';
+      workflowContext += '- Use `workflow_set_overrides` to record per-step parameter deviations from defaults. When invoking via galaxy-mcp `invoke_workflow`, pass the step\'s `parameterOverrides` as the `params` argument so the deviation actually flows to Galaxy.\n';
       if (activeInvocations.length > 0) {
         workflowContext += `\n**${activeInvocations.length} active workflow invocation(s)** — check status with \`workflow_invocation_check\`\n`;
       }

--- a/extensions/loom/notebook-parser.ts
+++ b/extensions/loom/notebook-parser.ts
@@ -85,6 +85,7 @@ export interface ParsedStep {
   completed_at?: string;
   summary?: string;
   qc_passed?: boolean | null;
+  parameter_overrides?: Record<string, unknown>;
   workflow_structure?: {
     step_count: number;
     tools?: string[];
@@ -333,6 +334,17 @@ export function parseStepBlocks(content: string): ParsedStep[] {
           ? null
           : undefined;
 
+      let parameterOverrides: Record<string, unknown> | undefined;
+      if (typeof stepData.parameter_overrides === "string" && stepData.parameter_overrides.length > 0) {
+        try {
+          parameterOverrides = JSON.parse(stepData.parameter_overrides) as Record<string, unknown>;
+        } catch {
+          // bad JSON, drop rather than crash
+        }
+      } else if (stepData.parameter_overrides && typeof stepData.parameter_overrides === "object") {
+        parameterOverrides = stepData.parameter_overrides as Record<string, unknown>;
+      }
+
       steps.push({
         id: String(stepData.id || ""),
         name: String(stepData.name || ""),
@@ -353,6 +365,7 @@ export function parseStepBlocks(content: string): ParsedStep[] {
         completed_at: stepData.completed_at as string | undefined,
         summary: stepData.summary as string | undefined,
         qc_passed: qcPassed,
+        parameter_overrides: parameterOverrides,
         workflow_structure: workflowStructure,
       });
     }
@@ -705,6 +718,7 @@ export function notebookToPlan(notebook: ParsedNotebook): AnalysisPlan {
       })),
       result,
       workflowStructure,
+      parameterOverrides: step.parameter_overrides,
       dependsOn: [],
     };
   });

--- a/extensions/loom/notebook-writer.ts
+++ b/extensions/loom/notebook-writer.ts
@@ -258,6 +258,9 @@ export function generateNotebook(plan: AnalysisPlan): string {
     if (step.result && step.result.qcPassed !== null && step.result.qcPassed !== undefined) {
       lines.push(`  qc_passed: ${step.result.qcPassed}`);
     }
+    if (step.parameterOverrides && Object.keys(step.parameterOverrides).length > 0) {
+      lines.push(`  parameter_overrides: '${escapeJsonInYaml(step.parameterOverrides)}'`);
+    }
 
     lines.push("```");
     lines.push("");
@@ -265,6 +268,16 @@ export function generateNotebook(plan: AnalysisPlan): string {
     if (step.workflowStructure) {
       lines.push("");
       lines.push(`**Workflow pipeline**: ${step.workflowStructure.toolNames.join(' -> ')}`);
+    }
+    if (step.parameterOverrides && Object.keys(step.parameterOverrides).length > 0) {
+      lines.push("");
+      lines.push("**Parameter overrides (deviations from workflow defaults):**");
+      lines.push("");
+      lines.push("| Key | Override value |");
+      lines.push("|-----|----------------|");
+      for (const [k, v] of Object.entries(step.parameterOverrides)) {
+        lines.push(`| ${mdTableEscape(k)} | ${mdTableEscape(stringify(v))} |`);
+      }
     }
     lines.push("");
   }
@@ -583,6 +596,17 @@ function escapeYamlString(str: string): string {
  */
 function escapeJsonInYaml(obj: unknown): string {
   return JSON.stringify(obj).replace(/'/g, "''");
+}
+
+function mdTableEscape(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function stringify(value: unknown): string {
+  if (value === null || value === undefined) return '-';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return JSON.stringify(value);
 }
 
 /**

--- a/extensions/loom/state.ts
+++ b/extensions/loom/state.ts
@@ -941,6 +941,32 @@ export function updateFigure(figureId: string, updates: Partial<FigureSpec>): Fi
 }
 
 /**
+ * Set per-step workflow parameter overrides. Merges with existing overrides
+ * on the step (so repeated calls accumulate rather than clobber). Returns
+ * the final override map for the step.
+ */
+export function setStepParameterOverrides(
+  stepId: string,
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  if (!state.currentPlan) {
+    throw new Error("No active plan");
+  }
+
+  const step = state.currentPlan.steps.find((s) => s.id === stepId);
+  if (!step) {
+    throw new Error(`Step ${stepId} not found`);
+  }
+
+  const merged = { ...(step.parameterOverrides || {}), ...overrides };
+  step.parameterOverrides = merged;
+  state.currentPlan.updated = new Date().toISOString();
+  notifyPlanChange();
+
+  return merged;
+}
+
+/**
  * Update Galaxy connection state
  */
 export function setGalaxyConnection(connected: boolean, historyId?: string, serverUrl?: string): void {

--- a/extensions/loom/tools.ts
+++ b/extensions/loom/tools.ts
@@ -55,6 +55,8 @@ import {
   getBRCContext,
   // Tool version resolution
   resolveToolVersions,
+  // Parameter overrides
+  setStepParameterOverrides,
 } from "./state";
 import type {
   StepStatus,
@@ -2737,6 +2739,56 @@ analyses in Galaxy.`,
     renderResult: (result) => {
       const d = result.details as { updated?: number } | undefined;
       return new Text(`🔖 Resolved versions for ${d?.updated ?? 0} step(s)`);
+    },
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Per-step workflow parameter overrides
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  pi.registerTool({
+    name: "workflow_set_overrides",
+    label: "Set workflow parameter overrides",
+    description:
+      "Record per-invocation parameter deviations from the workflow defaults on a " +
+      "plan step. Use this when tuning an existing workflow for a specific locus, sample, " +
+      "or sensitivity setting. The overrides are stored on the step and passed to " +
+      "galaxy-mcp invoke_workflow as its `params` argument on subsequent runs.",
+    parameters: Type.Object({
+      stepId: Type.String({ description: "Plan step id to attach overrides to" }),
+      overrides: Type.Unknown({
+        description:
+          "Object mapping workflow step id or tool param name to the override value. " +
+          "Nested values are preserved verbatim.",
+      }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+      if (!getCurrentPlan()) {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ success: false, error: "No active plan" }) }],
+          details: { updated: 0 },
+        };
+      }
+
+      try {
+        const overrides = params.overrides as Record<string, unknown>;
+        const merged = setStepParameterOverrides(params.stepId, overrides);
+        await syncToNotebook('frontmatter', { updated: new Date().toISOString() });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ success: true, overrides: merged }) }],
+          details: { stepId: params.stepId, count: Object.keys(merged).length },
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ success: false, error: msg }) }],
+          details: { error: msg },
+        };
+      }
+    },
+    renderResult: (result) => {
+      const d = result.details as { stepId?: string; count?: number } | undefined;
+      return new Text(`⚙️ overrides set on step ${d?.stepId} (${d?.count} key(s))`);
     },
   });
 

--- a/extensions/loom/types.ts
+++ b/extensions/loom/types.ts
@@ -322,6 +322,11 @@ export interface AnalysisStep {
   // Workflow metadata (when executionType is 'workflow')
   workflowStructure?: WorkflowStructure;
 
+  // Per-invocation parameter overrides (deviations from workflow defaults).
+  // Keyed by the workflow step id or tool param name. Passed straight to
+  // galaxy-mcp invoke_workflow as the `params` argument.
+  parameterOverrides?: Record<string, unknown>;
+
   // Dependencies
   dependsOn: string[];
 }

--- a/tests/extension-integration.test.ts
+++ b/tests/extension-integration.test.ts
@@ -123,6 +123,7 @@ const EXPECTED_TOOLS = [
   "workflow_to_plan",
   "workflow_invocation_link",
   "workflow_invocation_check",
+  "workflow_set_overrides",
 
   // BRC Catalog Context
   "brc_set_context",

--- a/tests/parameter-overrides.test.ts
+++ b/tests/parameter-overrides.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  createPlan,
+  resetState,
+  addStep,
+  addWorkflowStep,
+  setStepParameterOverrides,
+  getCurrentPlan,
+} from "../extensions/loom/state";
+import { generateNotebook } from "../extensions/loom/notebook-writer";
+import { parseNotebook, notebookToPlan } from "../extensions/loom/notebook-parser";
+
+describe("workflow_set_overrides", () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  function seedWorkflowPlan() {
+    createPlan({
+      title: "Parameter Overrides",
+      researchQuestion: "Does the override ride through to galaxy-mcp?",
+      dataDescription: "synthetic",
+      expectedOutcomes: [],
+      constraints: [],
+    });
+    addWorkflowStep({
+      workflowId: "wf-ag-gwas",
+      trsId: "iwc-ag-gwas",
+      workflowStructure: {
+        name: "AlphaGenome GWAS",
+        version: 1,
+        toolIds: ["alphagenome_ism_scanner", "alphagenome_variant_scorer"],
+        toolNames: ["ism_scanner", "variant_scorer"],
+        inputLabels: ["Lead SNP"],
+        outputLabels: ["Ranked positions"],
+        stepCount: 2,
+      },
+    });
+  }
+
+  it("stores overrides on the step", () => {
+    seedWorkflowPlan();
+    const merged = setStepParameterOverrides("1", {
+      variant_ism_width: 600,
+      "ism_scanner.max_region_width": 600,
+    });
+
+    expect(merged).toEqual({
+      variant_ism_width: 600,
+      "ism_scanner.max_region_width": 600,
+    });
+    expect(getCurrentPlan()!.steps[0].parameterOverrides).toEqual(merged);
+  });
+
+  it("merges (not replaces) across repeated calls", () => {
+    seedWorkflowPlan();
+    setStepParameterOverrides("1", { variant_ism_width: 600 });
+    const merged = setStepParameterOverrides("1", {
+      "ism_scanner.max_region_width": 600,
+    });
+    expect(merged).toEqual({
+      variant_ism_width: 600,
+      "ism_scanner.max_region_width": 600,
+    });
+  });
+
+  it("renders a deviation table under the step in the notebook", () => {
+    seedWorkflowPlan();
+    setStepParameterOverrides("1", {
+      variant_ism_width: 600,
+      enable_stranded: true,
+    });
+
+    const markdown = generateNotebook(getCurrentPlan()!);
+    expect(markdown).toContain("Parameter overrides (deviations from workflow defaults)");
+    expect(markdown).toContain("| variant_ism_width | 600 |");
+    expect(markdown).toContain("| enable_stranded | true |");
+  });
+
+  it("round-trips overrides through parseNotebook", () => {
+    seedWorkflowPlan();
+    setStepParameterOverrides("1", {
+      variant_ism_width: 600,
+      "ism_scanner.max_region_width": 600,
+      notes: "per-locus sensitivity tweak",
+    });
+
+    const markdown = generateNotebook(getCurrentPlan()!);
+    const parsed = parseNotebook(markdown);
+    const restored = notebookToPlan(parsed!);
+
+    expect(restored.steps[0].parameterOverrides).toEqual({
+      variant_ism_width: 600,
+      "ism_scanner.max_region_width": 600,
+      notes: "per-locus sensitivity tweak",
+    });
+  });
+
+  it("errors when the step is missing", () => {
+    seedWorkflowPlan();
+    expect(() => setStepParameterOverrides("999", { x: 1 })).toThrow(
+      /Step 999 not found/
+    );
+  });
+
+  it("handles nested override values verbatim (passed straight to invoke_workflow)", () => {
+    seedWorkflowPlan();
+    const overrides = {
+      "1": { variant_ism_width: 600 },
+      "2": { scorers: ["CHIP_TF", "ATAC"], include_lead: true },
+    };
+    setStepParameterOverrides("1", overrides);
+
+    const markdown = generateNotebook(getCurrentPlan()!);
+    const restored = notebookToPlan(parseNotebook(markdown)!);
+
+    expect(restored.steps[0].parameterOverrides).toEqual(overrides);
+  });
+});
+
+describe("parameter overrides round-trip on a plain tool step", () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  it("works on tool steps too, not just workflow steps", () => {
+    createPlan({
+      title: "Tool step overrides",
+      researchQuestion: "Q",
+      dataDescription: "D",
+      expectedOutcomes: [],
+      constraints: [],
+    });
+    addStep({
+      name: "ISM",
+      description: "",
+      executionType: "tool",
+      toolId: "alphagenome_ism_scanner",
+      inputs: [],
+      expectedOutputs: [],
+      dependsOn: [],
+    });
+    setStepParameterOverrides("1", { max_region_width: 600 });
+
+    const markdown = generateNotebook(getCurrentPlan()!);
+    const restored = notebookToPlan(parseNotebook(markdown)!);
+    expect(restored.steps[0].parameterOverrides).toEqual({ max_region_width: 600 });
+  });
+});


### PR DESCRIPTION
## Summary
**Stacked on #1 (Sprint 0).** Merge that first; the diff here shows only Sprint 2b's work.

During the malaria chr6 run, each locus needed different \`variant_ism_width\` / \`ism_scanner.max_region_width\` values to avoid the 4kb scanner clipping problem. Loom had no way to record those deviations on the plan -- they were passed ad-hoc through galaxy-mcp \`invoke_workflow\` every run, fragile and unprovenanced.

New: \`AnalysisStep.parameterOverrides\` holds the deviation map. \`workflow_set_overrides(stepId, overrides)\` merges overrides in (repeated calls accumulate rather than clobber). The LLM is guided in \`context.ts\` to pass \`step.parameterOverrides\` as the \`params\` argument to galaxy-mcp \`invoke_workflow\`.

Notebook gets an authoritative \`parameter_overrides\` JSON (inside the step YAML) plus a human-readable \"Parameter overrides (deviations from workflow defaults)\" table under the step. Stacks on Sprint 0 for the JSON-in-YAML round-trip pattern.

## Test plan
- [x] \`npm test\` -- 146 tests passing (was 139 on Sprint 0)
- [x] \`tsc --noEmit\` -- clean
- [x] \`tests/parameter-overrides.test.ts\` covers storage, merging, rendering, round-trip on both workflow and tool steps, nested override values, and missing-step error
- [ ] Manual: set overrides on a workflow step, kick off \`galaxy_invoke_workflow\`, confirm the params actually flow through