### PR TITLE
brain prompt: Galaxy glossary — recognize UDT, workflow invocation, IWC (refs #22)

### DIFF
--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -169,7 +169,7 @@ resources before deciding what runs where:
   inventing a local workaround.
 - **Workflow invocation**: a single run of a Galaxy workflow on a
   history. Tracked in the notebook via \`loom-invocation\` blocks.
-- **IWC**: Intergalactic Workflow Commons — registry of curated
+- **IWC**: Intergalactic Workflow Commission — registry of curated
   workflows. \`galaxy_search_iwc\` queries it.
 
 The three operating modes are an *outcome* of the plan you draft, not a

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -157,6 +157,21 @@ resources before deciding what runs where:
    \`Step 3: BWA alignment (Galaxy: bwa-mem2/2.2.1)\`
    \`Step 4: VCF filter (local awk)\`
 
+### Galaxy terminology
+
+- **User-defined tool** ("UDT"): a server-side custom tool the user
+  registers in their Galaxy account. Created/managed via Galaxy API
+  (and the Galaxy MCP if/when the version installed exposes UDT
+  endpoints). **Do not generate old-style XML tool wrappers locally
+  when the user asks for a UDT** — that's a different concept (legacy
+  ToolShed tools). If the connected Galaxy MCP doesn't expose UDT
+  tools, say so and point the user to the Galaxy UI rather than
+  inventing a local workaround.
+- **Workflow invocation**: a single run of a Galaxy workflow on a
+  history. Tracked in the notebook via \`loom-invocation\` blocks.
+- **IWC**: Intergalactic Workflow Commons — registry of curated
+  workflows. \`galaxy_search_iwc\` queries it.
+
 The three operating modes are an *outcome* of the plan you draft, not a
 mode setting:
 - **local** — every step runs locally


### PR DESCRIPTION
Refs #22.

Addresses the user-feedback half of the issue (the brain fabricating old-style XML tool wrappers when asked about user-defined tools). The version-bump half is blocked on upstream — \`bin/loom.js\` already pins \`galaxy-mcp>=1.4.0\` so the UDT-aware release will be picked up automatically once it ships on PyPI.

## Change

Adds a small \"Galaxy terminology\" subsection to the connected-Galaxy block in \`extensions/loom/context.ts\`:

- **UDT** — explicitly defined as a server-side custom tool. \"Do not generate old-style XML tool wrappers locally when the user asks for a UDT.\" Points the user to the Galaxy UI when MCP doesn't expose UDT endpoints (today's state).
- **Workflow invocation** — short definition + reference to \`loom-invocation\` blocks.
- **IWC** — short definition.

15 lines added, no behavior change beyond the system prompt.

## Test

- \`npm run typecheck\` clean
- \`npm test\` 117/117

#22 should stay open until the upstream UDT release lands and we verify end-to-end UDT creation against a real Galaxy.