### PR TITLE
ci: cross-platform matrix build (closes #37)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            app/package-lock.json
+
+      - name: Install root deps
+        run: npm ci
+
+      - name: Typecheck (root)
+        run: npm run typecheck
+
+      - name: Test (root)
+        run: npm test
+
+      - name: Install app deps
+        working-directory: app
+        run: npm ci
+
+      - name: Typecheck (app)
+        working-directory: app
+        run: npx tsc --noEmit
+
+      - name: Package Electron app
+        working-directory: app
+        run: npx electron-forge package


### PR DESCRIPTION
Closes #37.

## What

\`.github/workflows/build.yml\` runs on every PR and push to \`main\`:

- Matrix: \`ubuntu-latest\`, \`macos-latest\`, \`windows-latest\`
- Root: \`npm ci\`, \`npm run typecheck\`, \`npm test\`
- App: \`npm ci\`, \`npx tsc --noEmit\`, \`npx electron-forge package\`

## Why

Catches the kind of regression that bit us recently (DOMPurify import broke the renderer; only the Linux dev box surfaced it). With a Mac/Windows runner we'd have caught it in CI before merge. Same applies to dependency-resolution differences (e.g. the recent vite 6/8 incident, #8).

## Out of scope

- Electron smoke launch (Playwright \`_electron.launch()\`) — adds value but needs \`xvfb-run\` on Linux + virtual display strategy on macOS/Windows; defer to a follow-up.
- \`npm run validate:provenance\` — script in root \`package.json\` targets a deleted test file; CI runs plain \`npm test\` instead.

## Notes

- Caches both lockfiles for speed on cache hit.
- \`fail-fast: false\` so a Windows-only failure doesn't hide a macOS-only issue.
- \`electron-forge package\` is the heavy step (~5 min/runner); the rest is fast.