### PR TITLE
Add in-app issue reporter (closes #33, option A)

### DIFF
--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, BrowserWindow, shell } from "electron";
+import { ipcMain, dialog, BrowserWindow, shell, app } from "electron";
 import type { AgentManager } from "./agent.js";
 import { startFilesWatcher, resolveWithin } from "./files-handler.js";
 import { loadSessionHistory } from "./session-replay.js";
@@ -367,6 +367,32 @@ export function registerIpcHandlers(agent: AgentManager): void {
     if (err) return { opened: false, error: err };
     return { opened: true };
   });
+
+  // Issue reporter: returns sysinfo for the renderer to bundle into the
+  // report body. No secrets — just versions + platform + arch.
+  ipcMain.handle("report:sysinfo", () => ({
+    appVersion: app.getVersion(),
+    electronVersion: process.versions.electron,
+    nodeVersion: process.versions.node,
+    chromeVersion: process.versions.chrome,
+    platform: process.platform,
+    arch: process.arch,
+  }));
+
+  // Issue reporter: opens a pre-filled GitHub "new issue" URL in the user's
+  // browser. The renderer never gets a generic openExternal capability —
+  // we hard-code the repo here so a compromised renderer can't redirect.
+  ipcMain.handle(
+    "report:open-issue",
+    async (_e, payload: { title?: unknown; body?: unknown }) => {
+      const title = typeof payload?.title === "string" ? payload.title : "";
+      const body = typeof payload?.body === "string" ? payload.body : "";
+      const params = new URLSearchParams({ title, body });
+      const url = `https://github.com/galaxyproject/loom/issues/new?${params.toString()}`;
+      await shell.openExternal(url);
+      return { opened: true };
+    },
+  );
 }
 
 /**

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -82,6 +82,15 @@ export interface OrbitAPI {
   onProcUpdate(callback: (procs: ProcInfo[]) => void): () => void;
   onSessionHistory(callback: (history: ReplaySegment[]) => void): () => void;
   replayChat(): Promise<{ ok: true; segments: number } | { ok: false; error: string }>;
+  getReportSysinfo(): Promise<{
+    appVersion: string;
+    electronVersion: string;
+    nodeVersion: string;
+    chromeVersion: string;
+    platform: string;
+    arch: string;
+  }>;
+  openIssueReport(payload: { title: string; body: string }): Promise<{ opened: boolean }>;
 }
 
 const api: OrbitAPI = {
@@ -167,6 +176,9 @@ const api: OrbitAPI = {
   },
 
   replayChat: () => ipcRenderer.invoke("chat:replay"),
+
+  getReportSysinfo: () => ipcRenderer.invoke("report:sysinfo"),
+  openIssueReport: (payload) => ipcRenderer.invoke("report:open-issue", payload),
   onSessionHistory: (callback) => {
     const handler = (_e: unknown, history: ReplaySegment[]) => callback(history);
     ipcRenderer.on("agent:session-history", handler);

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -2312,6 +2312,116 @@ window.orbit.onShowSlashCommands(() => {
   chat.addInfoMessage(slashCommandsHtml());
 });
 
+// ── Report-issue modal ───────────────────────────────────────────────────────
+//
+// One-click affordance for alpha testers: pre-fills a GitHub "new issue" URL
+// with the user's title/description plus opt-in sysinfo + log tails, then
+// opens the user's browser. The renderer never gets a generic openExternal —
+// the URL is constructed in main against a hard-coded repo (#33 option A).
+
+const reportBtn = document.getElementById("report-issue-btn")!;
+const reportOverlay = document.getElementById("report-overlay")!;
+const reportClose = document.getElementById("report-close")!;
+const reportCancel = document.getElementById("report-cancel")!;
+const reportSubmit = document.getElementById("report-submit") as HTMLButtonElement;
+const reportTitle = document.getElementById("report-title") as HTMLInputElement;
+const reportBody = document.getElementById("report-body") as HTMLTextAreaElement;
+const reportIncludeSysinfo = document.getElementById("report-include-sysinfo") as HTMLInputElement;
+const reportIncludeLogs = document.getElementById("report-include-logs") as HTMLInputElement;
+
+const REPORT_BODY_CAP = 6000;
+
+function openReportModal(): void {
+  reportTitle.value = "";
+  reportBody.value = "";
+  reportIncludeSysinfo.checked = true;
+  reportIncludeLogs.checked = true;
+  reportOverlay.classList.remove("hidden");
+  reportTitle.focus();
+}
+function closeReportModal(): void {
+  reportOverlay.classList.add("hidden");
+}
+
+async function buildReportBody(userText: string): Promise<string> {
+  const sections: string[] = [userText.trim() || "(no description provided)"];
+
+  if (reportIncludeSysinfo.checked) {
+    try {
+      const info = await window.orbit.getReportSysinfo();
+      const cfg = (await window.orbit.getConfig()) as {
+        llm?: { provider?: string; model?: string };
+        galaxy?: { active: string | null };
+      };
+      const cwd = await window.orbit.getCwd().catch(() => "(unknown)");
+      sections.push(
+        `## System info\n` +
+        `- Orbit: ${info.appVersion}\n` +
+        `- Platform: ${info.platform} ${info.arch}\n` +
+        `- Electron: ${info.electronVersion}, Chrome: ${info.chromeVersion}, Node: ${info.nodeVersion}\n` +
+        `- LLM: ${cfg.llm?.provider ?? "(none)"} / ${cfg.llm?.model ?? "(none)"}\n` +
+        `- Galaxy: ${cfg.galaxy?.active ? "configured" : "not configured"}\n` +
+        `- cwd: \`${cwd}\``
+      );
+    } catch (err) {
+      sections.push(`## System info\n(failed to collect: ${err instanceof Error ? err.message : String(err)})`);
+    }
+  }
+
+  if (reportIncludeLogs.checked) {
+    // Activity tail (last 30 lines of activity.jsonl, if present)
+    try {
+      const res = await window.orbit.readFile("activity.jsonl");
+      if (res.ok) {
+        const text = new TextDecoder("utf-8").decode(res.bytes);
+        const lines = text.split("\n").filter(Boolean);
+        const tail = lines.slice(-30).join("\n");
+        sections.push("## activity.jsonl (last 30 lines)\n```\n" + tail + "\n```");
+      }
+    } catch { /* file missing or unreadable — skip */ }
+
+    // Shell tail (last ~150 lines of in-memory ShellPanel)
+    const shellTail = shell.tail(150);
+    if (shellTail.trim()) {
+      sections.push("## Shell stream (last ~150 lines)\n```\n" + shellTail + "\n```");
+    }
+  }
+
+  let body = sections.join("\n\n");
+  if (body.length > REPORT_BODY_CAP) {
+    body = body.slice(0, REPORT_BODY_CAP - 50) + "\n\n…(truncated)";
+  }
+  return body;
+}
+
+reportBtn.addEventListener("click", openReportModal);
+reportClose.addEventListener("click", closeReportModal);
+reportCancel.addEventListener("click", closeReportModal);
+reportOverlay.addEventListener("click", (e) => {
+  if (e.target === reportOverlay) closeReportModal();
+});
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape" && !reportOverlay.classList.contains("hidden")) {
+    closeReportModal();
+  }
+});
+
+reportSubmit.addEventListener("click", async () => {
+  const title = reportTitle.value.trim();
+  if (!title) {
+    reportTitle.focus();
+    return;
+  }
+  reportSubmit.disabled = true;
+  try {
+    const body = await buildReportBody(reportBody.value);
+    await window.orbit.openIssueReport({ title, body });
+    closeReportModal();
+  } finally {
+    reportSubmit.disabled = false;
+  }
+});
+
 // ── Agent shell event feed ────────────────────────────────────────────────────
 
 /** Extract a short, useful summary from an agent event and append to the shell. */

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -2334,8 +2334,11 @@ const REPORT_BODY_CAP = 6000;
 function openReportModal(): void {
   reportTitle.value = "";
   reportBody.value = "";
-  reportIncludeSysinfo.checked = true;
-  reportIncludeLogs.checked = true;
+  // Default to no auto-collected data. The destination is a public GitHub
+  // issue, so opt-in beats opt-out -- forces the user to read the
+  // disclosure before sharing logs or sysinfo.
+  reportIncludeSysinfo.checked = false;
+  reportIncludeLogs.checked = false;
   reportOverlay.classList.remove("hidden");
   reportTitle.focus();
 }
@@ -2353,15 +2356,16 @@ async function buildReportBody(userText: string): Promise<string> {
         llm?: { provider?: string; model?: string };
         galaxy?: { active: string | null };
       };
-      const cwd = await window.orbit.getCwd().catch(() => "(unknown)");
+      // Deliberately not including cwd -- a path like /home/<user>/<project>
+      // leaks both username and project name to a public issue, and isn't
+      // useful for debugging.
       sections.push(
         `## System info\n` +
         `- Orbit: ${info.appVersion}\n` +
         `- Platform: ${info.platform} ${info.arch}\n` +
         `- Electron: ${info.electronVersion}, Chrome: ${info.chromeVersion}, Node: ${info.nodeVersion}\n` +
         `- LLM: ${cfg.llm?.provider ?? "(none)"} / ${cfg.llm?.model ?? "(none)"}\n` +
-        `- Galaxy: ${cfg.galaxy?.active ? "configured" : "not configured"}\n` +
-        `- cwd: \`${cwd}\``
+        `- Galaxy: ${cfg.galaxy?.active ? "configured" : "not configured"}`
       );
     } catch (err) {
       sections.push(`## System info\n(failed to collect: ${err instanceof Error ? err.message : String(err)})`);
@@ -2409,7 +2413,10 @@ document.addEventListener("keydown", (e) => {
 reportSubmit.addEventListener("click", async () => {
   const title = reportTitle.value.trim();
   if (!title) {
-    reportTitle.focus();
+    // Native validity tooltip is consistent with how form validation works
+    // elsewhere in the app and avoids silent failure when the button click
+    // doesn't appear to do anything.
+    reportTitle.reportValidity();
     return;
   }
   reportSubmit.disabled = true;

--- a/app/src/renderer/chat/shell-panel.ts
+++ b/app/src/renderer/chat/shell-panel.ts
@@ -48,4 +48,15 @@ export class ShellPanel {
   clear(): void {
     this.body.innerHTML = "";
   }
+
+  /** Last N lines of the shell stream as plain text — used by the issue reporter. */
+  tail(n: number): string {
+    const lines: string[] = [];
+    const children = this.body.children;
+    const start = Math.max(0, children.length - n);
+    for (let i = start; i < children.length; i++) {
+      lines.push(children[i].textContent ?? "");
+    }
+    return lines.join("\n");
+  }
 }

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -440,21 +440,21 @@
         </div>
         <div class="prefs-row">
           <label for="report-title">Title</label>
-          <input id="report-title" type="text" placeholder="Short summary" />
+          <input id="report-title" type="text" placeholder="Short summary" required />
         </div>
         <div class="prefs-row">
           <label for="report-body">What happened?</label>
           <textarea id="report-body" rows="6" placeholder="Steps to reproduce, expected vs actual, screenshots if relevant..."></textarea>
         </div>
         <div class="report-options">
-          <label><input type="checkbox" id="report-include-sysinfo" checked /> Include system info</label>
-          <label><input type="checkbox" id="report-include-logs" checked /> Include logs</label>
+          <label><input type="checkbox" id="report-include-sysinfo" /> Include system info</label>
+          <label><input type="checkbox" id="report-include-logs" /> Include logs</label>
         </div>
         <details class="report-disclosure">
           <summary>What's in this report?</summary>
-          <p><b>System info:</b> Orbit version, OS, Electron/Node versions, LLM model + provider name (no API key), Galaxy connection state (no credentials), current working directory.</p>
-          <p><b>Logs:</b> last 30 lines of <code>activity.jsonl</code> (if present in the cwd) and last ~150 lines of the in-app shell stream.</p>
-          <p>Both are off by toggle if you'd rather not share them.</p>
+          <p><b>System info:</b> Orbit version, OS, Electron/Node versions, LLM model + provider name (no API key), Galaxy connection state (no credentials).</p>
+          <p><b>Logs:</b> last 30 lines of <code>activity.jsonl</code> (if present in the cwd) and last ~150 lines of the in-app shell stream. These can include filenames, tool arguments, and command output -- review the issue body on GitHub before you click Submit there.</p>
+          <p>Both are off by default. Opt in only when you've decided you're OK sharing them on a public issue.</p>
         </details>
       </div>
       <div class="modal-footer">

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -154,6 +154,7 @@
       <button id="galaxy-status" class="footer-control is-interactive status-dot status-dot-disconnected" title="Galaxy: not configured" aria-label="Galaxy connection: not configured. Click to open Preferences.">
         <span class="status-dot-label">Galaxy</span>
       </button>
+      <button id="report-issue-btn" class="footer-control is-interactive" title="Report an issue" aria-label="Report an issue">Report</button>
       <div id="exec-mode-toggle" class="footer-control footer-control-segmented" role="radiogroup" aria-label="Execution mode" title="Execution mode: Local = everything runs locally; Cloud = agent decides per plan whether each step runs locally or on Galaxy.">
         <button id="exec-mode-local" class="exec-mode-btn" data-mode="local" role="radio" aria-checked="false">Local</button>
         <button id="exec-mode-cloud" class="exec-mode-btn active" data-mode="cloud" role="radio" aria-checked="true">Cloud</button>
@@ -415,6 +416,51 @@
           <button id="ext-confirm" class="plan-btn primary hidden">OK</button>
           <button id="ext-deny" class="plan-btn hidden">No</button>
           <button id="ext-accept" class="plan-btn primary hidden">Yes</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Report-issue modal -->
+  <div id="report-overlay" class="modal-overlay hidden">
+    <div class="modal">
+      <div class="modal-header">
+        <h2>Report an issue</h2>
+        <button id="report-close" class="modal-close" title="Close" aria-label="Close">×</button>
+      </div>
+      <div class="modal-body">
+        <div class="report-account-note">
+          You'll need a GitHub account to submit this — your default browser
+          will open the pre-filled issue page on
+          <a href="https://github.com/galaxyproject/loom" target="_blank" rel="noopener noreferrer">github.com/galaxyproject/loom</a>,
+          and you click <em>Submit</em> there. No GitHub account?
+          <a href="https://github.com/signup" target="_blank" rel="noopener noreferrer">Create one</a>
+          — if you're serious about data analysis, you'll want one anyway
+          (code, notebooks, collaboration all live there).
+        </div>
+        <div class="prefs-row">
+          <label for="report-title">Title</label>
+          <input id="report-title" type="text" placeholder="Short summary" />
+        </div>
+        <div class="prefs-row">
+          <label for="report-body">What happened?</label>
+          <textarea id="report-body" rows="6" placeholder="Steps to reproduce, expected vs actual, screenshots if relevant..."></textarea>
+        </div>
+        <div class="report-options">
+          <label><input type="checkbox" id="report-include-sysinfo" checked /> Include system info</label>
+          <label><input type="checkbox" id="report-include-logs" checked /> Include logs</label>
+        </div>
+        <details class="report-disclosure">
+          <summary>What's in this report?</summary>
+          <p><b>System info:</b> Orbit version, OS, Electron/Node versions, LLM model + provider name (no API key), Galaxy connection state (no credentials), current working directory.</p>
+          <p><b>Logs:</b> last 30 lines of <code>activity.jsonl</code> (if present in the cwd) and last ~150 lines of the in-app shell stream.</p>
+          <p>Both are off by toggle if you'd rather not share them.</p>
+        </details>
+      </div>
+      <div class="modal-footer">
+        <div class="modal-actions">
+          <button id="report-cancel" class="plan-btn">Cancel</button>
+          <button id="report-submit" class="plan-btn primary">Open as GitHub issue</button>
         </div>
       </div>
     </div>

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -1498,7 +1498,8 @@ body:not(.artifact-collapsed) #artifact-toggle {
 
 .prefs-row input[type="text"],
 .prefs-row input[type="password"],
-.prefs-row select {
+.prefs-row select,
+.prefs-row textarea {
   flex: 1;
   padding: 6px 10px;
   background: var(--bg);
@@ -1511,10 +1512,57 @@ body:not(.artifact-collapsed) #artifact-toggle {
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 
+.prefs-row textarea {
+  resize: vertical;
+  min-height: 80px;
+  font-family: var(--font-sans);
+  line-height: 1.4;
+}
+
 .prefs-row input:focus,
-.prefs-row select:focus {
+.prefs-row select:focus,
+.prefs-row textarea:focus {
   border-color: var(--accent-light);
   box-shadow: 0 0 0 2px var(--accent-bg);
+}
+
+.report-account-note {
+  background: var(--accent-bg);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  padding: 10px 12px;
+  margin-bottom: 16px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text);
+}
+
+.report-options {
+  display: flex;
+  gap: 16px;
+  font-size: 12px;
+  color: var(--text);
+  margin-top: 8px;
+}
+.report-options label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+.report-disclosure {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.report-disclosure summary {
+  cursor: pointer;
+  color: var(--text);
+}
+.report-disclosure p {
+  margin-top: 6px;
+  line-height: 1.5;
 }
 
 .prefs-row-with-btn {


### PR DESCRIPTION
Closes #33 with option A from the issue (pre-filled GitHub URL).

## What

Footer **Report** button (next to Galaxy dot) opens a modal:

- Title input + description textarea
- Two opt-in checkboxes (default on): "Include system info" / "Include logs"
- "What's in this report?" disclosure spelling out exactly what gets sent
- Gold-tinted note at the top explaining the GitHub-account requirement, with a signup link
- **Open as GitHub issue** primary button → opens \`github.com/galaxyproject/loom/issues/new\` in the user's browser with title + body pre-filled

User reviews and clicks **Submit** on GitHub. No mailto, no save-to-file (yet — easy to add as siblings later).

## Auto-collected (opt-in)

**sysinfo** — Orbit version, platform/arch, Electron/Chrome/Node versions, LLM provider+model (no API key), Galaxy state (no creds), cwd.

**logs** — last 30 lines of \`activity.jsonl\` (if present) + last ~150 lines of the in-memory shell stream.

Body capped at ~6000 chars to fit GitHub URL limits; tail-truncated with a marker if it would overflow.

## Security / privacy notes

- Repo is **hard-coded in main IPC** — the renderer never gets a generic \`openExternal\` capability, so a compromised renderer can't redirect to a malicious URL.
- API keys never leave the renderer (\`getConfig()\` already returns masked config without secrets).
- Both data collection toggles are opt-in/visible. The disclosure spells out what each includes.

## Files

- \`app/src/renderer/index.html\` — modal markup
- \`app/src/renderer/styles.css\` — modal + note styling
- \`app/src/renderer/app.ts\` — open/close, body builder, submit
- \`app/src/renderer/chat/shell-panel.ts\` — \`tail(n)\` helper
- \`app/src/preload/preload.ts\` — \`getReportSysinfo\` + \`openIssueReport\` bindings
- \`app/src/main/ipc-handlers.ts\` — IPC handlers

## Test

- \`npm run typecheck\` clean (root + app)
- \`npm test\` 117/117
- Smoke: Report → fill title → submit → browser opens to pre-filled GH issue page; sysinfo + logs visible in body