### PR TITLE
Structured assertions with 6 kinds (Sprint 2a)

### DIFF
--- a/extensions/loom/notebook-parser.ts
+++ b/extensions/loom/notebook-parser.ts
@@ -27,6 +27,7 @@ import type {
   BiologicalFinding,
   FindingCategory,
   WorkflowStructure,
+  Assertion,
 } from "./types";
 
 /**
@@ -48,6 +49,7 @@ export interface ParsedNotebook {
   dataProvenance?: DataProvenance;
   researchQuestionDetails?: ResearchQuestion;
   publication?: PublicationMaterials;
+  assertions?: Assertion[];
 }
 
 export interface NotebookFrontmatter {
@@ -505,6 +507,24 @@ export function parseInterpretation(content: string): InterpretationFindings | u
 }
 
 /**
+ * Parse the authoritative assertions_json block from the Verification section.
+ */
+export function parseAssertions(content: string): Assertion[] | undefined {
+  const section = getSection(content, "Verification");
+  if (!section) return undefined;
+
+  const match = section.match(/assertions_json:\s*'([\s\S]*?)'\s*\n/);
+  if (!match) return undefined;
+
+  try {
+    const json = match[1].replace(/''/g, "'");
+    return JSON.parse(json) as Assertion[];
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Parse the authoritative publication_json block from the Publication Materials section.
  * Covers methods draft, figures, supplementary data, and data sharing info.
  */
@@ -637,6 +657,7 @@ export function parseNotebook(content: string): ParsedNotebook | null {
     dataProvenance: parseDataProvenance(content),
     researchQuestionDetails: parseResearchQuestionDetails(content),
     publication: parsePublicationMaterials(content),
+    assertions: parseAssertions(content),
   };
 }
 
@@ -777,6 +798,10 @@ export function notebookToPlan(notebook: ParsedNotebook): AnalysisPlan {
 
   if (notebook.publication) {
     plan.publication = notebook.publication;
+  }
+
+  if (notebook.assertions && notebook.assertions.length > 0) {
+    plan.assertions = notebook.assertions;
   }
 
   return plan;

--- a/extensions/loom/notebook-writer.ts
+++ b/extensions/loom/notebook-writer.ts
@@ -22,6 +22,7 @@ import type {
   InterpretationFindings,
   BiologicalFinding,
   WorkflowStructure,
+  Assertion,
 } from "./types";
 
 /**
@@ -271,6 +272,26 @@ export function generateNotebook(plan: AnalysisPlan): string {
 
   lines.push("---");
   lines.push("");
+
+  // Verification (structured assertions)
+  if (plan.assertions && plan.assertions.length > 0) {
+    lines.push("## Verification");
+    lines.push("");
+    lines.push("```yaml");
+    lines.push(`assertions_json: '${escapeJsonInYaml(plan.assertions)}'`);
+    lines.push("```");
+    lines.push("");
+    lines.push("| Step | Kind | Claim | Expected | Observed | Verdict |");
+    lines.push("|------|------|-------|----------|----------|---------|");
+    for (const a of plan.assertions) {
+      lines.push(
+        `| ${a.stepId || '-'} | ${a.kind} | ${mdTableEscape(a.claim)} | ${mdTableEscape(stringify(a.expected))} | ${mdTableEscape(stringify(a.observed))} | \`${a.verdict}\` |`
+      );
+    }
+    lines.push("");
+    lines.push("---");
+    lines.push("");
+  }
 
   // Interpretation (Phase 4)
   if (plan.interpretation && (plan.interpretation.findings.length > 0 || plan.interpretation.summary)) {
@@ -583,6 +604,17 @@ function escapeYamlString(str: string): string {
  */
 function escapeJsonInYaml(obj: unknown): string {
   return JSON.stringify(obj).replace(/'/g, "''");
+}
+
+function mdTableEscape(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+function stringify(value: unknown): string {
+  if (value === null || value === undefined) return '-';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return JSON.stringify(value);
 }
 
 /**

--- a/extensions/loom/state.ts
+++ b/extensions/loom/state.ts
@@ -34,6 +34,9 @@ import type {
   BiologicalFinding,
   InterpretationFindings,
   WorkflowStructure,
+  Assertion,
+  AssertionKind,
+  AssertionVerdict,
 } from "./types";
 import {
   generateNotebook,
@@ -938,6 +941,162 @@ export function updateFigure(figureId: string, updates: Partial<FigureSpec>): Fi
   state.currentPlan.updated = new Date().toISOString();
   notifyPlanChange();
   return figure;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Assertion recording + verdict logic
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compute the verdict for an assertion given expected, observed, and tolerance.
+ * No reliance on plan state; pure function so tests can exercise it directly.
+ */
+export function computeAssertionVerdict(
+  kind: AssertionKind,
+  expected: unknown,
+  observed: unknown,
+  tolerance?: number,
+): AssertionVerdict {
+  switch (kind) {
+    case 'scalar': {
+      const exp = Number(expected);
+      const obs = Number(observed);
+      if (!Number.isFinite(exp) || !Number.isFinite(obs)) return 'mismatch';
+      if (exp === obs) return 'exact_match';
+      const frac = tolerance ?? 0;
+      const allowed = Math.abs(exp * frac);
+      const diff = Math.abs(exp - obs);
+      if (diff <= allowed) return 'within_tolerance';
+      // Drift: close but outside tolerance; cap at 2x the allowed window
+      if (allowed > 0 && diff <= allowed * 2) return 'drift';
+      return 'mismatch';
+    }
+    case 'categorical': {
+      return String(expected) === String(observed) ? 'exact_match' : 'mismatch';
+    }
+    case 'rank':
+    case 'count': {
+      const exp = Number(expected);
+      const obs = Number(observed);
+      if (!Number.isInteger(exp) || !Number.isInteger(obs)) return 'mismatch';
+      if (exp === obs) return 'exact_match';
+      const tol = tolerance ?? 0;
+      return Math.abs(exp - obs) <= tol ? 'within_tolerance' : 'mismatch';
+    }
+    case 'set_member': {
+      if (!Array.isArray(expected)) return 'mismatch';
+      return expected.some((v) => v === observed) ? 'exact_match' : 'mismatch';
+    }
+    case 'coord_range': {
+      if (
+        !Array.isArray(expected) ||
+        expected.length !== 2 ||
+        typeof expected[0] !== 'number' ||
+        typeof expected[1] !== 'number'
+      ) {
+        return 'mismatch';
+      }
+      const obs = Number(observed);
+      if (!Number.isFinite(obs)) return 'mismatch';
+      const [min, max] = expected;
+      return obs >= min && obs <= max ? 'within_range' : 'out_of_range';
+    }
+    default:
+      return 'pending';
+  }
+}
+
+export interface RecordAssertionParams {
+  stepId?: string;
+  claim: string;
+  kind: AssertionKind;
+  expected: unknown;
+  observed: unknown;
+  tolerance?: number;
+  datasetId?: string;
+  source?: string;
+  expectedFromPlan?: Assertion['expectedFromPlan'];
+}
+
+/**
+ * Record an assertion on the current plan. Returns the stored Assertion with
+ * its computed verdict so callers can render it.
+ */
+export function recordAssertion(params: RecordAssertionParams): Assertion {
+  if (!state.currentPlan) {
+    throw new Error("No active plan");
+  }
+
+  if (!state.currentPlan.assertions) {
+    state.currentPlan.assertions = [];
+  }
+
+  const assertion: Assertion = {
+    id: `assertion-${state.currentPlan.assertions.length + 1}`,
+    stepId: params.stepId,
+    claim: params.claim,
+    kind: params.kind,
+    expected: params.expected,
+    observed: params.observed,
+    tolerance: params.tolerance,
+    datasetId: params.datasetId,
+    source: params.source,
+    verdict: computeAssertionVerdict(params.kind, params.expected, params.observed, params.tolerance),
+    recordedAt: new Date().toISOString(),
+    expectedFromPlan: params.expectedFromPlan,
+  };
+
+  state.currentPlan.assertions.push(assertion);
+  state.currentPlan.updated = assertion.recordedAt;
+  notifyPlanChange();
+
+  return assertion;
+}
+
+/**
+ * Resolve a cross-plan reference (expectedFromPlan) by reading another plan's
+ * notebook from disk and extracting a field. Simple dotted-path accessor.
+ * Returns the value or undefined if the plan, step, or field can't be found.
+ */
+export async function resolveExpectedFromPlan(params: {
+  planId: string;
+  stepId: string;
+  field: string;
+  searchDirectories?: string[];
+}): Promise<unknown> {
+  const dirs = params.searchDirectories || [process.cwd()];
+  for (const dir of dirs) {
+    const summaries = await findNotebooks(dir);
+    for (const summary of summaries) {
+      try {
+        const content = await readNotebook(summary.path);
+        const parsed = parseNotebook(content);
+        if (!parsed || parsed.frontmatter.plan_id !== params.planId) continue;
+
+        const plan = notebookToPlan(parsed);
+        const step = plan.steps.find((s) => s.id === params.stepId);
+        if (!step) continue;
+
+        return readNestedField(step, params.field);
+      } catch {
+        continue;
+      }
+    }
+  }
+  return undefined;
+}
+
+function readNestedField(obj: unknown, path: string): unknown {
+  const parts = path.split('.');
+  let cur: unknown = obj;
+  for (const p of parts) {
+    if (cur && typeof cur === 'object' && p in (cur as Record<string, unknown>)) {
+      cur = (cur as Record<string, unknown>)[p];
+    } else {
+      return undefined;
+    }
+  }
+  return cur;
 }
 
 /**

--- a/extensions/loom/tools.ts
+++ b/extensions/loom/tools.ts
@@ -55,6 +55,9 @@ import {
   getBRCContext,
   // Tool version resolution
   resolveToolVersions,
+  // Assertions
+  recordAssertion,
+  resolveExpectedFromPlan,
 } from "./state";
 import type {
   StepStatus,
@@ -2737,6 +2740,92 @@ analyses in Galaxy.`,
     renderResult: (result) => {
       const d = result.details as { updated?: number } | undefined;
       return new Text(`🔖 Resolved versions for ${d?.updated ?? 0} step(s)`);
+    },
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Structured assertions (verification table)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  pi.registerTool({
+    name: "analysis_assert",
+    label: "Record assertion",
+    description:
+      "Record a structured claim check against observed analysis output. Use when " +
+      "comparing a numerical value, top variant, rank, set membership, coordinate, or " +
+      "count against an expected value from a paper, prior run, or spec. Verdict is " +
+      "computed automatically from the expected/observed/tolerance triple.",
+    parameters: Type.Object({
+      stepId: Type.Optional(Type.String({ description: "Step this assertion tests" })),
+      claim: Type.String({ description: "Human-readable claim, e.g. 'top ISM position CHIP_TF score is 4.17'" }),
+      kind: Type.Union([
+        Type.Literal("scalar"),
+        Type.Literal("categorical"),
+        Type.Literal("rank"),
+        Type.Literal("set_member"),
+        Type.Literal("coord_range"),
+        Type.Literal("count"),
+      ], { description: "Assertion kind; drives the verdict logic" }),
+      expected: Type.Unknown({
+        description:
+          "Expected value. Scalar/rank/count: number. Categorical: string. " +
+          "set_member: array. coord_range: [min, max] number pair.",
+      }),
+      observed: Type.Unknown({ description: "Value actually observed in this run" }),
+      tolerance: Type.Optional(Type.Number({
+        description:
+          "Scalar: fractional (0.05 = 5% of expected). Rank/count: integer absolute.",
+      })),
+      datasetId: Type.Optional(Type.String({ description: "Galaxy dataset id the observed value came from" })),
+      source: Type.Optional(Type.String({ description: "Source of the expected value: paper DOI, prior plan id, spec" })),
+      expectedFromPlan: Type.Optional(Type.Object({
+        planId: Type.String(),
+        stepId: Type.String(),
+        field: Type.String({ description: "Dotted path on AnalysisStep (e.g. 'result.summary')" }),
+      }, { description: "Resolve expected value from another plan's notebook at assertion time" })),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+      if (!getCurrentPlan()) {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ success: false, error: "No active plan" }) }],
+          details: { verdict: "pending" },
+        };
+      }
+
+      let expectedValue = params.expected;
+      if (params.expectedFromPlan) {
+        try {
+          const resolved = await resolveExpectedFromPlan(params.expectedFromPlan);
+          if (resolved !== undefined) {
+            expectedValue = resolved;
+          }
+        } catch (err) {
+          console.warn("expectedFromPlan resolution failed:", err);
+        }
+      }
+
+      const stored = recordAssertion({
+        stepId: params.stepId,
+        claim: params.claim,
+        kind: params.kind,
+        expected: expectedValue,
+        observed: params.observed,
+        tolerance: params.tolerance,
+        datasetId: params.datasetId,
+        source: params.source,
+        expectedFromPlan: params.expectedFromPlan,
+      });
+
+      await syncToNotebook('frontmatter', { updated: new Date().toISOString() });
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify({ success: true, assertion: stored }) }],
+        details: { verdict: stored.verdict, kind: stored.kind },
+      };
+    },
+    renderResult: (result) => {
+      const d = result.details as { verdict?: string; kind?: string } | undefined;
+      return new Text(`✅ assertion ${d?.kind} → ${d?.verdict}`);
     },
   });
 

--- a/extensions/loom/types.ts
+++ b/extensions/loom/types.ts
@@ -291,6 +291,60 @@ export interface AnalysisPlan {
 
   // Publication materials (Phase 5)
   publication?: PublicationMaterials;
+
+  // Structured claim checks recorded at analysis time
+  assertions?: Assertion[];
+}
+
+/**
+ * The six assertion kinds cover what shows up in a real paper-audit pass:
+ *   scalar        -- numeric value within tolerance (e.g. CHIP_TF score 4.169 +/- 5%)
+ *   categorical   -- string equality (e.g. top variant is rs334)
+ *   rank          -- integer rank within tolerance positions
+ *   set_member    -- observed in a discrete expected set (credible-set VCF, cell type list)
+ *   coord_range   -- observed coord falls within [min, max] interval
+ *   count         -- integer count within tolerance
+ */
+export type AssertionKind =
+  | 'scalar'
+  | 'categorical'
+  | 'rank'
+  | 'set_member'
+  | 'coord_range'
+  | 'count';
+
+/**
+ * Verdict tells the researcher "did my claim hold?" without forcing boolean
+ * pass/fail when a scalar drifted a few percent.
+ */
+export type AssertionVerdict =
+  | 'exact_match'
+  | 'within_tolerance'
+  | 'within_range'
+  | 'drift'
+  | 'mismatch'
+  | 'out_of_range'
+  | 'pending';
+
+export interface Assertion {
+  id: string;
+  stepId?: string;
+  claim: string;
+  kind: AssertionKind;
+  expected: unknown;
+  observed: unknown;
+  /** Absolute tolerance for rank/count; fractional (0.05 = 5%) for scalar. */
+  tolerance?: number;
+  datasetId?: string;
+  source?: string;
+  verdict: AssertionVerdict;
+  recordedAt: string;
+  /** Optional cross-plan reference resolved at assertion time. */
+  expectedFromPlan?: {
+    planId: string;
+    stepId: string;
+    field: string;
+  };
 }
 
 export type PlanStatus = 'draft' | 'active' | 'completed' | 'abandoned';

--- a/tests/assertion-kinds.test.ts
+++ b/tests/assertion-kinds.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  createPlan,
+  resetState,
+  addStep,
+  recordAssertion,
+  computeAssertionVerdict,
+  resolveExpectedFromPlan,
+  getCurrentPlan,
+} from "../extensions/loom/state";
+import { generateNotebook } from "../extensions/loom/notebook-writer";
+import { parseNotebook, notebookToPlan } from "../extensions/loom/notebook-parser";
+
+describe("computeAssertionVerdict", () => {
+  it("scalar: within_tolerance when diff <= tolerance fraction of expected", () => {
+    // 4.17 vs 4.169 with 5% tolerance → within_tolerance
+    expect(computeAssertionVerdict("scalar", 4.17, 4.169, 0.05)).toBe("within_tolerance");
+  });
+
+  it("scalar: exact_match on identical floats", () => {
+    expect(computeAssertionVerdict("scalar", 4.17, 4.17, 0.01)).toBe("exact_match");
+  });
+
+  it("scalar: drift when inside 2x tolerance but outside 1x", () => {
+    // Expected 4.0, observed 4.25, tolerance 5% → allowed 0.2, diff 0.25 → drift
+    expect(computeAssertionVerdict("scalar", 4.0, 4.25, 0.05)).toBe("drift");
+  });
+
+  it("scalar: mismatch when diff > 2x tolerance", () => {
+    expect(computeAssertionVerdict("scalar", 4.0, 5.0, 0.05)).toBe("mismatch");
+  });
+
+  it("scalar: mismatch on non-numeric inputs", () => {
+    expect(computeAssertionVerdict("scalar", "foo", "bar")).toBe("mismatch");
+  });
+
+  it("categorical: exact_match on string equality", () => {
+    expect(computeAssertionVerdict("categorical", "rs334", "rs334")).toBe("exact_match");
+  });
+
+  it("categorical: mismatch on any inequality", () => {
+    expect(computeAssertionVerdict("categorical", "rs334", "rs1050828")).toBe("mismatch");
+  });
+
+  it("rank: exact_match on same integer rank", () => {
+    expect(computeAssertionVerdict("rank", 1, 1)).toBe("exact_match");
+  });
+
+  it("rank: within_tolerance when off by tolerance positions", () => {
+    expect(computeAssertionVerdict("rank", 1, 3, 2)).toBe("within_tolerance");
+  });
+
+  it("rank: mismatch when outside tolerance", () => {
+    expect(computeAssertionVerdict("rank", 1, 5, 2)).toBe("mismatch");
+  });
+
+  it("set_member: exact_match when observed is in the expected set", () => {
+    expect(
+      computeAssertionVerdict("set_member", ["rs334", "rs1050828", "rs2814778"], "rs334")
+    ).toBe("exact_match");
+  });
+
+  it("set_member: mismatch when observed is not in the set", () => {
+    expect(
+      computeAssertionVerdict("set_member", ["rs334", "rs1050828"], "rs2814778")
+    ).toBe("mismatch");
+  });
+
+  it("coord_range: within_range on coordinate inside interval", () => {
+    expect(computeAssertionVerdict("coord_range", [92618200, 92618300], 92618245)).toBe(
+      "within_range"
+    );
+  });
+
+  it("coord_range: out_of_range on coordinate outside interval", () => {
+    expect(computeAssertionVerdict("coord_range", [92618200, 92618300], 92650000)).toBe(
+      "out_of_range"
+    );
+  });
+
+  it("coord_range: mismatch on malformed expected", () => {
+    expect(computeAssertionVerdict("coord_range", "not a range", 100)).toBe("mismatch");
+  });
+
+  it("count: exact_match on identical counts", () => {
+    expect(computeAssertionVerdict("count", 15, 15)).toBe("exact_match");
+  });
+
+  it("count: within_tolerance and mismatch behave like rank", () => {
+    expect(computeAssertionVerdict("count", 15, 18, 3)).toBe("within_tolerance");
+    expect(computeAssertionVerdict("count", 15, 20, 3)).toBe("mismatch");
+  });
+});
+
+describe("recordAssertion", () => {
+  beforeEach(() => {
+    resetState();
+  });
+
+  function seedPlan() {
+    createPlan({
+      title: "Assertion recording",
+      researchQuestion: "Q",
+      dataDescription: "D",
+      expectedOutcomes: [],
+      constraints: [],
+    });
+    addStep({
+      name: "ISM",
+      description: "",
+      executionType: "tool",
+      toolId: "alphagenome_ism_scanner",
+      inputs: [],
+      expectedOutputs: [],
+      dependsOn: [],
+    });
+  }
+
+  it("stores each kind on the plan with verdict computed", () => {
+    seedPlan();
+    const a1 = recordAssertion({
+      stepId: "1",
+      claim: "Top CHIP_TF score",
+      kind: "scalar",
+      expected: 4.17,
+      observed: 4.169,
+      tolerance: 0.05,
+    });
+    const a2 = recordAssertion({
+      stepId: "1",
+      claim: "Top variant",
+      kind: "categorical",
+      expected: "rs334",
+      observed: "rs334",
+    });
+
+    expect(a1.verdict).toBe("within_tolerance");
+    expect(a2.verdict).toBe("exact_match");
+    expect(getCurrentPlan()!.assertions).toHaveLength(2);
+    expect(getCurrentPlan()!.assertions![0].id).toBe("assertion-1");
+    expect(getCurrentPlan()!.assertions![1].id).toBe("assertion-2");
+  });
+
+  it("round-trips assertions through notebook write + parse", () => {
+    seedPlan();
+    recordAssertion({
+      stepId: "1",
+      claim: "Top CHIP_TF score 4.17 +/- 5%",
+      kind: "scalar",
+      expected: 4.17,
+      observed: 4.169,
+      tolerance: 0.05,
+    });
+    recordAssertion({
+      stepId: "1",
+      claim: "Lead SNP in credible set",
+      kind: "set_member",
+      expected: ["rs334", "rs1050828", "rs2814778"],
+      observed: "rs334",
+    });
+    recordAssertion({
+      claim: "Plan-level note: peak count",
+      kind: "count",
+      expected: 15,
+      observed: 18,
+      tolerance: 3,
+    });
+
+    const markdown = generateNotebook(getCurrentPlan()!);
+    expect(markdown).toContain("## Verification");
+    expect(markdown).toContain("| 1 | scalar | Top CHIP_TF");
+    expect(markdown).toContain("`within_tolerance`");
+
+    const parsed = parseNotebook(markdown);
+    const restored = notebookToPlan(parsed!);
+
+    expect(restored.assertions).toHaveLength(3);
+    expect(restored.assertions![0]).toMatchObject({
+      stepId: "1",
+      kind: "scalar",
+      expected: 4.17,
+      observed: 4.169,
+      verdict: "within_tolerance",
+    });
+    expect(restored.assertions![1]).toMatchObject({
+      kind: "set_member",
+      verdict: "exact_match",
+    });
+    expect(restored.assertions![1].expected).toEqual([
+      "rs334",
+      "rs1050828",
+      "rs2814778",
+    ]);
+    expect(restored.assertions![2]).toMatchObject({
+      kind: "count",
+      verdict: "within_tolerance",
+    });
+    expect(restored.assertions![2].stepId).toBeFalsy();
+  });
+});
+
+describe("expectedFromPlan cross-reference", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    resetState();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "loom-assert-"));
+  });
+
+  it("resolves an expected value from another plan's notebook on disk", async () => {
+    // 1. Create a reference plan and write its notebook to the tmpDir.
+    const ref = createPlan({
+      title: "Reference run",
+      researchQuestion: "Q",
+      dataDescription: "D",
+      expectedOutcomes: [],
+      constraints: [],
+    });
+    addStep({
+      name: "Prior ISM",
+      description: "Baseline ISM peak",
+      executionType: "tool",
+      toolId: "alphagenome_ism_scanner",
+      inputs: [],
+      expectedOutputs: [],
+      dependsOn: [],
+    });
+    // Manually set a summary on the step's result so we can cross-reference it.
+    ref.steps[0].result = {
+      completedAt: "2026-03-01T00:00:00Z",
+      jobId: "job-ref",
+      summary: "peak=4.17",
+      qcPassed: true,
+    };
+    // Write the notebook to disk matching the naming convention the
+    // listNotebooks helper uses.
+    const refContent = generateNotebook(getCurrentPlan()!);
+    const refPath = path.join(tmpDir, "reference-run-notebook.md");
+    fs.writeFileSync(refPath, refContent);
+
+    resetState();
+
+    // 2. Resolve the field from the reference plan.
+    const resolved = await resolveExpectedFromPlan({
+      planId: ref.id,
+      stepId: "1",
+      field: "result.summary",
+      searchDirectories: [tmpDir],
+    });
+
+    expect(resolved).toBe("peak=4.17");
+  });
+});

--- a/tests/extension-integration.test.ts
+++ b/tests/extension-integration.test.ts
@@ -134,6 +134,9 @@ const EXPECTED_TOOLS = [
   // Tool Version Resolution
   "analysis_resolve_versions",
 
+  // Assertions
+  "analysis_assert",
+
   // Shell-facing tools (structured widget emitters)
   "report_result",
   "analyze_plan_parameters",


### PR DESCRIPTION
Reopening after the original #5 merged into the stacked base branch but never landed in main. Rebased onto current main.

Adds `analysis_assert` tool supporting scalar, categorical, rank, set_member, coord_range, and count verdict kinds. Each kind computes a pass/drift/fail verdict automatically from expected/observed/tolerance. Cross-plan references via `expectedFromPlan` resolve at assertion time. Notebook renders a per-plan verification table.

Part of Sprint 2a in `~/work/brain/plans/loom-publication-ready-analysis/`.