### PR TITLE
Pin galaxy-mcp to >=1.4.0

### DIFF
--- a/bin/loom.js
+++ b/bin/loom.js
@@ -165,7 +165,7 @@ if (!isInformationalCommand) {
   if (executionMode === "remote" && hasGalaxyCredentials) {
     mcpConfig.mcpServers.galaxy = {
       command: "uvx",
-      args: ["galaxy-mcp"],
+      args: ["galaxy-mcp>=1.4.0"],
       directTools: true,
       env: {
         GALAXY_URL: galaxyUrl,


### PR DESCRIPTION
## Summary
- Switches the Galaxy MCP registration in `bin/loom.js` from unpinned `uvx galaxy-mcp` to `uvx galaxy-mcp>=1.4.0`, so fresh installs pick up the 1.4.0 release and its new user-defined tools + vault-credential features by default.
- Floor pin (`>=1.4.0`) rather than exact -- older versions still technically work, they just don't expose the new tools. This lets patch releases flow through without another bump.

## Test plan
- [x] `node --check bin/loom.js`
- [x] `npm run typecheck`
- [x] `npm test` (275/275 pass)
- [ ] Manual: run `loom` in remote mode with Galaxy creds and confirm the generated `mcp.json` contains `"args": ["galaxy-mcp>=1.4.0"]` and uvx resolves 1.4.0+.