### PR TITLE
session-index: searchable FTS5 layer over Pi.dev session JSONLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 
 # Test-generated notebook files
 *-notebook.md
+
+# Agent worktrees
+.worktrees/

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -14,6 +14,7 @@ import {
   renderSketchForPrompt,
 } from "./sketches";
 import { isTeamDispatchEnabled } from "./teams/is-enabled";
+import { isSessionIndexEnabled } from "./session-index/is-enabled";
 
 /**
  * System-prompt block describing team_dispatch usage. Empty string when the
@@ -51,6 +52,30 @@ Confirmation heuristic: if the user's request gives concrete roles, task
 framing, and success criteria, dispatch without asking. If the request
 is vague (e.g. "use a team"), propose the TeamSpec in chat and ask the
 user to approve or edit it first.
+`;
+}
+
+/**
+ * System-prompt block describing the session-index tools. Empty when the
+ * experimental flag is off (tools aren't registered either, so mentioning
+ * them would mislead the model).
+ */
+export function buildSessionIndexContext(): string {
+  if (!isSessionIndexEnabled()) return "";
+  return `
+## Prior-session recall
+
+You have access to your prior analysis sessions via \`chat_search\`,
+\`chat_find_tool_calls\`, and \`chat_session_context\`. Use them when:
+
+- The user references past work ("when we worked on X").
+- You need to recall a prior decision or rationale.
+- You want to reuse parameters from a previous session.
+
+Searches default to all sessions across all projects. Pass
+\`scope: 'cwd'\` to scope to the current analysis directory. Retrieved
+entries may pre-date compaction — surface them verbatim when the user
+asks what was said.
 `;
 }
 
@@ -150,7 +175,7 @@ right away without asking clarifying questions first.
 ${brcSection}
 ${galaxyContext}
 ${buildExecutionModeContext()}
-${buildTeamDispatchContext()}`
+${buildTeamDispatchContext()}${buildSessionIndexContext()}`
       };
     }
 
@@ -239,7 +264,7 @@ ${planSummary}
 ${workflowContext}${brcSection}${sketchSection}
 ${galaxyContext}
 ${buildExecutionModeContext()}
-${buildTeamDispatchContext()}`
+${buildTeamDispatchContext()}${buildSessionIndexContext()}`
     };
   });
 

--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -14,6 +14,8 @@ import { registerSessionLifecycle } from "./session-bootstrap";
 import { registerExecutionCommands } from "./execution-commands";
 import { registerTeamTools } from "./teams/tool";
 import { isTeamDispatchEnabled } from "./teams/is-enabled";
+import { registerSessionIndexTools } from "./session-index/tools";
+import { isSessionIndexEnabled } from "./session-index/is-enabled";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -47,6 +49,9 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
   registerExecutionCommands(pi);
   if (isTeamDispatchEnabled()) {
     registerTeamTools(pi);
+  }
+  if (isSessionIndexEnabled()) {
+    registerSessionIndexTools(pi);
   }
 
   // ─────────────────────────────────────────────────────────────────────────────

--- a/extensions/loom/session-index/cwd.ts
+++ b/extensions/loom/session-index/cwd.ts
@@ -1,0 +1,18 @@
+/**
+ * Pi.dev encodes each working directory as "--<path-with-slashes-as-dashes>--"
+ * and uses that as the per-cwd session directory name under ~/.pi/agent/sessions/.
+ *
+ * Lossy by design -- a cwd with a literal hyphen collides with one where a
+ * slash sat in the same position. This matches Pi's own on-disk encoding
+ * (see Pi's SessionManager.getDefaultSessionDir). Do not add escaping; the
+ * indexer needs to reproduce the exact directory name Pi writes.
+ */
+export function encodeCwd(cwd: string): string {
+  return `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
+}
+
+export function decodeCwd(encoded: string): string | null {
+  if (!encoded.startsWith("--") || !encoded.endsWith("--")) return null;
+  const inner = encoded.slice(2, -2);
+  return "/" + inner.replace(/-/g, "/");
+}

--- a/extensions/loom/session-index/db.ts
+++ b/extensions/loom/session-index/db.ts
@@ -1,0 +1,57 @@
+import Database, { type Database as Db } from "better-sqlite3";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { SCHEMA_SQL, SCHEMA_VERSION } from "./schema";
+
+export { SCHEMA_VERSION };
+
+/**
+ * Open (and if needed rebuild) the session-index database.
+ *
+ * The index is a derived cache -- Pi's JSONL files are the source of truth --
+ * so a schema-version mismatch triggers a clean rebuild rather than a
+ * migration. Cheap because the next scan will repopulate.
+ */
+export function openIndexDb(filePath: string): Db {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  let db = new Database(filePath);
+  db.pragma("journal_mode = WAL");
+  db.pragma("foreign_keys = ON");
+
+  const existing = isSchemaCurrent(db);
+  if (!existing) {
+    // Single-writer assumption: the session-index DB has one owner per user.
+    // If a second process opens between close() and the rmSync calls, its
+    // handle becomes invalid -- accepted tradeoff for a derived-cache layer.
+    db.close();
+    fs.rmSync(filePath, { force: true });
+    fs.rmSync(filePath + "-wal", { force: true });
+    fs.rmSync(filePath + "-shm", { force: true });
+    db = new Database(filePath);
+    db.pragma("journal_mode = WAL");
+    db.pragma("foreign_keys = ON");
+    db.exec(SCHEMA_SQL);
+    db.prepare("INSERT INTO meta(key, value) VALUES ('schema_version', ?)").run(
+      String(SCHEMA_VERSION),
+    );
+  }
+  return db;
+}
+
+function isSchemaCurrent(db: Db): boolean {
+  try {
+    const row = db
+      .prepare("SELECT value FROM meta WHERE key='schema_version'")
+      .get() as { value: string } | undefined;
+    return row?.value === String(SCHEMA_VERSION);
+  } catch {
+    // meta table doesn't exist yet
+    return false;
+  }
+}
+
+/** Default location: ~/.loom/sessions-index.db. */
+export function defaultDbPath(): string {
+  return path.join(os.homedir(), ".loom", "sessions-index.db");
+}

--- a/extensions/loom/session-index/indexer.ts
+++ b/extensions/loom/session-index/indexer.ts
@@ -1,0 +1,155 @@
+import type { Database as Db } from "better-sqlite3";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { parseSessionFile, type EntryRow, type ToolCallRow } from "./parse";
+import { decodeCwd } from "./cwd";
+
+export interface ScanReport {
+  sessionsSeen: number;
+  sessionsRemoved: number;
+  entriesInserted: number;
+  toolCallsInserted: number;
+}
+
+/**
+ * Default location of Pi's session corpus.
+ */
+export function defaultSessionsDir(): string {
+  return path.join(os.homedir(), ".pi", "agent", "sessions");
+}
+
+/**
+ * Incrementally synchronize the index DB against a sessions directory.
+ *
+ * Safe to call repeatedly. On the first call, indexes every file in bulk.
+ * Subsequent calls resume per-file from the stored byte offset; files
+ * whose mtime hasn't advanced are skipped. Sessions whose file has been
+ * deleted are removed from the index.
+ */
+export function scanSessions(db: Db, sessionsDir: string = defaultSessionsDir()): ScanReport {
+  const report: ScanReport = {
+    sessionsSeen: 0,
+    sessionsRemoved: 0,
+    entriesInserted: 0,
+    toolCallsInserted: 0,
+  };
+
+  if (!fs.existsSync(sessionsDir)) return report;
+
+  const knownFiles = listJsonlFiles(sessionsDir);
+  const seenPaths = new Set(knownFiles);
+
+  // Stale-session cleanup (ON DELETE CASCADE handles entries + tool_calls)
+  const existing = db.prepare("SELECT session_id, file_path FROM sessions").all() as Array<{
+    session_id: string;
+    file_path: string;
+  }>;
+  const del = db.prepare("DELETE FROM sessions WHERE session_id = ?");
+  for (const row of existing) {
+    if (!seenPaths.has(row.file_path)) {
+      del.run(row.session_id);
+      report.sessionsRemoved++;
+    }
+  }
+
+  const selState = db.prepare(
+    "SELECT session_id, last_indexed_offset FROM sessions WHERE file_path = ?",
+  );
+  const upsertSession = db.prepare(`
+    INSERT INTO sessions(
+      session_id, file_path, cwd, name, parent_session, notebook_path,
+      created_at, last_indexed_at, last_indexed_offset
+    )
+    VALUES (@session_id, @file_path, @cwd, @name, @parent_session, @notebook_path,
+            @created_at, @last_indexed_at, @last_indexed_offset)
+    ON CONFLICT(session_id) DO UPDATE SET
+      name            = COALESCE(excluded.name, sessions.name),
+      notebook_path   = COALESCE(excluded.notebook_path, sessions.notebook_path),
+      last_indexed_at = excluded.last_indexed_at,
+      last_indexed_offset = excluded.last_indexed_offset
+  `);
+  const insEntry = db.prepare(`
+    INSERT OR IGNORE INTO entries(
+      entry_id, session_id, parent_id, entry_type, timestamp, role, text_content, raw_json
+    ) VALUES (@entry_id, @session_id, @parent_id, @entry_type, @timestamp, @role, @text_content, @raw_json)
+  `);
+  const insTc = db.prepare(`
+    INSERT OR IGNORE INTO tool_calls(entry_id, session_id, tool_name, arguments_json, result_text)
+    VALUES (@entry_id, @session_id, @tool_name, @arguments_json, @result_text)
+  `);
+
+  const indexOne = db.transaction((filePath: string) => {
+    const prior = selState.get(filePath) as
+      | { session_id: string; last_indexed_offset: number }
+      | undefined;
+    const startOffset = prior?.last_indexed_offset ?? 0;
+    const fileSize = fs.statSync(filePath).size;
+    if (prior && startOffset >= fileSize) return;
+
+    const parsed = parseSessionFile(filePath, {
+      startOffset,
+      skipHeader: startOffset > 0,
+    });
+
+    // Decode cwd from directory name (fallback to header.cwd when decode fails)
+    const enclosingDir = path.basename(path.dirname(filePath));
+    const cwd = decodeCwd(enclosingDir) ?? parsed.header.cwd ?? "";
+
+    const sessionId = prior?.session_id ?? parsed.header.id;
+    if (!sessionId) return;
+
+    upsertSession.run({
+      session_id: sessionId,
+      file_path: filePath,
+      cwd,
+      name: parsed.sessionName,
+      parent_session: parsed.header.parentSession,
+      notebook_path: parsed.notebookPath,
+      created_at: parsed.header.createdAt || new Date().toISOString(),
+      last_indexed_at: new Date().toISOString(),
+      last_indexed_offset: parsed.endOffset,
+    });
+
+    for (const entry of parsed.entries) {
+      const info = insEntry.run({
+        ...entry,
+        session_id: sessionId,
+      } as EntryRow & { session_id: string });
+      if (info.changes > 0) report.entriesInserted++;
+    }
+    for (const tc of parsed.tool_calls) {
+      const info = insTc.run({
+        ...tc,
+        session_id: sessionId,
+      } as ToolCallRow & { session_id: string });
+      if (info.changes > 0) report.toolCallsInserted++;
+    }
+
+    report.sessionsSeen++;
+  });
+
+  for (const fp of knownFiles) {
+    try {
+      indexOne(fp);
+    } catch {
+      // Broken file -- skip, don't halt the scan
+    }
+  }
+
+  return report;
+}
+
+function listJsonlFiles(root: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const sub = path.join(root, entry.name);
+    for (const file of fs.readdirSync(sub, { withFileTypes: true })) {
+      if (!file.isFile()) continue;
+      if (!file.name.endsWith(".jsonl")) continue;
+      out.push(path.join(sub, file.name));
+    }
+  }
+  return out;
+}

--- a/extensions/loom/session-index/indexer.ts
+++ b/extensions/loom/session-index/indexer.ts
@@ -75,8 +75,8 @@ export function scanSessions(db: Db, sessionsDir: string = defaultSessionsDir())
     ) VALUES (@entry_id, @session_id, @parent_id, @entry_type, @timestamp, @role, @text_content, @raw_json)
   `);
   const insTc = db.prepare(`
-    INSERT OR IGNORE INTO tool_calls(entry_id, session_id, tool_name, arguments_json, result_text)
-    VALUES (@entry_id, @session_id, @tool_name, @arguments_json, @result_text)
+    INSERT OR IGNORE INTO tool_calls(entry_id, session_id, tool_use_id, tool_name, arguments_json, result_text)
+    VALUES (@entry_id, @session_id, @tool_use_id, @tool_name, @arguments_json, @result_text)
   `);
 
   const indexOne = db.transaction((filePath: string) => {

--- a/extensions/loom/session-index/is-enabled.ts
+++ b/extensions/loom/session-index/is-enabled.ts
@@ -1,0 +1,16 @@
+import { loadConfig } from "../config";
+
+/**
+ * Whether the experimental session-index tools are opted in.
+ *
+ * Resolution order mirrors isTeamDispatchEnabled():
+ *   1. LOOM_SESSION_INDEX env var -- "1" -> on, "0" -> off, else defer.
+ *   2. config.experiments.sessionIndex -- boolean.
+ *   3. Default: off.
+ */
+export function isSessionIndexEnabled(): boolean {
+  const env = process.env.LOOM_SESSION_INDEX;
+  if (env === "1") return true;
+  if (env === "0") return false;
+  return loadConfig().experiments?.sessionIndex === true;
+}

--- a/extensions/loom/session-index/parse.ts
+++ b/extensions/loom/session-index/parse.ts
@@ -1,0 +1,250 @@
+import fs from "node:fs";
+
+export interface SessionHeader {
+  id: string;
+  cwd: string;
+  createdAt: string;
+  parentSession: string | null;
+}
+
+export interface EntryRow {
+  entry_id: string;
+  parent_id: string | null;
+  entry_type: string;
+  timestamp: string;
+  role: "user" | "assistant" | null;
+  text_content: string | null;
+  raw_json: string;
+}
+
+export interface ToolCallRow {
+  entry_id: string;
+  tool_name: string;
+  arguments_json: string;
+  result_text: string | null;
+}
+
+export interface ParseResult {
+  header: SessionHeader;
+  entries: EntryRow[];
+  tool_calls: ToolCallRow[];
+  /** Latest customType=galaxy_analyst_plan entry's data.notebookPath, if any. */
+  notebookPath: string | null;
+  /** Latest customType=session_info name, if any. */
+  sessionName: string | null;
+  /** Byte offset (exclusive) of the last parsed line in the file. */
+  endOffset: number;
+}
+
+export interface ParseOptions {
+  /** Start parsing from this byte offset (used for incremental scans). */
+  startOffset?: number;
+  /** Skip emitting the header if we're resuming past it. */
+  skipHeader?: boolean;
+}
+
+/**
+ * Parse a Pi session JSONL file into normalized rows for the index.
+ *
+ * Does NOT throw on malformed lines; invalid JSON lines are skipped and
+ * the caller's endOffset still advances past them (so incremental scans
+ * don't loop on a corrupt line).
+ */
+export function parseSessionFile(
+  filePath: string,
+  opts: ParseOptions = {},
+): ParseResult {
+  const startOffset = opts.startOffset ?? 0;
+  const buf = fs.readFileSync(filePath);
+  const slice = buf.subarray(startOffset);
+  const text = slice.toString("utf8");
+
+  const entries: EntryRow[] = [];
+  const toolCalls: ToolCallRow[] = [];
+  const pendingResults = new Map<string, string>();
+  let header: SessionHeader | null = null;
+  let notebookPath: string | null = null;
+  let sessionName: string | null = null;
+
+  let lineStart = 0;
+  for (let i = 0; i <= text.length; i++) {
+    if (i !== text.length && text.charCodeAt(i) !== 10 /* \n */) continue;
+    const raw = text.slice(lineStart, i);
+    lineStart = i + 1;
+    if (raw.length === 0) continue;
+    let obj: Record<string, unknown>;
+    try {
+      obj = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+
+    if (obj.type === "session") {
+      if (!opts.skipHeader) {
+        header = {
+          id: String(obj.id ?? ""),
+          cwd: String(obj.cwd ?? ""),
+          createdAt: String(obj.timestamp ?? ""),
+          parentSession: typeof obj.parentSession === "string" ? obj.parentSession : null,
+        };
+      }
+      continue;
+    }
+
+    const row = entryRowFromObj(obj);
+    if (!row) continue;
+    entries.push(row);
+
+    if (row.entry_type === "message" && row.role === "assistant") {
+      for (const tc of extractToolUses(obj)) {
+        toolCalls.push({ entry_id: row.entry_id, ...tc });
+      }
+    }
+    if (row.entry_type === "message" && row.role === "user") {
+      for (const { tool_use_id, text_content } of extractToolResults(obj)) {
+        pendingResults.set(tool_use_id, text_content);
+      }
+    }
+
+    if (row.entry_type === "custom") {
+      const customType = String((obj as { customType?: unknown }).customType ?? "");
+      if (customType === "galaxy_analyst_plan") {
+        const data = (obj as { data?: { notebookPath?: string } }).data;
+        if (data?.notebookPath) notebookPath = data.notebookPath;
+      }
+    }
+    if (row.entry_type === "session_info") {
+      const name = (obj as { name?: string }).name;
+      if (name) sessionName = name;
+    }
+  }
+
+  // Join tool-call results (resolve by tool_use_id stashed on each call)
+  const byUseId = new Map<string, ToolCallRow>();
+  for (const tc of toolCalls) {
+    const useId = (tc as ToolCallRow & { __tool_use_id?: string }).__tool_use_id;
+    if (useId) byUseId.set(useId, tc);
+  }
+  for (const [useId, text] of pendingResults) {
+    const target = byUseId.get(useId);
+    if (target) target.result_text = text;
+  }
+  // Clean internal marker before returning
+  for (const tc of toolCalls) {
+    delete (tc as ToolCallRow & { __tool_use_id?: string }).__tool_use_id;
+  }
+
+  if (!header && !opts.skipHeader) {
+    throw new Error(`No session header found in ${filePath}`);
+  }
+
+  return {
+    header: header ?? ({ id: "", cwd: "", createdAt: "", parentSession: null } as SessionHeader),
+    entries,
+    tool_calls: toolCalls,
+    notebookPath,
+    sessionName,
+    endOffset: startOffset + Buffer.byteLength(text, "utf8"),
+  };
+}
+
+function entryRowFromObj(obj: Record<string, unknown>): EntryRow | null {
+  const type = typeof obj.type === "string" ? obj.type : "";
+  const entryId = typeof obj.id === "string" ? obj.id : null;
+  if (!type || !entryId) return null;
+
+  const parentId = typeof obj.parentId === "string" ? obj.parentId : null;
+  const timestamp = typeof obj.timestamp === "string" ? obj.timestamp : "";
+
+  let role: "user" | "assistant" | null = null;
+  let text: string | null = null;
+  if (type === "message") {
+    const msg = (obj as { message?: { role?: string; content?: unknown } }).message;
+    const r = msg?.role;
+    if (r === "user" || r === "assistant") role = r;
+    text = flattenTextBlocks(msg?.content);
+  } else if (type === "compaction") {
+    text = typeof (obj as { summary?: string }).summary === "string"
+      ? (obj as { summary: string }).summary
+      : null;
+  } else if (type === "branch_summary") {
+    text = typeof (obj as { summary?: string }).summary === "string"
+      ? (obj as { summary: string }).summary
+      : null;
+  } else if (type === "custom") {
+    text = JSON.stringify((obj as { data?: unknown }).data ?? null);
+  }
+
+  return {
+    entry_id: entryId,
+    parent_id: parentId,
+    entry_type: type,
+    timestamp,
+    role,
+    text_content: text,
+    raw_json: JSON.stringify(obj),
+  };
+}
+
+function flattenTextBlocks(content: unknown): string | null {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return null;
+  const parts: string[] = [];
+  for (const block of content) {
+    if (typeof block === "string") {
+      parts.push(block);
+      continue;
+    }
+    if (!block || typeof block !== "object") continue;
+    const b = block as { type?: string; text?: string };
+    if (b.type === "text" && typeof b.text === "string") parts.push(b.text);
+  }
+  return parts.length > 0 ? parts.join("\n") : null;
+}
+
+function extractToolUses(
+  obj: Record<string, unknown>,
+): Array<{ tool_name: string; arguments_json: string; result_text: null; __tool_use_id?: string }> {
+  const content = (obj as { message?: { content?: unknown } }).message?.content;
+  if (!Array.isArray(content)) return [];
+  const out: Array<{
+    tool_name: string;
+    arguments_json: string;
+    result_text: null;
+    __tool_use_id?: string;
+  }> = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const b = block as { type?: string; name?: string; input?: unknown; id?: string };
+    if (b.type !== "tool_use" || typeof b.name !== "string") continue;
+    out.push({
+      tool_name: b.name,
+      arguments_json: JSON.stringify(b.input ?? {}),
+      result_text: null,
+      __tool_use_id: b.id,
+    });
+  }
+  return out;
+}
+
+function extractToolResults(
+  obj: Record<string, unknown>,
+): Array<{ tool_use_id: string; text_content: string }> {
+  const content = (obj as { message?: { content?: unknown } }).message?.content;
+  if (!Array.isArray(content)) return [];
+  const out: Array<{ tool_use_id: string; text_content: string }> = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const b = block as {
+      type?: string;
+      tool_use_id?: string;
+      content?: unknown;
+    };
+    if (b.type !== "tool_result" || typeof b.tool_use_id !== "string") continue;
+    out.push({
+      tool_use_id: b.tool_use_id,
+      text_content: flattenTextBlocks(b.content) ?? "",
+    });
+  }
+  return out;
+}

--- a/extensions/loom/session-index/parse.ts
+++ b/extensions/loom/session-index/parse.ts
@@ -19,6 +19,7 @@ export interface EntryRow {
 
 export interface ToolCallRow {
   entry_id: string;
+  tool_use_id: string;
   tool_name: string;
   arguments_json: string;
   result_text: string | null;
@@ -126,19 +127,14 @@ export function parseSessionFile(
     }
   }
 
-  // Join tool-call results (resolve by tool_use_id stashed on each call)
+  // Join tool-call results by tool_use_id (now a first-class field).
   const byUseId = new Map<string, ToolCallRow>();
   for (const tc of toolCalls) {
-    const useId = (tc as ToolCallRow & { __tool_use_id?: string }).__tool_use_id;
-    if (useId) byUseId.set(useId, tc);
+    byUseId.set(tc.tool_use_id, tc);
   }
   for (const [useId, text] of pendingResults) {
     const target = byUseId.get(useId);
     if (target) target.result_text = text;
-  }
-  // Clean internal marker before returning
-  for (const tc of toolCalls) {
-    delete (tc as ToolCallRow & { __tool_use_id?: string }).__tool_use_id;
   }
 
   if (!header && !opts.skipHeader) {
@@ -211,24 +207,27 @@ function flattenTextBlocks(content: unknown): string | null {
 
 function extractToolUses(
   obj: Record<string, unknown>,
-): Array<{ tool_name: string; arguments_json: string; result_text: null; __tool_use_id?: string }> {
+): Array<{ tool_use_id: string; tool_name: string; arguments_json: string; result_text: null }> {
   const content = (obj as { message?: { content?: unknown } }).message?.content;
   if (!Array.isArray(content)) return [];
   const out: Array<{
+    tool_use_id: string;
     tool_name: string;
     arguments_json: string;
     result_text: null;
-    __tool_use_id?: string;
   }> = [];
   for (const block of content) {
     if (!block || typeof block !== "object") continue;
     const b = block as { type?: string; name?: string; input?: unknown; id?: string };
     if (b.type !== "tool_use" || typeof b.name !== "string") continue;
+    const tool_use_id = typeof b.id === "string" && b.id.length > 0
+      ? b.id
+      : `synth-${b.name}-${out.length}`;
     out.push({
+      tool_use_id,
       tool_name: b.name,
       arguments_json: JSON.stringify(b.input ?? {}),
       result_text: null,
-      __tool_use_id: b.id,
     });
   }
   return out;

--- a/extensions/loom/session-index/parse.ts
+++ b/extensions/loom/session-index/parse.ts
@@ -32,7 +32,12 @@ export interface ParseResult {
   notebookPath: string | null;
   /** Latest customType=session_info name, if any. */
   sessionName: string | null;
-  /** Byte offset (exclusive) of the last parsed line in the file. */
+  /**
+   * Byte offset (exclusive) of the last newline-terminated line parsed.
+   * Trailing bytes after the last newline are not consumed -- the next
+   * scan will re-read them, so a torn read while Pi is actively writing
+   * doesn't silently drop the partial line.
+   */
   endOffset: number;
 }
 
@@ -67,10 +72,12 @@ export function parseSessionFile(
   let sessionName: string | null = null;
 
   let lineStart = 0;
-  for (let i = 0; i <= text.length; i++) {
-    if (i !== text.length && text.charCodeAt(i) !== 10 /* \n */) continue;
+  let lastCompleteLineEnd = 0;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) !== 10 /* \n */) continue;
     const raw = text.slice(lineStart, i);
     lineStart = i + 1;
+    lastCompleteLineEnd = i + 1;
     if (raw.length === 0) continue;
     let obj: Record<string, unknown>;
     try {
@@ -144,7 +151,7 @@ export function parseSessionFile(
     tool_calls: toolCalls,
     notebookPath,
     sessionName,
-    endOffset: startOffset + Buffer.byteLength(text, "utf8"),
+    endOffset: startOffset + Buffer.byteLength(text.slice(0, lastCompleteLineEnd), "utf8"),
   };
 }
 

--- a/extensions/loom/session-index/query.ts
+++ b/extensions/loom/session-index/query.ts
@@ -1,0 +1,201 @@
+import type { Database as Db } from "better-sqlite3";
+
+export interface SearchHit {
+  entry_id: string;
+  session_id: string;
+  session_name: string | null;
+  cwd: string;
+  notebook_path: string | null;
+  timestamp: string;
+  role: "user" | "assistant" | null;
+  snippet: string;
+}
+
+export interface ContextRow {
+  entry_id: string;
+  role: "user" | "assistant" | null;
+  entry_type: string;
+  timestamp: string;
+  text: string;
+}
+
+export interface ToolCallHit {
+  entry_id: string;
+  session_id: string;
+  cwd: string;
+  notebook_path: string | null;
+  timestamp: string;
+  arguments: unknown;
+  result_summary: string | null;
+}
+
+export interface SearchParams {
+  query: string;
+  scope?: "all" | "cwd";
+  cwd?: string;
+  limit?: number;
+}
+
+export interface ContextParams {
+  entry_id: string;
+  before?: number;
+  after?: number;
+}
+
+export interface ToolCallParams {
+  tool_name: string;
+  args_contains?: string;
+  scope?: "all" | "cwd";
+  cwd?: string;
+  limit?: number;
+}
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+function clampLimit(n?: number): number {
+  if (typeof n !== "number" || !Number.isFinite(n)) return DEFAULT_LIMIT;
+  return Math.max(1, Math.min(MAX_LIMIT, Math.floor(n)));
+}
+
+export function searchChat(db: Db, params: SearchParams): SearchHit[] {
+  const limit = clampLimit(params.limit);
+  const scopeCwd = params.scope === "cwd" && params.cwd;
+  const scopeClause = scopeCwd ? "AND s.cwd = @cwd" : "";
+
+  const rows = db
+    .prepare(
+      `
+      SELECT
+        e.entry_id,
+        e.session_id,
+        s.name          AS session_name,
+        s.cwd,
+        s.notebook_path,
+        e.timestamp,
+        e.role,
+        snippet(entries_fts, 0, '[', ']', '…', 20) AS snippet
+      FROM entries_fts
+      JOIN entries e ON e.rowid = entries_fts.rowid
+      JOIN sessions s ON s.session_id = e.session_id
+      WHERE entries_fts MATCH @query
+        ${scopeClause}
+      ORDER BY e.timestamp DESC
+      LIMIT @limit
+      `,
+    )
+    .all({ query: params.query, cwd: params.cwd ?? "", limit }) as SearchHit[];
+
+  return rows;
+}
+
+export function getSessionContext(db: Db, params: ContextParams): ContextRow[] {
+  const before = Math.max(0, params.before ?? 3);
+  const after = Math.max(0, params.after ?? 3);
+
+  const anchor = db
+    .prepare("SELECT session_id, timestamp FROM entries WHERE entry_id = ?")
+    .get(params.entry_id) as { session_id: string; timestamp: string } | undefined;
+  if (!anchor) return [];
+
+  const beforeRows = db
+    .prepare(
+      `
+      SELECT entry_id, role, entry_type, timestamp, COALESCE(text_content, '') AS text
+      FROM entries
+      WHERE session_id = @sid AND (timestamp, entry_id) < (@ts, @eid)
+      ORDER BY timestamp DESC, entry_id DESC
+      LIMIT @n
+      `,
+    )
+    .all({ sid: anchor.session_id, ts: anchor.timestamp, eid: params.entry_id, n: before }) as ContextRow[];
+
+  const anchorRow = db
+    .prepare(
+      `
+      SELECT entry_id, role, entry_type, timestamp, COALESCE(text_content, '') AS text
+      FROM entries WHERE entry_id = ?
+      `,
+    )
+    .get(params.entry_id) as ContextRow;
+
+  const afterRows = db
+    .prepare(
+      `
+      SELECT entry_id, role, entry_type, timestamp, COALESCE(text_content, '') AS text
+      FROM entries
+      WHERE session_id = @sid AND (timestamp, entry_id) > (@ts, @eid)
+      ORDER BY timestamp ASC, entry_id ASC
+      LIMIT @n
+      `,
+    )
+    .all({ sid: anchor.session_id, ts: anchor.timestamp, eid: params.entry_id, n: after }) as ContextRow[];
+
+  return [...beforeRows.reverse(), anchorRow, ...afterRows];
+}
+
+export function findToolCalls(db: Db, params: ToolCallParams): ToolCallHit[] {
+  const limit = clampLimit(params.limit);
+  const scopeCwd = params.scope === "cwd" && params.cwd;
+  const scopeClause = scopeCwd ? "AND s.cwd = @cwd" : "";
+  const argsClause = params.args_contains
+    ? "AND tc.arguments_json LIKE @args ESCAPE '\\'"
+    : "";
+
+  const bindParams: Record<string, unknown> = { tool: params.tool_name, limit };
+  if (params.args_contains) bindParams.args = `%${escapeLike(params.args_contains)}%`;
+  if (scopeCwd) bindParams.cwd = params.cwd;
+
+  const rows = db
+    .prepare(
+      `
+      SELECT
+        tc.entry_id,
+        tc.session_id,
+        s.cwd,
+        s.notebook_path,
+        e.timestamp,
+        tc.arguments_json,
+        tc.result_text
+      FROM tool_calls tc
+      JOIN entries  e ON e.entry_id  = tc.entry_id
+      JOIN sessions s ON s.session_id = tc.session_id
+      WHERE tc.tool_name = @tool
+        ${argsClause}
+        ${scopeClause}
+      ORDER BY e.timestamp DESC
+      LIMIT @limit
+      `,
+    )
+    .all(bindParams) as Array<{
+      entry_id: string;
+      session_id: string;
+      cwd: string;
+      notebook_path: string | null;
+      timestamp: string;
+      arguments_json: string;
+      result_text: string | null;
+    }>;
+
+  return rows.map(r => ({
+    entry_id: r.entry_id,
+    session_id: r.session_id,
+    cwd: r.cwd,
+    notebook_path: r.notebook_path,
+    timestamp: r.timestamp,
+    arguments: safeJson(r.arguments_json),
+    result_summary: r.result_text ? r.result_text.slice(0, 500) : null,
+  }));
+}
+
+function safeJson(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}
+
+function escapeLike(s: string): string {
+  return s.replace(/[\\%_]/g, "\\$&");
+}

--- a/extensions/loom/session-index/schema.ts
+++ b/extensions/loom/session-index/schema.ts
@@ -2,7 +2,7 @@
  * by dropping the existing DB and rebuilding from scratch -- the source of
  * truth is the Pi JSONLs, so this is cheap and safe.
  */
-export const SCHEMA_VERSION = 1;
+export const SCHEMA_VERSION = 2;
 
 export const SCHEMA_SQL = `
 CREATE TABLE sessions (
@@ -43,7 +43,6 @@ CREATE INDEX tool_calls_name ON tool_calls(tool_name);
 
 CREATE VIRTUAL TABLE entries_fts USING fts5(
   text_content,
-  tool_calls_text,
   content='entries',
   content_rowid='rowid',
   tokenize='porter unicode61'
@@ -51,18 +50,18 @@ CREATE VIRTUAL TABLE entries_fts USING fts5(
 
 -- Keep FTS in sync with entries
 CREATE TRIGGER entries_ai AFTER INSERT ON entries BEGIN
-  INSERT INTO entries_fts(rowid, text_content, tool_calls_text)
-  VALUES (new.rowid, coalesce(new.text_content, ''), '');
+  INSERT INTO entries_fts(rowid, text_content)
+  VALUES (new.rowid, coalesce(new.text_content, ''));
 END;
 CREATE TRIGGER entries_ad AFTER DELETE ON entries BEGIN
-  INSERT INTO entries_fts(entries_fts, rowid, text_content, tool_calls_text)
-  VALUES ('delete', old.rowid, coalesce(old.text_content, ''), '');
+  INSERT INTO entries_fts(entries_fts, rowid, text_content)
+  VALUES ('delete', old.rowid, coalesce(old.text_content, ''));
 END;
 CREATE TRIGGER entries_au AFTER UPDATE ON entries BEGIN
-  INSERT INTO entries_fts(entries_fts, rowid, text_content, tool_calls_text)
-  VALUES ('delete', old.rowid, coalesce(old.text_content, ''), '');
-  INSERT INTO entries_fts(rowid, text_content, tool_calls_text)
-  VALUES (new.rowid, coalesce(new.text_content, ''), '');
+  INSERT INTO entries_fts(entries_fts, rowid, text_content)
+  VALUES ('delete', old.rowid, coalesce(old.text_content, ''));
+  INSERT INTO entries_fts(rowid, text_content)
+  VALUES (new.rowid, coalesce(new.text_content, ''));
 END;
 
 CREATE TABLE meta (

--- a/extensions/loom/session-index/schema.ts
+++ b/extensions/loom/session-index/schema.ts
@@ -1,0 +1,72 @@
+/** Bump this whenever a migration would be needed. openIndexDb() responds
+ * by dropping the existing DB and rebuilding from scratch -- the source of
+ * truth is the Pi JSONLs, so this is cheap and safe.
+ */
+export const SCHEMA_VERSION = 1;
+
+export const SCHEMA_SQL = `
+CREATE TABLE sessions (
+  session_id          TEXT PRIMARY KEY,
+  file_path           TEXT NOT NULL UNIQUE,
+  cwd                 TEXT NOT NULL,
+  name                TEXT,
+  parent_session      TEXT,
+  notebook_path       TEXT,
+  created_at          TEXT NOT NULL,
+  last_indexed_at     TEXT NOT NULL,
+  last_indexed_offset INTEGER NOT NULL
+);
+CREATE INDEX sessions_cwd ON sessions(cwd);
+
+CREATE TABLE entries (
+  entry_id     TEXT PRIMARY KEY,
+  session_id   TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+  parent_id    TEXT,
+  entry_type   TEXT NOT NULL,
+  timestamp    TEXT NOT NULL,
+  role         TEXT,
+  text_content TEXT,
+  raw_json     TEXT NOT NULL
+);
+CREATE INDEX entries_session ON entries(session_id, timestamp);
+CREATE INDEX entries_type    ON entries(entry_type);
+
+CREATE TABLE tool_calls (
+  entry_id       TEXT NOT NULL REFERENCES entries(entry_id) ON DELETE CASCADE,
+  session_id     TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+  tool_name      TEXT NOT NULL,
+  arguments_json TEXT NOT NULL,
+  result_text    TEXT,
+  PRIMARY KEY (entry_id, tool_name)
+);
+CREATE INDEX tool_calls_name ON tool_calls(tool_name);
+
+CREATE VIRTUAL TABLE entries_fts USING fts5(
+  text_content,
+  tool_calls_text,
+  content='entries',
+  content_rowid='rowid',
+  tokenize='porter unicode61'
+);
+
+-- Keep FTS in sync with entries
+CREATE TRIGGER entries_ai AFTER INSERT ON entries BEGIN
+  INSERT INTO entries_fts(rowid, text_content, tool_calls_text)
+  VALUES (new.rowid, coalesce(new.text_content, ''), '');
+END;
+CREATE TRIGGER entries_ad AFTER DELETE ON entries BEGIN
+  INSERT INTO entries_fts(entries_fts, rowid, text_content, tool_calls_text)
+  VALUES ('delete', old.rowid, coalesce(old.text_content, ''), '');
+END;
+CREATE TRIGGER entries_au AFTER UPDATE ON entries BEGIN
+  INSERT INTO entries_fts(entries_fts, rowid, text_content, tool_calls_text)
+  VALUES ('delete', old.rowid, coalesce(old.text_content, ''), '');
+  INSERT INTO entries_fts(rowid, text_content, tool_calls_text)
+  VALUES (new.rowid, coalesce(new.text_content, ''), '');
+END;
+
+CREATE TABLE meta (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+`;

--- a/extensions/loom/session-index/schema.ts
+++ b/extensions/loom/session-index/schema.ts
@@ -2,7 +2,7 @@
  * by dropping the existing DB and rebuilding from scratch -- the source of
  * truth is the Pi JSONLs, so this is cheap and safe.
  */
-export const SCHEMA_VERSION = 2;
+export const SCHEMA_VERSION = 3;
 
 export const SCHEMA_SQL = `
 CREATE TABLE sessions (
@@ -34,10 +34,11 @@ CREATE INDEX entries_type    ON entries(entry_type);
 CREATE TABLE tool_calls (
   entry_id       TEXT NOT NULL REFERENCES entries(entry_id) ON DELETE CASCADE,
   session_id     TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+  tool_use_id    TEXT NOT NULL,
   tool_name      TEXT NOT NULL,
   arguments_json TEXT NOT NULL,
   result_text    TEXT,
-  PRIMARY KEY (entry_id, tool_name)
+  PRIMARY KEY (entry_id, tool_use_id)
 );
 CREATE INDEX tool_calls_name ON tool_calls(tool_name);
 

--- a/extensions/loom/session-index/tools.ts
+++ b/extensions/loom/session-index/tools.ts
@@ -36,6 +36,7 @@ export function registerSessionIndexTools(pi: ExtensionAPI): void {
     label: "Search prior sessions",
     description:
       "Full-text search across every Pi session you've had in this account. " +
+      "Searches message text only -- for tool-call arguments use chat_find_tool_calls. " +
       "Default scope is 'all' (every project). Use scope='cwd' to restrict to the " +
       "current analysis directory. Returns ranked hits with a snippet; follow up " +
       "with chat_session_context to read surrounding turns.",

--- a/extensions/loom/session-index/tools.ts
+++ b/extensions/loom/session-index/tools.ts
@@ -1,0 +1,149 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { Type } from "@sinclair/typebox";
+import { openIndexDb, defaultDbPath } from "./db";
+import { scanSessions } from "./indexer";
+import {
+  searchChat,
+  getSessionContext,
+  findToolCalls,
+} from "./query";
+
+export function registerSessionIndexTools(pi: ExtensionAPI): void {
+  // Long-lived DB handle for the lifetime of the extension. The session-index
+  // DB assumes a single writer per user (see db.ts) -- opening once here and
+  // keeping the WAL/shm files live for the process is the intended shape.
+  const db = openIndexDb(defaultDbPath());
+
+  // Dedup refreshes inside a burst of tool calls. Pi routes a model's tool
+  // round-trips through us in quick succession; re-scanning every time would
+  // triple-stat the corpus for no added freshness.
+  const REFRESH_WINDOW_MS = 2_000;
+  let lastScanAt = 0;
+  function refresh(): void {
+    const now = Date.now();
+    if (now - lastScanAt < REFRESH_WINDOW_MS) return;
+    lastScanAt = now;
+    try {
+      scanSessions(db);
+    } catch {
+      // Don't fail a tool call because of a broken scan; return whatever's indexed.
+    }
+  }
+
+  pi.registerTool({
+    name: "chat_search",
+    label: "Search prior sessions",
+    description:
+      "Full-text search across every Pi session you've had in this account. " +
+      "Default scope is 'all' (every project). Use scope='cwd' to restrict to the " +
+      "current analysis directory. Returns ranked hits with a snippet; follow up " +
+      "with chat_session_context to read surrounding turns.",
+    parameters: Type.Object({
+      query: Type.String({ minLength: 1, description: "FTS5 query (porter-stemmed tokens)." }),
+      scope: Type.Optional(
+        Type.Union([Type.Literal("all"), Type.Literal("cwd")], {
+          description: "Which sessions to search. Default: 'all'.",
+        }),
+      ),
+      limit: Type.Optional(
+        Type.Integer({ minimum: 1, maximum: 100, description: "Max hits. Default 20." }),
+      ),
+    }),
+    async execute(_id, params) {
+      refresh();
+      try {
+        const hits = searchChat(db, {
+          query: params.query,
+          scope: params.scope ?? "all",
+          cwd: process.cwd(),
+          limit: params.limit,
+        });
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify(hits, null, 2) }],
+          details: { count: hits.length, error: undefined as string | undefined },
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{
+            type: "text" as const,
+            text: JSON.stringify({ error: msg, hint: "Check FTS5 query syntax (e.g. quoting)." }, null, 2),
+          }],
+          details: { count: 0, error: msg as string | undefined },
+        };
+      }
+    },
+    renderResult: (result) => {
+      const d = result.details as { count?: number; error?: string } | undefined;
+      if (d?.error) return new Text(`⚠️  ${d.error}`);
+      return new Text(`🔎 ${d?.count ?? 0} hits`);
+    },
+  });
+
+  pi.registerTool({
+    name: "chat_session_context",
+    label: "Read surrounding turns",
+    description:
+      "Given an entry_id (from chat_search or chat_find_tool_calls), return a " +
+      "window of N entries before and after it from the same session. Default " +
+      "window is 3 before + 3 after. Entries above a compaction point are " +
+      "still retrievable (the index keeps everything the JSONL keeps).",
+    parameters: Type.Object({
+      entry_id: Type.String({ minLength: 1 }),
+      before: Type.Optional(Type.Integer({ minimum: 0, maximum: 50, default: 3 })),
+      after: Type.Optional(Type.Integer({ minimum: 0, maximum: 50, default: 3 })),
+    }),
+    async execute(_id, params) {
+      refresh();
+      const rows = getSessionContext(db, {
+        entry_id: params.entry_id,
+        before: params.before,
+        after: params.after,
+      });
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(rows, null, 2) }],
+        details: { count: rows.length },
+      };
+    },
+    renderResult: (result) => {
+      const d = result.details as { count?: number } | undefined;
+      return new Text(`📜 ${d?.count ?? 0} entries`);
+    },
+  });
+
+  pi.registerTool({
+    name: "chat_find_tool_calls",
+    label: "Find prior tool calls",
+    description:
+      "Structured search over prior tool invocations. Pass tool_name to filter " +
+      "(e.g. 'workflow_set_overrides'); optional args_contains does a substring " +
+      "match on the arguments JSON (underscore and percent are escaped to avoid " +
+      "LIKE wildcard surprises). Returns parsed arguments and a truncated " +
+      "result summary per hit.",
+    parameters: Type.Object({
+      tool_name: Type.String({ minLength: 1 }),
+      args_contains: Type.Optional(Type.String({ minLength: 1 })),
+      scope: Type.Optional(Type.Union([Type.Literal("all"), Type.Literal("cwd")])),
+      limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
+    }),
+    async execute(_id, params) {
+      refresh();
+      const calls = findToolCalls(db, {
+        tool_name: params.tool_name,
+        args_contains: params.args_contains,
+        scope: params.scope ?? "all",
+        cwd: process.cwd(),
+        limit: params.limit,
+      });
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(calls, null, 2) }],
+        details: { count: calls.length, tool: params.tool_name },
+      };
+    },
+    renderResult: (result) => {
+      const d = result.details as { count?: number; tool?: string } | undefined;
+      return new Text(`🛠 ${d?.count ?? 0} ${d?.tool ?? ""} calls`);
+    },
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,15 +11,18 @@
       "dependencies": {
         "@mariozechner/pi-coding-agent": "^0.67.3",
         "@sinclair/typebox": "^0.34.49",
+        "better-sqlite3": "^12.9.0",
         "pi-mcp-adapter": "^2.4.0",
         "pi-web-access": "^0.10.6",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.2"
       },
       "bin": {
         "loom": "bin/loom.js"
       },
       "devDependencies": {
         "@mariozechner/pi-ai": "^0.67.3",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/uuid": "^11.0.0",
         "typescript": "^6.0.2",
         "vitest": "^4.1.4"
@@ -2472,6 +2475,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2788,6 +2801,20 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -2795,6 +2822,26 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -2840,6 +2887,30 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-crc32": {
@@ -2931,6 +3002,12 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/cli-highlight": {
       "version": "2.1.11",
@@ -3136,6 +3213,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/default-browser": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
@@ -3203,7 +3304,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3488,6 +3588,15 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -3702,6 +3811,12 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -3780,6 +3895,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3929,6 +4050,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "13.0.1",
@@ -4188,6 +4315,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ip-address": {
@@ -4733,6 +4866,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -4769,6 +4914,15 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -4777,6 +4931,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4814,6 +4974,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -4830,6 +4996,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -5207,6 +5385,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -5336,6 +5541,35 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/require-directory": {
@@ -5526,6 +5760,18 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -5683,6 +5929,51 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -5763,6 +6054,15 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -5817,6 +6117,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strnum": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
@@ -5855,6 +6164,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/thenify": {
@@ -5961,6 +6298,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/turndown": {
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
@@ -6057,6 +6406,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "13.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@mariozechner/pi-coding-agent": "^0.67.3",
     "@sinclair/typebox": "^0.34.49",
+    "better-sqlite3": "^12.9.0",
     "pi-mcp-adapter": "^2.4.0",
     "pi-web-access": "^0.10.6",
     "uuid": "^13.0.0",
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@mariozechner/pi-ai": "^0.67.3",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/uuid": "^11.0.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.4"

--- a/shared/loom-config.d.ts
+++ b/shared/loom-config.d.ts
@@ -23,6 +23,12 @@ export interface LoomConfig {
   experiments?: {
     /** Register the experimental team_dispatch tool and its prompt guidance. */
     teamDispatch?: boolean;
+    /**
+     * Register the experimental session-index tools (chat_search,
+     * chat_session_context, chat_find_tool_calls) that query Pi's JSONL
+     * session corpus via a SQLite+FTS5 mirror at ~/.loom/sessions-index.db.
+     */
+    sessionIndex?: boolean;
   };
 }
 

--- a/tests/session-index/cwd.test.ts
+++ b/tests/session-index/cwd.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { encodeCwd, decodeCwd } from "../../extensions/loom/session-index/cwd";
+
+describe("cwd codec", () => {
+  it("encodes absolute paths Pi-style", () => {
+    expect(encodeCwd("/Users/dannon/work/loom")).toBe("--Users-dannon-work-loom--");
+    expect(encodeCwd("/tmp")).toBe("--tmp--");
+    expect(encodeCwd("/")).toBe("----");
+  });
+
+  it("decodes Pi-style back to absolute", () => {
+    expect(decodeCwd("--Users-dannon-work-loom--")).toBe("/Users/dannon/work/loom");
+    expect(decodeCwd("--tmp--")).toBe("/tmp");
+  });
+
+  it("round-trips", () => {
+    const paths = ["/a", "/a/b", "/Users/x/y", "/var/folders/cp/loomtest"];
+    for (const p of paths) {
+      expect(decodeCwd(encodeCwd(p))).toBe(p);
+    }
+  });
+
+  it("round-trips the root path", () => {
+    expect(encodeCwd("/")).toBe("----");
+    expect(decodeCwd("----")).toBe("/");
+  });
+
+  it("returns null for non-encoded strings", () => {
+    expect(decodeCwd("not-an-encoded-cwd")).toBeNull();
+    expect(decodeCwd("")).toBeNull();
+  });
+});

--- a/tests/session-index/db.test.ts
+++ b/tests/session-index/db.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openIndexDb, SCHEMA_VERSION } from "../../extensions/loom/session-index/db";
+
+describe("session-index db", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-index-db-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("creates the schema on first open", () => {
+    const db = openIndexDb(path.join(dir, "idx.db"));
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+      .all()
+      .map((r: { name: string }) => r.name);
+    expect(tables).toEqual(
+      expect.arrayContaining(["sessions", "entries", "tool_calls", "meta"]),
+    );
+    // FTS5 virtual table's shadow tables exist too
+    expect(tables).toEqual(expect.arrayContaining(["entries_fts"]));
+    db.close();
+  });
+
+  it("records and reads the schema version", () => {
+    const db = openIndexDb(path.join(dir, "idx.db"));
+    const row = db.prepare("SELECT value FROM meta WHERE key='schema_version'").get() as
+      | { value: string }
+      | undefined;
+    expect(row?.value).toBe(String(SCHEMA_VERSION));
+    db.close();
+  });
+
+  it("rebuilds cleanly if schema_version mismatches", () => {
+    const p = path.join(dir, "idx.db");
+    const db1 = openIndexDb(p);
+    db1.prepare("INSERT INTO sessions(session_id, file_path, cwd, created_at, last_indexed_at, last_indexed_offset) VALUES (?, ?, ?, ?, ?, ?)")
+      .run("s1", "/tmp/f.jsonl", "/tmp", "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0);
+    db1.prepare("UPDATE meta SET value='0' WHERE key='schema_version'").run();
+    db1.close();
+
+    const db2 = openIndexDb(p);
+    // Rebuild: prior row is gone
+    const count = (db2.prepare("SELECT COUNT(*) as n FROM sessions").get() as { n: number }).n;
+    expect(count).toBe(0);
+    db2.close();
+  });
+});

--- a/tests/session-index/fixtures/basic-session.jsonl
+++ b/tests/session-index/fixtures/basic-session.jsonl
@@ -1,0 +1,4 @@
+{"type":"session","version":3,"id":"sess-basic","timestamp":"2026-04-01T10:00:00Z","cwd":"/tmp/proj"}
+{"type":"message","id":"e1","parentId":null,"timestamp":"2026-04-01T10:00:05Z","message":{"role":"user","content":[{"type":"text","text":"hello from fixture"}]}}
+{"type":"message","id":"e2","parentId":"e1","timestamp":"2026-04-01T10:00:10Z","message":{"role":"assistant","content":[{"type":"text","text":"hi! this is the assistant reply"}]}}
+{"type":"custom","id":"e3","parentId":"e2","timestamp":"2026-04-01T10:00:20Z","customType":"galaxy_analyst_plan","data":{"id":"plan-1","title":"Fixture Plan","notebookPath":"/tmp/proj/notebook.md"}}

--- a/tests/session-index/fixtures/tool-call-session.jsonl
+++ b/tests/session-index/fixtures/tool-call-session.jsonl
@@ -1,0 +1,4 @@
+{"type":"session","version":3,"id":"sess-tools","timestamp":"2026-04-02T09:00:00Z","cwd":"/tmp/proj"}
+{"type":"message","id":"t1","parentId":null,"timestamp":"2026-04-02T09:00:05Z","message":{"role":"user","content":[{"type":"text","text":"run the workflow with variant_ism_width=600"}]}}
+{"type":"message","id":"t2","parentId":"t1","timestamp":"2026-04-02T09:00:10Z","message":{"role":"assistant","content":[{"type":"text","text":"ok"},{"type":"tool_use","id":"tu1","name":"workflow_set_overrides","input":{"stepId":"ism","overrides":{"variant_ism_width":600}}}]}}
+{"type":"message","id":"t3","parentId":"t2","timestamp":"2026-04-02T09:00:12Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu1","content":[{"type":"text","text":"overrides recorded"}]}]}}

--- a/tests/session-index/indexer.test.ts
+++ b/tests/session-index/indexer.test.ts
@@ -92,6 +92,21 @@ describe("scanSessions", () => {
     db.close();
   });
 
+  it("indexes parallel tool_use calls to the same tool without collapsing", () => {
+    const fp = path.join(sessionsDir, encodeCwd("/tmp/proj"), "sess-basic.jsonl");
+    // Append an assistant message with TWO tool_use blocks for the same tool name.
+    fs.appendFileSync(fp,
+      `{"type":"message","id":"par","parentId":"e2","timestamp":"2026-04-01T10:00:30Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tuA","name":"workflow_set_overrides","input":{"stepId":"ism","overrides":{"variant_ism_width":600}}},{"type":"tool_use","id":"tuB","name":"workflow_set_overrides","input":{"stepId":"ism","overrides":{"ism_scanner":{"max_region_width":600}}}}]}}\n`,
+    );
+    const db = openIndexDb(dbPath);
+    scanSessions(db, sessionsDir);
+    const rows = db.prepare("SELECT tool_use_id, arguments_json FROM tool_calls WHERE entry_id = 'par'").all() as Array<{ tool_use_id: string; arguments_json: string }>;
+    expect(rows).toHaveLength(2);
+    const useIds = rows.map(r => r.tool_use_id).sort();
+    expect(useIds).toEqual(["tuA", "tuB"]);
+    db.close();
+  });
+
   it("does not index a partial line written without a trailing newline", () => {
     const fp = path.join(sessionsDir, encodeCwd("/tmp/proj"), "sess-basic.jsonl");
     // Simulate Pi mid-write: append a partial message line with NO trailing newline

--- a/tests/session-index/indexer.test.ts
+++ b/tests/session-index/indexer.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openIndexDb } from "../../extensions/loom/session-index/db";
+import { scanSessions } from "../../extensions/loom/session-index/indexer";
+import { encodeCwd } from "../../extensions/loom/session-index/cwd";
+
+const BASIC = `\
+{"type":"session","version":3,"id":"sess-basic","timestamp":"2026-04-01T10:00:00Z","cwd":"/tmp/proj"}
+{"type":"message","id":"e1","parentId":null,"timestamp":"2026-04-01T10:00:05Z","message":{"role":"user","content":[{"type":"text","text":"hello fixture"}]}}
+{"type":"message","id":"e2","parentId":"e1","timestamp":"2026-04-01T10:00:10Z","message":{"role":"assistant","content":[{"type":"text","text":"hi! this is the assistant reply"}]}}
+`;
+
+const APPENDED = `\
+{"type":"message","id":"e3","parentId":"e2","timestamp":"2026-04-01T10:00:15Z","message":{"role":"user","content":[{"type":"text","text":"follow up please"}]}}
+`;
+
+function makeSessionsDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-index-scan-"));
+  const cwdDir = path.join(dir, encodeCwd("/tmp/proj"));
+  fs.mkdirSync(cwdDir, { recursive: true });
+  fs.writeFileSync(path.join(cwdDir, "sess-basic.jsonl"), BASIC);
+  return dir;
+}
+
+describe("scanSessions", () => {
+  let sessionsDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    sessionsDir = makeSessionsDir();
+    dbPath = path.join(sessionsDir, "idx.db");
+  });
+
+  afterEach(() => {
+    fs.rmSync(sessionsDir, { recursive: true, force: true });
+  });
+
+  it("bulk indexes an untouched corpus", () => {
+    const db = openIndexDb(dbPath);
+    const report = scanSessions(db, sessionsDir);
+    expect(report.sessionsSeen).toBe(1);
+    expect(report.entriesInserted).toBe(2);
+
+    const entries = db.prepare("SELECT entry_id, role, text_content FROM entries ORDER BY timestamp").all() as Array<{
+      entry_id: string;
+      role: string | null;
+      text_content: string | null;
+    }>;
+    expect(entries.map(e => e.entry_id)).toEqual(["e1", "e2"]);
+    db.close();
+  });
+
+  it("incrementally appends new entries without re-inserting", () => {
+    const db = openIndexDb(dbPath);
+    scanSessions(db, sessionsDir);
+
+    const fp = path.join(sessionsDir, encodeCwd("/tmp/proj"), "sess-basic.jsonl");
+    fs.appendFileSync(fp, APPENDED);
+
+    const report2 = scanSessions(db, sessionsDir);
+    expect(report2.entriesInserted).toBe(1);
+
+    const count = (db.prepare("SELECT COUNT(*) as n FROM entries").get() as { n: number }).n;
+    expect(count).toBe(3);
+    db.close();
+  });
+
+  it("drops rows for sessions whose file has been deleted", () => {
+    const db = openIndexDb(dbPath);
+    scanSessions(db, sessionsDir);
+    const fp = path.join(sessionsDir, encodeCwd("/tmp/proj"), "sess-basic.jsonl");
+    fs.rmSync(fp);
+
+    const report = scanSessions(db, sessionsDir);
+    expect(report.sessionsRemoved).toBe(1);
+    const count = (db.prepare("SELECT COUNT(*) as n FROM sessions").get() as { n: number }).n;
+    expect(count).toBe(0);
+    db.close();
+  });
+
+  it("populates notebook_path from galaxy_analyst_plan custom entries", () => {
+    const fp = path.join(sessionsDir, encodeCwd("/tmp/proj"), "sess-basic.jsonl");
+    fs.appendFileSync(fp,
+      `{"type":"custom","id":"ec","parentId":"e2","timestamp":"2026-04-01T10:00:20Z","customType":"galaxy_analyst_plan","data":{"notebookPath":"/tmp/proj/notebook.md"}}\n`,
+    );
+    const db = openIndexDb(dbPath);
+    scanSessions(db, sessionsDir);
+    const row = db.prepare("SELECT notebook_path FROM sessions WHERE session_id='sess-basic'").get() as { notebook_path: string | null };
+    expect(row.notebook_path).toBe("/tmp/proj/notebook.md");
+    db.close();
+  });
+
+  it("does not index a partial line written without a trailing newline", () => {
+    const fp = path.join(sessionsDir, encodeCwd("/tmp/proj"), "sess-basic.jsonl");
+    // Simulate Pi mid-write: append a partial message line with NO trailing newline
+    fs.appendFileSync(fp, '{"type":"message","id":"partial","parentId":"e2","timestamp":"2026-04-01T10:00:12Z","message":{"role":"assistant","content":[{"type":"text","text":"half-writ');
+
+    const db = openIndexDb(dbPath);
+    const r1 = scanSessions(db, sessionsDir);
+    // Only the 2 complete lines from the original BASIC fixture get indexed
+    expect(r1.entriesInserted).toBe(2);
+    const mid = db.prepare("SELECT entry_id FROM entries WHERE entry_id = 'partial'").get();
+    expect(mid).toBeUndefined();
+
+    // Pi finishes the line (completes the JSON object and adds the newline)
+    fs.appendFileSync(fp, 'ten"}]}}\n');
+
+    const r2 = scanSessions(db, sessionsDir);
+    expect(r2.entriesInserted).toBe(1);
+    const row = db.prepare("SELECT entry_id FROM entries WHERE entry_id = 'partial'").get() as { entry_id?: string } | undefined;
+    expect(row?.entry_id).toBe("partial");
+    db.close();
+  });
+});

--- a/tests/session-index/integration.test.ts
+++ b/tests/session-index/integration.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openIndexDb } from "../../extensions/loom/session-index/db";
+import { scanSessions } from "../../extensions/loom/session-index/indexer";
+import { encodeCwd } from "../../extensions/loom/session-index/cwd";
+import {
+  searchChat,
+  findToolCalls,
+  getSessionContext,
+} from "../../extensions/loom/session-index/query";
+
+const MALARIA = `\
+{"type":"session","version":3,"id":"sess-mal","timestamp":"2026-04-01T10:00:00Z","cwd":"/tmp/malaria-chr6"}
+{"type":"message","id":"m1","parentId":null,"timestamp":"2026-04-01T10:00:05Z","message":{"role":"user","content":[{"type":"text","text":"Widen the ISM scan — too many secondary peaks"}]}}
+{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-04-01T10:00:10Z","message":{"role":"assistant","content":[{"type":"text","text":"Setting variant_ism_width=600 closes the secondary-cluster gap at chr6:92618200."},{"type":"tool_use","id":"tu1","name":"workflow_set_overrides","input":{"stepId":"ism","overrides":{"variant_ism_width":600}}}]}}
+{"type":"message","id":"m3","parentId":"m2","timestamp":"2026-04-01T10:00:15Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu1","content":[{"type":"text","text":"overrides recorded"}]}]}}
+{"type":"custom","id":"mc","parentId":"m3","timestamp":"2026-04-01T10:00:20Z","customType":"galaxy_analyst_plan","data":{"notebookPath":"/tmp/malaria-chr6/notebook.md"}}
+`;
+
+describe("session-index end-to-end", () => {
+  let root: string;
+  let db: ReturnType<typeof openIndexDb>;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "si-e2e-"));
+    const cwdDir = path.join(root, encodeCwd("/tmp/malaria-chr6"));
+    fs.mkdirSync(cwdDir, { recursive: true });
+    fs.writeFileSync(path.join(cwdDir, "sess-mal.jsonl"), MALARIA);
+    db = openIndexDb(path.join(root, "idx.db"));
+    scanSessions(db, root);
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('answers "why did we set variant_ism_width?"', () => {
+    // 1. Agent asks via chat_search
+    const hits = searchChat(db, { query: "variant_ism_width" });
+    expect(hits.length).toBeGreaterThan(0);
+    const best = hits[0];
+
+    // 2. Agent pulls context around the top hit
+    const ctx = getSessionContext(db, { entry_id: best.entry_id, before: 1, after: 1 });
+    const rationale = ctx.find(r => r.text.includes("secondary-cluster gap"));
+    expect(rationale).toBeDefined();
+
+    // 3. Agent also finds the structured tool call
+    const calls = findToolCalls(db, { tool_name: "workflow_set_overrides" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].arguments).toEqual({ stepId: "ism", overrides: { variant_ism_width: 600 } });
+    expect(calls[0].notebook_path).toBe("/tmp/malaria-chr6/notebook.md");
+  });
+});

--- a/tests/session-index/is-enabled.test.ts
+++ b/tests/session-index/is-enabled.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const loadConfigMock = vi.fn();
+
+vi.mock("../../extensions/loom/config", () => ({
+  loadConfig: () => loadConfigMock(),
+}));
+
+import { isSessionIndexEnabled } from "../../extensions/loom/session-index/is-enabled";
+
+describe("isSessionIndexEnabled", () => {
+  const originalEnv = process.env.LOOM_SESSION_INDEX;
+
+  beforeEach(() => {
+    delete process.env.LOOM_SESSION_INDEX;
+    loadConfigMock.mockReset();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.LOOM_SESSION_INDEX;
+    else process.env.LOOM_SESSION_INDEX = originalEnv;
+  });
+
+  it("defaults off when env is unset and config has no experiments block", () => {
+    loadConfigMock.mockReturnValue({});
+    expect(isSessionIndexEnabled()).toBe(false);
+  });
+
+  it("is on when config opts in and env is unset", () => {
+    loadConfigMock.mockReturnValue({ experiments: { sessionIndex: true } });
+    expect(isSessionIndexEnabled()).toBe(true);
+  });
+
+  it("env=1 forces on even when config is off", () => {
+    process.env.LOOM_SESSION_INDEX = "1";
+    loadConfigMock.mockReturnValue({ experiments: { sessionIndex: false } });
+    expect(isSessionIndexEnabled()).toBe(true);
+  });
+
+  it("env=0 forces off even when config is on", () => {
+    process.env.LOOM_SESSION_INDEX = "0";
+    loadConfigMock.mockReturnValue({ experiments: { sessionIndex: true } });
+    expect(isSessionIndexEnabled()).toBe(false);
+  });
+
+  it("ignores garbage env values and falls through to config", () => {
+    process.env.LOOM_SESSION_INDEX = "yes";
+    loadConfigMock.mockReturnValue({ experiments: { sessionIndex: true } });
+    expect(isSessionIndexEnabled()).toBe(true);
+  });
+
+  it("treats experiments.sessionIndex=undefined as off", () => {
+    loadConfigMock.mockReturnValue({ experiments: {} });
+    expect(isSessionIndexEnabled()).toBe(false);
+  });
+});

--- a/tests/session-index/parse.test.ts
+++ b/tests/session-index/parse.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import { parseSessionFile } from "../../extensions/loom/session-index/parse";
+
+const FIXTURE_DIR = path.resolve(__dirname, "fixtures");
+
+describe("parseSessionFile", () => {
+  it("extracts header, entries, and role/text from a basic session", () => {
+    const r = parseSessionFile(path.join(FIXTURE_DIR, "basic-session.jsonl"));
+    expect(r.header.id).toBe("sess-basic");
+    expect(r.header.cwd).toBe("/tmp/proj");
+    expect(r.entries).toHaveLength(3);
+
+    const [e1, e2, e3] = r.entries;
+    expect(e1.entry_id).toBe("e1");
+    expect(e1.role).toBe("user");
+    expect(e1.text_content).toBe("hello from fixture");
+
+    expect(e2.role).toBe("assistant");
+    expect(e2.text_content).toBe("hi! this is the assistant reply");
+
+    expect(e3.entry_type).toBe("custom");
+    expect(e3.role).toBeNull();
+    // galaxy_analyst_plan notebookPath is surfaced so the indexer can set it on sessions
+    expect(r.notebookPath).toBe("/tmp/proj/notebook.md");
+    expect(r.tool_calls).toHaveLength(0);
+  });
+
+  it("extracts tool calls and joins results by tool_use_id", () => {
+    const r = parseSessionFile(path.join(FIXTURE_DIR, "tool-call-session.jsonl"));
+    expect(r.tool_calls).toHaveLength(1);
+    const tc = r.tool_calls[0];
+    expect(tc.entry_id).toBe("t2");
+    expect(tc.tool_name).toBe("workflow_set_overrides");
+    expect(JSON.parse(tc.arguments_json)).toEqual({
+      stepId: "ism",
+      overrides: { variant_ism_width: 600 },
+    });
+    expect(tc.result_text).toBe("overrides recorded");
+  });
+
+  it("is byte-offset aware for incremental parsing", () => {
+    const r = parseSessionFile(path.join(FIXTURE_DIR, "basic-session.jsonl"));
+    expect(r.endOffset).toBeGreaterThan(0);
+    // Starting from the final offset yields zero new entries
+    const r2 = parseSessionFile(path.join(FIXTURE_DIR, "basic-session.jsonl"), {
+      startOffset: r.endOffset,
+      skipHeader: true,
+    });
+    expect(r2.entries).toHaveLength(0);
+    expect(r2.endOffset).toBe(r.endOffset);
+  });
+});

--- a/tests/session-index/query.test.ts
+++ b/tests/session-index/query.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { openIndexDb } from "../../extensions/loom/session-index/db";
+import { scanSessions } from "../../extensions/loom/session-index/indexer";
+import { encodeCwd } from "../../extensions/loom/session-index/cwd";
+import {
+  searchChat,
+  getSessionContext,
+  findToolCalls,
+} from "../../extensions/loom/session-index/query";
+
+function seed(sessionsDir: string, cwd: string, fileName: string, body: string) {
+  const d = path.join(sessionsDir, encodeCwd(cwd));
+  fs.mkdirSync(d, { recursive: true });
+  fs.writeFileSync(path.join(d, fileName), body);
+}
+
+describe("session-index query API", () => {
+  let dir: string;
+  let db: ReturnType<typeof openIndexDb>;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-index-query-"));
+    seed(dir, "/tmp/malaria", "sess-1.jsonl", `\
+{"type":"session","version":3,"id":"sess-1","timestamp":"2026-04-01T10:00:00Z","cwd":"/tmp/malaria"}
+{"type":"message","id":"m1","parentId":null,"timestamp":"2026-04-01T10:00:05Z","message":{"role":"user","content":[{"type":"text","text":"Tune variant_ism_width for malaria chr6"}]}}
+{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-04-01T10:00:10Z","message":{"role":"assistant","content":[{"type":"text","text":"Set variant_ism_width=600 to widen the scan."},{"type":"tool_use","id":"tu1","name":"workflow_set_overrides","input":{"stepId":"ism","overrides":{"variant_ism_width":600}}}]}}
+{"type":"message","id":"m3","parentId":"m2","timestamp":"2026-04-01T10:00:15Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu1","content":[{"type":"text","text":"overrides recorded"}]}]}}
+`);
+    seed(dir, "/tmp/hiv", "sess-2.jsonl", `\
+{"type":"session","version":3,"id":"sess-2","timestamp":"2026-04-02T09:00:00Z","cwd":"/tmp/hiv"}
+{"type":"message","id":"h1","parentId":null,"timestamp":"2026-04-02T09:00:05Z","message":{"role":"user","content":[{"type":"text","text":"Run HIV locus analysis"}]}}
+`);
+    db = openIndexDb(path.join(dir, "idx.db"));
+    scanSessions(db, dir);
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("searches across all sessions by default", () => {
+    const hits = searchChat(db, { query: "variant_ism_width" });
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0].cwd).toBe("/tmp/malaria");
+    expect(hits[0].snippet.toLowerCase()).toContain("variant_ism_width");
+  });
+
+  it("scope='cwd' filters to the given directory", () => {
+    const hits = searchChat(db, { query: "analysis", scope: "cwd", cwd: "/tmp/hiv" });
+    expect(hits.every(h => h.cwd === "/tmp/hiv")).toBe(true);
+    expect(hits.some(h => h.cwd === "/tmp/malaria")).toBe(false);
+  });
+
+  it("returns a window of entries around an anchor", () => {
+    const ctx = getSessionContext(db, { entry_id: "m2", before: 1, after: 1 });
+    expect(ctx.map(e => e.entry_id)).toEqual(["m1", "m2", "m3"]);
+  });
+
+  it("finds tool calls by name with args_contains filter", () => {
+    const calls = findToolCalls(db, { tool_name: "workflow_set_overrides" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].arguments).toEqual({ stepId: "ism", overrides: { variant_ism_width: 600 } });
+
+    const empty = findToolCalls(db, { tool_name: "workflow_set_overrides", args_contains: "neuroblastoma" });
+    expect(empty).toHaveLength(0);
+
+    const match = findToolCalls(db, { tool_name: "workflow_set_overrides", args_contains: "variant_ism_width" });
+    expect(match).toHaveLength(1);
+  });
+
+  it("respects the limit parameter", () => {
+    const hits = searchChat(db, { query: "malaria OR HIV OR analysis OR variant", limit: 1 });
+    expect(hits).toHaveLength(1);
+  });
+
+  it("includes timestamp-tied entries in the context window", () => {
+    // Create a fresh scenario with three entries sharing a timestamp.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "session-index-tie-"));
+    seed(tmp, "/tmp/tie", "sess-tie.jsonl", `\
+{"type":"session","version":3,"id":"sess-tie","timestamp":"2026-04-05T10:00:00Z","cwd":"/tmp/tie"}
+{"type":"message","id":"a","parentId":null,"timestamp":"2026-04-05T10:00:05Z","message":{"role":"user","content":[{"type":"text","text":"a"}]}}
+{"type":"message","id":"b","parentId":"a","timestamp":"2026-04-05T10:00:10Z","message":{"role":"assistant","content":[{"type":"text","text":"b"}]}}
+{"type":"message","id":"c","parentId":"b","timestamp":"2026-04-05T10:00:10Z","message":{"role":"user","content":[{"type":"text","text":"c"}]}}
+{"type":"message","id":"d","parentId":"c","timestamp":"2026-04-05T10:00:10Z","message":{"role":"assistant","content":[{"type":"text","text":"d"}]}}
+{"type":"message","id":"e","parentId":"d","timestamp":"2026-04-05T10:00:15Z","message":{"role":"user","content":[{"type":"text","text":"e"}]}}
+`);
+    const db2 = openIndexDb(path.join(tmp, "idx.db"));
+    scanSessions(db2, tmp);
+    const ctx = getSessionContext(db2, { entry_id: "c", before: 5, after: 5 });
+    expect(ctx.map(e => e.entry_id)).toEqual(["a", "b", "c", "d", "e"]);
+    db2.close();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("treats LIKE wildcards in args_contains as literals", () => {
+    // variant_ism_width should match literally -- NOT match variantxismxwidth.
+    // Seed a second tool call whose args contain 'variantxismxwidth' (underscores replaced).
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "session-index-like-"));
+    seed(tmp, "/tmp/like", "sess-like.jsonl", `\
+{"type":"session","version":3,"id":"sess-like","timestamp":"2026-04-05T10:00:00Z","cwd":"/tmp/like"}
+{"type":"message","id":"x1","parentId":null,"timestamp":"2026-04-05T10:00:05Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tux","name":"workflow_set_overrides","input":{"key":"variantxismxwidth","value":600}}]}}
+`);
+    const db2 = openIndexDb(path.join(tmp, "idx.db"));
+    scanSessions(db2, tmp);
+    const match = findToolCalls(db2, {
+      tool_name: "workflow_set_overrides",
+      args_contains: "variant_ism_width",
+    });
+    expect(match).toHaveLength(0); // underscore is literal, not a wildcard
+    const literalMatch = findToolCalls(db2, {
+      tool_name: "workflow_set_overrides",
+      args_contains: "variantxismxwidth",
+    });
+    expect(literalMatch).toHaveLength(1);
+    db2.close();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});

--- a/tests/session-index/tools.test.ts
+++ b/tests/session-index/tools.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { buildSessionIndexContext } from "../../extensions/loom/context";
+
+describe("buildSessionIndexContext", () => {
+  const original = process.env.LOOM_SESSION_INDEX;
+  afterEach(() => {
+    if (original === undefined) delete process.env.LOOM_SESSION_INDEX;
+    else process.env.LOOM_SESSION_INDEX = original;
+  });
+
+  it("returns empty string when flag is off", () => {
+    delete process.env.LOOM_SESSION_INDEX;
+    expect(buildSessionIndexContext()).toBe("");
+  });
+
+  it("returns a prompt block with the three tool names when flag is on", () => {
+    process.env.LOOM_SESSION_INDEX = "1";
+    const ctx = buildSessionIndexContext();
+    expect(ctx).toContain("chat_search");
+    expect(ctx).toContain("chat_session_context");
+    expect(ctx).toContain("chat_find_tool_calls");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a SQLite+FTS5 index over Pi.dev's session JSONLs so the agent can answer questions like *"when we worked on malaria chr6, what was the reason behind the variant_ism_width override?"* or *"use similar parameters to where we worked on Y"* from inside any Loom session.

- Central DB at `~/.loom/sessions-index.db`, incremental on-demand scan of `~/.pi/agent/sessions/`. Read-only mirror -- Pi's files stay the source of truth.
- Three new tools: `chat_search` (FTS5 over message text), `chat_session_context` (windowed context retrieval), `chat_find_tool_calls` (structured lookup with args_contains substring filter).
- Gated behind `experiments.sessionIndex` flag (default off). Set it to `true` in `~/.loom/config.json`, or export `LOOM_SESSION_INDEX=1` for a single session.

The motivation: Pi already durably stores every session as JSONL, but cross-session search requires loading every file into memory. FTS5 gives us fast keyword search, a `tool_calls` table gives us structured "every time I called X" queries, and the whole thing survives Pi's in-band compaction. Spec and plan live in `~/work/brain/plans/loom-session-index/`.

Scope intentionally small:
- No embedding/semantic search (mem0 territory, deferred).
- No UI surface -- agent-only for now.
- No write-side coupling to the notebook -- a future extension could index specific notebook steps back to their originating chat turn.

## Test plan

- [ ] `npm test` passes (275 tests, 27 files)
- [ ] `npm run typecheck` clean
- [ ] Default behavior unchanged: with the flag off, no DB created, no tools registered, no prompt injection
- [ ] Flip flag on locally (`LOOM_SESSION_INDEX=1`), start a session, ask the agent to search prior sessions for a known topic -- verify hits surface with useful snippets
- [ ] Try a malformed FTS query (`foo OR`) and confirm the tool returns a JSON error payload rather than crashing
- [ ] Run against a large real corpus and note first-scan wall time

## Commit series

9 atomic commits, one per task + one final-review fix:
1. `experiments.sessionIndex` flag + `better-sqlite3` dep
2. Schema + DB open/rebuild helper
3. Shared cwd encoder
4. JSONL parser (byte-offset-aware, handles torn reads)
5. Incremental scanner + stale-session cleanup
6. Query API (search / sessionContext / findToolCalls)
7. Pi tool registrations + system-prompt block
8. End-to-end integration test
9. `tool_use_id` in `tool_calls` PK (post-review fix for parallel tool-call collapse)