### PR TITLE
secure: encrypt API keys at rest via Electron safeStorage

### DIFF
--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -4,6 +4,37 @@ import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
 import type { BrowserWindow } from "electron";
+import { loadConfig } from "./config.js";
+import { resolveLlmApiKey, resolveGalaxyApiKey } from "./secure-config.js";
+
+const PROVIDER_ENV_MAP: Record<string, string> = {
+  anthropic: "ANTHROPIC_API_KEY",
+  openai: "OPENAI_API_KEY",
+  google: "GEMINI_API_KEY",
+  mistral: "MISTRAL_API_KEY",
+  groq: "GROQ_API_KEY",
+  xai: "XAI_API_KEY",
+};
+
+/** Build the secret env vars injected into the brain subprocess. */
+function buildSecretEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  const cfg = loadConfig();
+
+  const llmKey = resolveLlmApiKey(cfg);
+  if (llmKey) {
+    const provider = cfg.llm?.provider || "anthropic";
+    const envVar = PROVIDER_ENV_MAP[provider] || "AI_GATEWAY_API_KEY";
+    env[envVar] = llmKey;
+  }
+
+  const galaxyKey = resolveGalaxyApiKey(cfg);
+  if (galaxyKey) {
+    env.GALAXY_API_KEY = galaxyKey;
+  }
+
+  return env;
+}
 
 // Resolve the loom entry point relative to the app
 const LOOM_BIN = path.resolve(__dirname, "../../../bin/loom.js");
@@ -115,10 +146,19 @@ export class AgentManager {
     log("starting agent", { bin: LOOM_BIN, cwd: this.cwd, continue: args.includes("--continue"), fresh });
 
     try {
+      // Decrypted API keys flow to the brain via env so the child never reads
+      // plaintext from disk. buildSecretEnv re-reads config each spawn so
+      // key rotation in the settings UI takes effect on restart without
+      // needing to plumb explicit invalidation.
       this.process = spawn("node", args, {
         stdio: ["pipe", "pipe", "pipe"],
         cwd: this.cwd,
-        env: { ...process.env, LOOM_SHELL_KIND: "orbit", ...(fresh ? { LOOM_FRESH_SESSION: "1" } : {}) },
+        env: {
+          ...process.env,
+          LOOM_SHELL_KIND: "orbit",
+          ...buildSecretEnv(),
+          ...(fresh ? { LOOM_FRESH_SESSION: "1" } : {}),
+        },
       });
     } catch (err) {
       log("spawn failed:", err);

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -2,6 +2,108 @@ import { ipcMain, dialog, BrowserWindow, shell } from "electron";
 import type { AgentManager } from "./agent.js";
 import path from "node:path";
 import { loadConfig, saveConfig, type LoomConfig } from "./config.js";
+import { encryptSecret, isAvailable as safeStorageAvailable } from "./secure-config.js";
+
+/**
+ * Sentinel the renderer sends back in a secret field when the user did NOT
+ * change it. Main preserves whatever is already on disk in that case.
+ */
+export const UNCHANGED_SECRET = "__loom_unchanged_secret__";
+
+/** Masked shape returned to the renderer — never carries plaintext secrets. */
+interface MaskedLoomConfig extends Omit<LoomConfig, "llm" | "galaxy"> {
+  llm?: {
+    provider?: string;
+    model?: string;
+    hasApiKey: boolean;
+  };
+  galaxy?: {
+    active: string | null;
+    profiles: Record<string, { url: string; hasApiKey: boolean }>;
+  };
+}
+
+function maskConfig(cfg: LoomConfig): MaskedLoomConfig {
+  const { llm: _llm, galaxy: _galaxy, ...rest } = cfg;
+  const masked: MaskedLoomConfig = { ...rest };
+  if (cfg.llm) {
+    masked.llm = {
+      provider: cfg.llm.provider,
+      model: cfg.llm.model,
+      hasApiKey: Boolean(cfg.llm.apiKey || cfg.llm.apiKeyEncrypted),
+    };
+  }
+  if (cfg.galaxy) {
+    masked.galaxy = {
+      active: cfg.galaxy.active,
+      profiles: Object.fromEntries(
+        Object.entries(cfg.galaxy.profiles).map(([k, v]) => [
+          k,
+          { url: v.url, hasApiKey: Boolean(v.apiKey || v.apiKeyEncrypted) },
+        ])
+      ),
+    };
+  }
+  return masked;
+}
+
+/**
+ * Reconcile the renderer-supplied config against what's on disk, encrypting
+ * any newly-supplied plaintext secrets and preserving unchanged ones.
+ */
+function reconcileIncomingConfig(incoming: Record<string, unknown>): LoomConfig {
+  const current = loadConfig();
+  const canEncrypt = safeStorageAvailable();
+  const out: LoomConfig = { ...current, ...(incoming as LoomConfig) };
+
+  // LLM key reconciliation
+  const incomingLlm = (incoming as { llm?: { apiKey?: string } }).llm;
+  if (incomingLlm) {
+    const rawKey = incomingLlm.apiKey;
+    const mergedLlm: LoomConfig["llm"] = {
+      provider: (incoming as { llm?: { provider?: string } }).llm?.provider,
+      model: (incoming as { llm?: { model?: string } }).llm?.model,
+    };
+    if (rawKey === UNCHANGED_SECRET || rawKey === undefined) {
+      // Preserve whatever was on disk.
+      if (current.llm?.apiKeyEncrypted) mergedLlm.apiKeyEncrypted = current.llm.apiKeyEncrypted;
+      if (current.llm?.apiKey) mergedLlm.apiKey = current.llm.apiKey;
+    } else if (rawKey === "") {
+      // Explicit clear — drop both fields.
+    } else if (canEncrypt) {
+      mergedLlm.apiKeyEncrypted = encryptSecret(rawKey);
+    } else {
+      mergedLlm.apiKey = rawKey;
+    }
+    out.llm = mergedLlm;
+  }
+
+  // Galaxy profile reconciliation (per profile)
+  type GalaxyConfig = NonNullable<LoomConfig["galaxy"]>;
+  const incomingGalaxy = (incoming as { galaxy?: GalaxyConfig }).galaxy;
+  if (incomingGalaxy) {
+    const mergedProfiles: GalaxyConfig["profiles"] = {};
+    for (const [name, p] of Object.entries(incomingGalaxy.profiles || {})) {
+      const existing = current.galaxy?.profiles?.[name];
+      const rawKey = p.apiKey;
+      const profile: (typeof mergedProfiles)[string] = { url: p.url };
+      if (rawKey === UNCHANGED_SECRET || rawKey === undefined) {
+        if (existing?.apiKeyEncrypted) profile.apiKeyEncrypted = existing.apiKeyEncrypted;
+        if (existing?.apiKey) profile.apiKey = existing.apiKey;
+      } else if (rawKey === "") {
+        // Explicit clear — drop both fields.
+      } else if (canEncrypt) {
+        profile.apiKeyEncrypted = encryptSecret(rawKey);
+      } else {
+        profile.apiKey = rawKey;
+      }
+      mergedProfiles[name] = profile;
+    }
+    out.galaxy = { active: incomingGalaxy.active, profiles: mergedProfiles };
+  }
+
+  return out;
+}
 
 function log(...args: unknown[]): void {
   console.log("[ipc]", ...args);
@@ -96,12 +198,13 @@ export function registerIpcHandlers(agent: AgentManager): void {
   });
 
   ipcMain.handle("config:get", () => {
-    return loadConfig();
+    return maskConfig(loadConfig());
   });
 
-  ipcMain.handle("config:save", async (_e, config: LoomConfig) => {
+  ipcMain.handle("config:save", async (_e, incoming: Record<string, unknown>) => {
     try {
-      saveConfig(config);
+      const reconciled = reconcileIncomingConfig(incoming);
+      saveConfig(reconciled);
       log("config saved");
       // Restart agent subprocess to pick up new provider/model/API key
       agent.stop();

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import { registerIpcHandlers, confirmCwdChange } from "./ipc-handlers.js";
 import { AgentManager } from "./agent.js";
 import { ProcMonitor } from "./proc-monitor.js";
+import { migratePlaintextSecrets, isAvailable as safeStorageAvailable } from "./secure-config.js";
 
 // Workaround for systems where chrome-sandbox isn't suid root
 app.commandLine.appendSwitch("no-sandbox");
@@ -267,6 +268,21 @@ app.setName("Orbit");
 app.whenReady().then(() => {
   log("app ready");
   buildMenu();
+
+  // Migrate any plaintext API keys in ~/.loom/config.json to ciphertext. Must
+  // run before the agent spawns so the brain sees env-injected decrypted keys
+  // rather than the old plaintext.
+  if (safeStorageAvailable()) {
+    try {
+      const result = migratePlaintextSecrets();
+      if (result.migrated) log("migrated plaintext secrets → safeStorage");
+    } catch (err) {
+      log("secret migration failed:", err);
+    }
+  } else {
+    log("safeStorage unavailable — keys remain plaintext on disk");
+  }
+
   const cwd = getDefaultCwd();
   log("cwd:", cwd);
   createWindow(cwd);

--- a/app/src/main/secure-config.ts
+++ b/app/src/main/secure-config.ts
@@ -1,0 +1,104 @@
+import { safeStorage } from "electron";
+import type { LoomConfig } from "../../../shared/loom-config.js";
+import { loadConfig, saveConfig } from "../../../shared/loom-config.js";
+
+function log(...args: unknown[]): void {
+  console.log("[secure-config]", ...args);
+}
+
+export function isAvailable(): boolean {
+  try {
+    return safeStorage.isEncryptionAvailable();
+  } catch {
+    return false;
+  }
+}
+
+export function encryptSecret(plaintext: string): string {
+  return safeStorage.encryptString(plaintext).toString("base64");
+}
+
+export function decryptSecret(b64: string): string {
+  return safeStorage.decryptString(Buffer.from(b64, "base64"));
+}
+
+function tryDecrypt(b64: string | undefined): string | null {
+  if (!b64) return null;
+  try {
+    return decryptSecret(b64);
+  } catch (err) {
+    log("decrypt failed:", err);
+    return null;
+  }
+}
+
+/**
+ * Resolve the LLM API key for the brain. Returns the plaintext value if it can
+ * be obtained, preferring the encrypted field. `null` means no key is
+ * available via config (env vars may still supply one).
+ */
+export function resolveLlmApiKey(config: LoomConfig): string | null {
+  const llm = config.llm;
+  if (!llm) return null;
+  if (llm.apiKey) return llm.apiKey;
+  if (llm.apiKeyEncrypted && isAvailable()) {
+    return tryDecrypt(llm.apiKeyEncrypted);
+  }
+  return null;
+}
+
+/**
+ * Resolve the active Galaxy profile's API key. Returns `null` if no active
+ * profile, no key, or decryption unavailable.
+ */
+export function resolveGalaxyApiKey(config: LoomConfig): string | null {
+  const active = config.galaxy?.active;
+  if (!active) return null;
+  const profile = config.galaxy?.profiles?.[active];
+  if (!profile) return null;
+  if (profile.apiKey) return profile.apiKey;
+  if (profile.apiKeyEncrypted && isAvailable()) {
+    return tryDecrypt(profile.apiKeyEncrypted);
+  }
+  return null;
+}
+
+/**
+ * One-shot migration. If any plaintext apiKey field exists and safeStorage is
+ * available, encrypt it into apiKeyEncrypted and drop the plaintext. Writes
+ * the config back only if changes were made.
+ */
+export function migratePlaintextSecrets(): { migrated: boolean; skipped: string | null } {
+  if (!isAvailable()) {
+    return { migrated: false, skipped: "safeStorage unavailable" };
+  }
+  const config = loadConfig();
+  let changed = false;
+
+  if (config.llm?.apiKey) {
+    const enc = encryptSecret(config.llm.apiKey);
+    config.llm = { ...config.llm, apiKeyEncrypted: enc };
+    delete config.llm.apiKey;
+    changed = true;
+    log("migrated llm.apiKey → apiKeyEncrypted");
+  }
+
+  const profiles = config.galaxy?.profiles;
+  if (profiles) {
+    for (const name of Object.keys(profiles)) {
+      const p = profiles[name];
+      if (p.apiKey) {
+        const enc = encryptSecret(p.apiKey);
+        profiles[name] = { ...p, apiKeyEncrypted: enc };
+        delete profiles[name].apiKey;
+        changed = true;
+        log(`migrated galaxy.profiles.${name}.apiKey → apiKeyEncrypted`);
+      }
+    }
+  }
+
+  if (changed) {
+    saveConfig(config);
+  }
+  return { migrated: changed, skipped: null };
+}

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -301,8 +301,8 @@ welcomeSave.addEventListener("click", async () => {
 });
 
 async function checkFirstRun(): Promise<void> {
-  const cfg = (await window.orbit.getConfig()) as { llm?: { apiKey?: string } };
-  if (!cfg.llm?.apiKey) {
+  const cfg = (await window.orbit.getConfig()) as { llm?: { hasApiKey?: boolean } };
+  if (!cfg.llm?.hasApiKey) {
     populateWelcomeModels(welcomeProvider.value);
     welcomeOverlay.classList.remove("hidden");
   }
@@ -1272,24 +1272,34 @@ const prefsGalaxyKey = document.getElementById("prefs-galaxy-key") as HTMLInputE
 const prefsDefaultCwd = document.getElementById("prefs-default-cwd") as HTMLInputElement;
 const prefsCondaBin = document.getElementById("prefs-conda-bin") as HTMLSelectElement;
 
+/** Sentinel mirrors UNCHANGED_SECRET in main/ipc-handlers.ts. */
+const UNCHANGED_SECRET = "__loom_unchanged_secret__";
+/** Tracks whether a key is already on disk so blank-input = unchanged, not clear. */
+let prefsLlmHadKey = false;
+let prefsGalaxyHadKey = false;
+
 async function openPreferences(): Promise<void> {
   const config = await window.orbit.getConfig() as {
-    llm?: { provider?: string; apiKey?: string; model?: string };
-    galaxy?: { active: string | null; profiles: Record<string, { url: string; apiKey: string }> };
+    llm?: { provider?: string; model?: string; hasApiKey?: boolean };
+    galaxy?: { active: string | null; profiles: Record<string, { url: string; hasApiKey?: boolean }> };
     defaultCwd?: string;
     condaBin?: string;
   };
 
   prefsProvider.value = config.llm?.provider || "anthropic";
   populateModels(prefsProvider.value, config.llm?.model);
-  prefsApiKey.value = config.llm?.apiKey || "";
+  prefsLlmHadKey = Boolean(config.llm?.hasApiKey);
+  prefsApiKey.value = "";
+  prefsApiKey.placeholder = prefsLlmHadKey ? "•••••••• (unchanged)" : "";
 
   // Galaxy: use active profile
   const activeProfile = config.galaxy?.active
     ? config.galaxy.profiles?.[config.galaxy.active]
     : null;
   prefsGalaxyUrl.value = activeProfile?.url || "";
-  prefsGalaxyKey.value = activeProfile?.apiKey || "";
+  prefsGalaxyHadKey = Boolean(activeProfile?.hasApiKey);
+  prefsGalaxyKey.value = "";
+  prefsGalaxyKey.placeholder = prefsGalaxyHadKey ? "•••••••• (unchanged)" : "";
 
   prefsDefaultCwd.value = config.defaultCwd || "";
   prefsCondaBin.value = config.condaBin || "auto";
@@ -1302,42 +1312,48 @@ function closePreferences(): void {
 }
 
 async function savePreferences(): Promise<void> {
-  // Preserve existing config (galaxy profiles) and merge
-  const current = await window.orbit.getConfig() as {
-    llm?: { provider?: string; apiKey?: string; model?: string };
-    galaxy?: { active: string | null; profiles: Record<string, { url: string; apiKey: string }> };
-    defaultCwd?: string;
-    condaBin?: string;
+  // Build a delta — only fields the user can edit. Main reconciles secrets
+  // against what's on disk; the sentinel preserves a stored key when the
+  // user left the input blank.
+  const typedApiKey = prefsApiKey.value.trim();
+  const llmApiKey = typedApiKey
+    ? typedApiKey
+    : prefsLlmHadKey
+    ? UNCHANGED_SECRET
+    : "";
+
+  const typedGalaxyKey = prefsGalaxyKey.value.trim();
+  const galaxyUrl = prefsGalaxyUrl.value.trim();
+  const galaxyApiKey = typedGalaxyKey
+    ? typedGalaxyKey
+    : prefsGalaxyHadKey
+    ? UNCHANGED_SECRET
+    : "";
+
+  const config: Record<string, unknown> = {
+    llm: {
+      provider: prefsProvider.value,
+      model: prefsModel.value || undefined,
+      apiKey: llmApiKey,
+    },
   };
 
-  const config: typeof current = { ...current };
-
-  config.llm = {
-    provider: prefsProvider.value,
-    model: prefsModel.value || undefined,
-    apiKey: prefsApiKey.value.trim() || undefined,
-  };
-
-  // Galaxy: save as "default" profile
-  if (prefsGalaxyUrl.value.trim() || prefsGalaxyKey.value.trim()) {
+  if (galaxyUrl || prefsGalaxyHadKey || typedGalaxyKey) {
     config.galaxy = {
       active: "default",
       profiles: {
-        ...(current.galaxy?.profiles || {}),
         default: {
-          url: prefsGalaxyUrl.value.trim(),
-          apiKey: prefsGalaxyKey.value.trim(),
+          url: galaxyUrl,
+          apiKey: galaxyApiKey,
         },
       },
     };
-  } else {
-    delete config.galaxy;
   }
 
   config.defaultCwd = prefsDefaultCwd.value.trim() || undefined;
   config.condaBin = (prefsCondaBin.value as "auto" | "mamba" | "conda") || undefined;
 
-  const result = await window.orbit.saveConfig(config as Record<string, unknown>);
+  const result = await window.orbit.saveConfig(config);
   if (result.success) {
     closePreferences();
     chat.addUserMessage("[system] Preferences saved. Agent restarted.");

--- a/bin/loom.js
+++ b/bin/loom.js
@@ -203,6 +203,25 @@ function checkLLMProvider() {
   ];
   if (providerEnvVars.some(v => process.env[v])) return;
 
+  // Config has an encrypted key but this CLI can't decrypt it — Electron's
+  // safeStorage lives in the Orbit main process. Point the user at the two
+  // working paths instead of falling through to the generic error.
+  if (loomConfig.llm?.apiKeyEncrypted) {
+    console.error(`loom: your ~/.loom/config.json has an encrypted API key
+(apiKeyEncrypted), but the standalone CLI cannot decrypt it — that only
+works inside Orbit.
+
+Do one of the following:
+
+  • Launch via Orbit (\`cd app && npm start\`), which decrypts and injects
+    ANTHROPIC_API_KEY (or the provider-specific variable) into the brain.
+
+  • Export the key for this shell:
+      export ANTHROPIC_API_KEY=sk-ant-...
+`);
+    process.exit(1);
+  }
+
   const authPath = join(agentDir, "auth.json");
   if (existsSync(authPath)) {
     try {

--- a/extensions/loom/profiles.ts
+++ b/extensions/loom/profiles.ts
@@ -13,7 +13,10 @@ import { loadConfig, saveConfig } from "./config";
 
 export interface GalaxyProfile {
   url: string;
-  apiKey: string;
+  /** Plaintext API key. Orbit migrates this to apiKeyEncrypted on next startup. */
+  apiKey?: string;
+  /** Base64 ciphertext produced by Electron safeStorage (Orbit-only). */
+  apiKeyEncrypted?: string;
 }
 
 export interface GalaxyProfiles {
@@ -87,8 +90,14 @@ export function switchProfile(name: string): boolean {
   writeProfiles(profiles);
 
   process.env.GALAXY_URL = profile.url;
-  process.env.GALAXY_API_KEY = profile.apiKey;
-  syncMcpConfig(profile.url, profile.apiKey);
+  // If the profile only has an encrypted key, the brain can't decrypt it —
+  // leave GALAXY_API_KEY alone so the Orbit-injected env value keeps working.
+  if (profile.apiKey) {
+    process.env.GALAXY_API_KEY = profile.apiKey;
+    syncMcpConfig(profile.url, profile.apiKey);
+  } else if (process.env.GALAXY_API_KEY) {
+    syncMcpConfig(profile.url, process.env.GALAXY_API_KEY);
+  }
   return true;
 }
 

--- a/shared/loom-config.d.ts
+++ b/shared/loom-config.d.ts
@@ -1,12 +1,24 @@
 export interface LoomConfig {
   llm?: {
     provider?: string;
+    /** Plaintext API key. Orbit migrates this to apiKeyEncrypted on startup. */
     apiKey?: string;
+    /** Base64 ciphertext produced by Electron safeStorage. Orbit-only. */
+    apiKeyEncrypted?: string;
     model?: string;
   };
   galaxy?: {
     active: string | null;
-    profiles: Record<string, { url: string; apiKey: string }>;
+    profiles: Record<
+      string,
+      {
+        url: string;
+        /** Plaintext API key. Orbit migrates to apiKeyEncrypted on startup. */
+        apiKey?: string;
+        /** Base64 ciphertext produced by Electron safeStorage. Orbit-only. */
+        apiKeyEncrypted?: string;
+      }
+    >;
   };
   executionMode?: "local" | "remote";
   defaultCwd?: string;

--- a/shared/loom-config.js
+++ b/shared/loom-config.js
@@ -25,5 +25,10 @@ export function loadConfig() {
 export function saveConfig(config) {
   const dir = getConfigDir();
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(getConfigPath(), JSON.stringify(config, null, 2) + "\n");
+  const p = getConfigPath();
+  fs.writeFileSync(p, JSON.stringify(config, null, 2) + "\n", { mode: 0o600 });
+  // writeFileSync honors mode only on create; enforce on existing files too.
+  try {
+    fs.chmodSync(p, 0o600);
+  } catch {}
 }


### PR DESCRIPTION
## Summary

- Plaintext `apiKey` fields in `~/.loom/config.json` are migrated to `apiKeyEncrypted` (Electron `safeStorage` ciphertext, OS-keychain backed) on Orbit startup. Config file is also written `mode 0600`.
- Brain (`bin/loom.js`) gets decrypted keys via env vars on spawn — the child never reads plaintext from disk. Preferences UI uses a masked placeholder (`•••••••• (unchanged)`) and a sentinel so blank input preserves the stored key.
- IPC `config:get` returns a masked shape — no plaintext crosses the preload boundary. `config:save` re-encrypts or preserves per field.
- Standalone `loom` CLI (non-Orbit) now errors instructively when only `apiKeyEncrypted` is present and no provider env var is set.

## Motivation

`~/.loom/config.json` stored `llm.apiKey` and `galaxy.profiles[*].apiKey` in plaintext with default file perms. Any process running as the user could read them; backup/sync tooling (iCloud, Dropbox, rsync) could replicate them. This change removes both risks for Orbit users without breaking the standalone CLI path.

## Design notes

`safeStorage` is main-process-only. Orbit decrypts and injects via env on brain spawn (mirroring how `GALAXY_API_KEY` already flows). The CLI path intentionally does *not* decrypt ciphertext; users must either launch via Orbit or export the env var themselves.

Sentinel `__loom_unchanged_secret__` is how the renderer signals "I didn't touch this field — preserve existing encrypted value". Empty string means explicit clear.

On Linux without a session keyring, `safeStorage.isEncryptionAvailable()` returns false; the migration is a no-op and plaintext remains (file still written mode 0600). Behavior documented, not blocked.

## Test plan

- [x] `npm test` — 242/242 pass
- [x] `npm run typecheck` (root) + `cd app && npx tsc --noEmit` — both clean
- [x] Smoke: Orbit boots, config on disk shows `apiKeyEncrypted` (no `apiKey`), `stat` shows `0600`
- [x] Brain round-trip: chat works (decrypt → env → brain)
- [x] CLI fallback: `unset ANTHROPIC_API_KEY && node bin/loom.js` prints the instructive error
- [ ] Preferences: open/save without touching the key input preserves it (manual UI test recommended)
- [ ] Preferences: paste new key + save rewrites the ciphertext (manual UI test recommended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)