### PR TITLE
Fix stale UI after cwd change via top-bar button

### DIFF
--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -58,7 +58,7 @@ export function registerIpcHandlers(agent: AgentManager): void {
     return result.filePaths[0] ?? null;
   });
 
-  ipcMain.handle("dialog:select-directory", async () => {
+  ipcMain.handle("dialog:select-directory", async (e) => {
     const result = await dialog.showOpenDialog({
       title: "Choose working directory",
       defaultPath: agent.getCwd(),
@@ -67,6 +67,12 @@ export function registerIpcHandlers(agent: AgentManager): void {
     const dir = result.filePaths[0] ?? null;
     if (dir && agent.switchCwd(dir)) {
       log("directory changed to:", dir);
+      // Mirror the File > Open Analysis Directory path so the renderer
+      // resets its UI when the cwd changes via the top-bar "change" button.
+      BrowserWindow.fromWebContents(e.sender)?.webContents.send(
+        "agent:cwd-changed",
+        dir,
+      );
     }
     return dir;
   });

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -7,6 +7,25 @@ function log(...args: unknown[]): void {
   console.log("[ipc]", ...args);
 }
 
+/**
+ * Ask the user to confirm that switching analysis directories will start
+ * a fresh agent session and clear the current chat/plan/notebook view.
+ * Returns true if the user confirmed.
+ */
+export async function confirmCwdChange(window?: BrowserWindow): Promise<boolean> {
+  const result = await dialog.showMessageBox(window!, {
+    type: "warning",
+    buttons: ["Cancel", "Continue"],
+    defaultId: 0,
+    cancelId: 0,
+    title: "Change analysis directory?",
+    message: "Changing the analysis directory will start a new agent session.",
+    detail:
+      "The current chat, plan, and notebook view will be cleared from this window. The previous session remains on disk and can be resumed by opening that directory again.",
+  });
+  return result.response === 1;
+}
+
 export function registerIpcHandlers(agent: AgentManager): void {
   ipcMain.handle("agent:prompt", async (_e, message: string) => {
     log("prompt:", message.slice(0, 80));
@@ -59,6 +78,8 @@ export function registerIpcHandlers(agent: AgentManager): void {
   });
 
   ipcMain.handle("dialog:select-directory", async (e) => {
+    const window = BrowserWindow.fromWebContents(e.sender) ?? undefined;
+    if (!(await confirmCwdChange(window))) return null;
     const result = await dialog.showOpenDialog({
       title: "Choose working directory",
       defaultPath: agent.getCwd(),
@@ -69,10 +90,7 @@ export function registerIpcHandlers(agent: AgentManager): void {
       log("directory changed to:", dir);
       // Mirror the File > Open Analysis Directory path so the renderer
       // resets its UI when the cwd changes via the top-bar "change" button.
-      BrowserWindow.fromWebContents(e.sender)?.webContents.send(
-        "agent:cwd-changed",
-        dir,
-      );
+      window?.webContents.send("agent:cwd-changed", dir);
     }
     return dir;
   });

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -3,7 +3,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import * as fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { registerIpcHandlers } from "./ipc-handlers.js";
+import { registerIpcHandlers, confirmCwdChange } from "./ipc-handlers.js";
 import { AgentManager } from "./agent.js";
 import { ProcMonitor } from "./proc-monitor.js";
 
@@ -205,6 +205,7 @@ function buildMenu(): void {
           accelerator: "CmdOrCtrl+O",
           click: async () => {
             if (!agentManager || !mainWindow) return;
+            if (!(await confirmCwdChange(mainWindow))) return;
             const result = await dialog.showOpenDialog({
               title: "Choose analysis directory",
               defaultPath: agentManager.getCwd(),


### PR DESCRIPTION
## Summary

Two related fixes to the masthead "change" button / File menu cwd-switch flow:

1. **UI stays in sync with the main process** when the cwd is switched via the top-bar button (not just the File menu).
2. **User is warned** before a cwd switch, because the switch tears down the current agent session and resets the UI — previously silent, trivially triggerable by a stray click.

## Commits

### 1. `Fix stale UI after cwd change via top-bar button`

Two IPC paths call \`agent.switchCwd()\`:

- \`app/src/main/main.ts\` (File menu) — calls \`switchCwd()\` **and** sends \`agent:cwd-changed\` to the renderer, which triggers \`applyCwdChange()\` and resets the UI.
- \`app/src/main/ipc-handlers.ts\` (\`dialog:select-directory\`, used by the top-bar button) — calls \`switchCwd()\` but never emits \`agent:cwd-changed\`. The agent subprocess restarts in the new cwd, but the renderer doesn't know.

The renderer's \`cwdChangeBtn\` click handler awaits the \`selectDirectory\` invocation and discards the returned path, so the UI path is entirely dependent on the main-process event it never receives.

**Fix:** after a successful \`switchCwd\` in the IPC handler, send \`agent:cwd-changed\` to the sender's window. Uses \`BrowserWindow.fromWebContents(e.sender)\` so the event reaches the window that actually triggered the dialog.

### 2. `Warn before changing analysis directory`

Switching cwd stops the agent subprocess and restarts it without \`--continue\`, discarding the current chat history from this window (the previous session stays on disk and can be resumed by reopening that directory). That's destructive and was previously silent.

**Fix:** shared \`confirmCwdChange()\` helper shows a warning dialog before the directory picker. Called from both entry points (top-bar button and File menu). Cancel is the default button.

## Test plan
- [ ] Click masthead "change" → warning appears → Continue → pick directory → masthead updates, chat resets
- [ ] Click "change" → warning appears → Cancel → no picker, no session change
- [ ] File > Open Analysis Directory… → same two behaviors
- [ ] Pick the same directory in the picker → no UI reset (handler only emits when cwd actually changes)
- [ ] Previous session remains on disk → reopening that dir resumes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)