### PR TITLE
Orbit UI fixes (#34): Galaxy half-filled save + file-viewer focus ring

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -2051,6 +2051,7 @@ prefsProvider.addEventListener("change", () => {
 wireApiKeyValidation(prefsProvider, prefsApiKey, prefsApiKeyStatus);
 const prefsGalaxyUrl = document.getElementById("prefs-galaxy-url") as HTMLInputElement;
 const prefsGalaxyKey = document.getElementById("prefs-galaxy-key") as HTMLInputElement;
+const prefsGalaxyError = document.getElementById("prefs-galaxy-error")!;
 const prefsDefaultCwd = document.getElementById("prefs-default-cwd") as HTMLInputElement;
 const prefsCondaBin = document.getElementById("prefs-conda-bin") as HTMLSelectElement;
 const prefsSkillsRows = document.getElementById("prefs-skills-rows")!;
@@ -2144,6 +2145,21 @@ const UNCHANGED_SECRET = "__loom_unchanged_secret__";
 let prefsLlmHadKey = false;
 let prefsGalaxyHadKey = false;
 
+// Both-or-neither: a half-filled Galaxy profile gets rejected by the brain
+// silently, so disable Save and surface why inline rather than letting the
+// user click and discover via an alert.
+function updatePrefsGalaxyValidity(): void {
+  const hasUrl = Boolean(prefsGalaxyUrl.value.trim());
+  const hasKey = Boolean(prefsGalaxyKey.value.trim() || prefsGalaxyHadKey);
+  const halfFilled = hasUrl !== hasKey;
+  prefsGalaxyError.textContent = halfFilled
+    ? "Provide both URL and API key, or leave both blank."
+    : "";
+  (prefsSave as HTMLButtonElement).disabled = halfFilled;
+}
+prefsGalaxyUrl.addEventListener("input", updatePrefsGalaxyValidity);
+prefsGalaxyKey.addEventListener("input", updatePrefsGalaxyValidity);
+
 async function openPreferences(): Promise<void> {
   const config = await window.orbit.getConfig() as {
     llm?: { provider?: string; model?: string; hasApiKey?: boolean };
@@ -2169,6 +2185,7 @@ async function openPreferences(): Promise<void> {
   prefsGalaxyHadKey = Boolean(activeProfile?.hasApiKey);
   prefsGalaxyKey.value = "";
   prefsGalaxyKey.placeholder = prefsGalaxyHadKey ? "•••••••• (unchanged)" : "";
+  updatePrefsGalaxyValidity();
 
   prefsDefaultCwd.value = config.defaultCwd || "";
   prefsCondaBin.value = config.condaBin || "auto";
@@ -2214,7 +2231,8 @@ async function savePreferences(): Promise<void> {
   const hasGalaxyUrl = Boolean(galaxyUrl);
   const hasGalaxyKey = Boolean(typedGalaxyKey || prefsGalaxyHadKey);
   if (hasGalaxyUrl !== hasGalaxyKey) {
-    alert("Galaxy: provide both URL and API key, or leave both blank.");
+    // Save button should already be disabled by updatePrefsGalaxyValidity.
+    // Belt-and-suspenders: bail silently if it somehow fires anyway.
     return;
   }
 

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -230,6 +230,7 @@
             <label for="prefs-galaxy-key">API Key</label>
             <input id="prefs-galaxy-key" type="password" placeholder="Galaxy API key" />
           </div>
+          <div id="prefs-galaxy-error" class="prefs-galaxy-error"></div>
         </section>
 
         <section class="prefs-section">

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -428,6 +428,14 @@ body:not(.artifact-collapsed) #artifact-toggle {
   display: none;
 }
 
+/* Class-level outline: none above kills the default browser ring at the
+   same specificity as *:focus-visible; restore a keyboard-only focus ring
+   so a11y users editing a file see where their caret is. */
+.file-viewer-editor:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
 .file-viewer-preview {
   flex: 1;
   overflow-y: auto;

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -1389,6 +1389,11 @@ body:not(.artifact-collapsed) #artifact-toggle {
   color: var(--error);
   font-size: 12px;
 }
+.prefs-galaxy-error {
+  color: var(--error);
+  font-size: 12px;
+  min-height: 14px;
+}
 .required {
   color: var(--error);
   font-size: 11px;


### PR DESCRIPTION
Closes the remaining gaps from #34. Most of the 6-phase plan was already shipped during the recent \`notebook-rewire-pure-md\` merge; this PR addresses the two items still outstanding.

## Phase 2 — Galaxy half-filled Save (\`537d5e2\`)

Preferences now disables the Save button + shows an inline error under the Galaxy section when only one of URL/key is filled. Replaces the post-click \`alert()\`. Welcome modal already showed inline errors; this brings Preferences in line.

## Phase 5 — file-viewer keyboard focus (\`b1f8773\`)

\`.file-viewer-editor { outline: none }\` was overriding the global \`*:focus-visible\` at equal specificity, so a11y users editing a file got no focus indicator. Restores a gold inset outline via \`:focus-visible\` (inset because the editor fills its pane and an outset ring would be clipped).

## Already-done items (verified, no commit)

| Phase | Items | Where |
|-------|-------|-------|
| 1 — theme | \`.plan-btn\` base + variants, blue→gold focus, gold/c8a200/state-border literals | styles.css:1670-1701, 80-84, etc. |
| 2 — UX | welcome Skip+Esc, Galaxy validation, Skills confirm, addInfoMessage, stuck-badge click | app.ts:573-587, 541-545, 2105, 2283, 1891-1916 |
| 3 — chat ergonomics | revealActivityForTurn collapsed-only, leading info cards, placeholder, /new merge, proc-monitor empty, switch-dir delegation | app.ts:2473-2481, 1033-1035, 1099-1102, 1183-1199, 1204-1209 |
| 4 — responsive | breakpoints (TS, 900/700), pane-tab ellipsis, empty-state padding, tabs left-align, pane-tab-close 20px, prompt-num min-width, proc-count zero | app.ts:298-338, styles.css:1751,1776-1779,1806-1807,1877-1896 |
| 5 — a11y | aria-labels on icon buttons, galaxy-status as button, slash popup activedescendant, queued ↓ aria-hidden, global :focus-visible | index.html:51,57,79,84,154,170,68; app.ts:1391,1456-1461; styles.css:80 |
| 6 — polish | Atkinson font dropped, notebook empty-state, Start-fresh warning, \`<strong>\`, tab-label case, notify emoji+SVG, SLASH_COMMANDS single source | index.html, app.ts:1846-1864, 898-904 |

## Test

- \`npm run typecheck\` clean (root + app)
- \`npm test\` 117/117
- Smoke: half-fill Galaxy URL or key in Preferences → Save greys out + inline error; restore field → Save re-enables
- Smoke: Tab into a file's editor in Orbit → gold inset focus ring visible