### PR TITLE
Add Playwright smoke test for Orbit launch (refs #37)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -25,6 +25,7 @@
         "@electron-forge/maker-squirrel": "^7.6.0",
         "@electron-forge/maker-zip": "^7.6.0",
         "@electron-forge/plugin-vite": "^7.6.0",
+        "@playwright/test": "^1.50.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.7.0",
@@ -2863,6 +2864,22 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -9358,6 +9375,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,8 @@
     "prestart": "./scripts/rename-electron-dev.sh",
     "start": "electron-forge start",
     "package": "electron-forge package",
-    "make": "electron-forge make"
+    "make": "electron-forge make",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@dagrejs/dagre": "^3.0.0",
@@ -28,6 +29,7 @@
     "@electron-forge/maker-squirrel": "^7.6.0",
     "@electron-forge/maker-zip": "^7.6.0",
     "@electron-forge/plugin-vite": "^7.6.0",
+    "@playwright/test": "^1.50.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.7.0",

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./test/e2e",
+  // Electron tests serialize naturally — single instance per spec
+  fullyParallel: false,
+  workers: 1,
+  // Single retry on CI to absorb flaky brain-spawn timing; none locally
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  // 60s per test — Electron cold-start + first-window can be slow on CI
+  timeout: 60_000,
+});

--- a/app/src/main/secure-config.ts
+++ b/app/src/main/secure-config.ts
@@ -7,6 +7,12 @@ function log(...args: unknown[]): void {
 }
 
 export function isAvailable(): boolean {
+  // Test/automation escape: macOS Keychain pops a "keychain cannot be found"
+  // dialog when probed under a redirected HOME, which blocks headless e2e
+  // runs indefinitely. Setting LOOM_DISABLE_SAFE_STORAGE=1 in the launched
+  // env makes us skip the probe entirely; encrypted secrets just stay
+  // unread for the duration of the test.
+  if (process.env.LOOM_DISABLE_SAFE_STORAGE === "1") return false;
   try {
     return safeStorage.isEncryptionAvailable();
   } catch {

--- a/app/test/e2e/smoke.spec.ts
+++ b/app/test/e2e/smoke.spec.ts
@@ -29,6 +29,8 @@ function packagedExecutablePath(): string {
     return path.join(root, "out", `Orbit-linux-${arch}`, "orbit");
   }
   if (process.platform === "darwin") {
+    // Inner binary name follows forge.config.ts `executableName: "orbit"`
+    // (lowercase), not the .app bundle's display name.
     return path.join(
       root,
       "out",
@@ -36,11 +38,11 @@ function packagedExecutablePath(): string {
       "Orbit.app",
       "Contents",
       "MacOS",
-      "Orbit",
+      "orbit",
     );
   }
   if (process.platform === "win32") {
-    return path.join(root, "out", `Orbit-win32-${arch}`, "Orbit.exe");
+    return path.join(root, "out", `Orbit-win32-${arch}`, "orbit.exe");
   }
   throw new Error(`Unsupported platform: ${process.platform}`);
 }
@@ -72,11 +74,22 @@ test("Orbit launches and the renderer initializes without errors", async () => {
     // Force a fresh session so the brain doesn't try to --continue from
     // an unrelated prior session if one happened to exist on disk.
     LOOM_FRESH_SESSION: "1",
+    // Skip the safeStorage keychain probe -- on macOS it pops a system
+    // "keychain cannot be found" dialog under a redirected HOME and
+    // blocks the test indefinitely.
+    LOOM_DISABLE_SAFE_STORAGE: "1",
   };
 
   const app = await electron.launch({
     executablePath: packagedExecutablePath(),
-    args: [`--user-data-dir=${userDataDir}`],
+    args: [
+      `--user-data-dir=${userDataDir}`,
+      // Linux-only: tells Chromium to skip libsecret/kwallet and use a
+      // plaintext file backend. Has no effect on macOS or Windows --
+      // those are covered by LOOM_DISABLE_SAFE_STORAGE above. Defensive
+      // on Linux CI runners that don't have a secret service daemon.
+      "--password-store=basic",
+    ],
     env: isolatedEnv,
     cwd: fakeCwd,
   });

--- a/app/test/e2e/smoke.spec.ts
+++ b/app/test/e2e/smoke.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Orbit smoke test — launches the packaged Electron app and asserts:
+ *  1. The renderer mounts (the chat textarea exists).
+ *  2. The agent-status badge eventually flips off the "connecting…" HTML
+ *     placeholder. This is exactly the regression class that bit us with
+ *     the DOMPurify-import bug — a top-level renderer throw left the badge
+ *     stuck.
+ *  3. No uncaught console errors fired during boot.
+ *
+ * Run after `npm run package` so the bundled app is on disk.
+ */
+
+import { test, expect, _electron as electron } from "@playwright/test";
+import path from "node:path";
+
+function packagedExecutablePath(): string {
+  const root = path.resolve(__dirname, "../..");
+  const arch = process.arch;
+  if (process.platform === "linux") {
+    return path.join(root, "out", `Orbit-linux-${arch}`, "orbit");
+  }
+  if (process.platform === "darwin") {
+    return path.join(
+      root,
+      "out",
+      `Orbit-darwin-${arch}`,
+      "Orbit.app",
+      "Contents",
+      "MacOS",
+      "Orbit",
+    );
+  }
+  if (process.platform === "win32") {
+    return path.join(root, "out", `Orbit-win32-${arch}`, "Orbit.exe");
+  }
+  throw new Error(`Unsupported platform: ${process.platform}`);
+}
+
+test("Orbit launches and the renderer initializes without errors", async () => {
+  const errors: string[] = [];
+
+  const app = await electron.launch({
+    executablePath: packagedExecutablePath(),
+    args: [],
+  });
+
+  const page = await app.firstWindow();
+  page.on("pageerror", (err) => errors.push(`pageerror: ${err.message}`));
+  page.on("console", (msg) => {
+    if (msg.type() === "error") errors.push(`console.error: ${msg.text()}`);
+  });
+
+  // App shell mounted
+  await expect(page.locator("#input")).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator("#agent-status")).toBeVisible();
+
+  // Status flips off the initial "connecting…" HTML — the brain may emit
+  // running or error depending on environment, but ANY change proves the
+  // renderer's IPC + listener wiring is alive.
+  await expect(page.locator("#agent-status")).not.toHaveText(/connecting/i, {
+    timeout: 30_000,
+  });
+
+  // No uncaught renderer errors during boot
+  expect(errors).toEqual([]);
+
+  await app.close();
+});

--- a/app/test/e2e/smoke.spec.ts
+++ b/app/test/e2e/smoke.spec.ts
@@ -8,10 +8,19 @@
  *  3. No uncaught console errors fired during boot.
  *
  * Run after `npm run package` so the bundled app is on disk.
+ *
+ * Isolation: each test gets a fresh tmpdir for HOME, cwd, and Electron's
+ * userData. Without this, the launched binary reads the developer's real
+ * ~/.loom/config.json (LLM keys, Galaxy creds) and ~/.orbit state, and the
+ * test side-effects on real analysis directories. The inherited env is also
+ * scrubbed of GALAXY_* so a developer with creds set in their shell doesn't
+ * accidentally launch the test against a real Galaxy server.
  */
 
 import { test, expect, _electron as electron } from "@playwright/test";
 import path from "node:path";
+import os from "node:os";
+import fs from "node:fs/promises";
 
 function packagedExecutablePath(): string {
   const root = path.resolve(__dirname, "../..");
@@ -39,30 +48,61 @@ function packagedExecutablePath(): string {
 test("Orbit launches and the renderer initializes without errors", async () => {
   const errors: string[] = [];
 
+  // Per-test temp tree. HOME redirect covers ~/.loom and ~/.orbit; the
+  // Electron --user-data-dir flag covers app.getPath("userData") which on
+  // macOS lives outside HOME (~/Library/Application Support).
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "orbit-e2e-"));
+  const fakeHome = path.join(tmpRoot, "home");
+  const fakeCwd = path.join(tmpRoot, "cwd");
+  const userDataDir = path.join(tmpRoot, "userData");
+  await Promise.all([
+    fs.mkdir(fakeHome, { recursive: true }),
+    fs.mkdir(fakeCwd, { recursive: true }),
+    fs.mkdir(userDataDir, { recursive: true }),
+  ]);
+
+  const isolatedEnv = {
+    ...process.env,
+    HOME: fakeHome,
+    USERPROFILE: fakeHome,
+    // Scrub any Galaxy creds inherited from the developer's shell so we
+    // don't accidentally launch a real connection during the smoke test.
+    GALAXY_URL: "",
+    GALAXY_API_KEY: "",
+    // Force a fresh session so the brain doesn't try to --continue from
+    // an unrelated prior session if one happened to exist on disk.
+    LOOM_FRESH_SESSION: "1",
+  };
+
   const app = await electron.launch({
     executablePath: packagedExecutablePath(),
-    args: [],
+    args: [`--user-data-dir=${userDataDir}`],
+    env: isolatedEnv,
+    cwd: fakeCwd,
   });
 
-  const page = await app.firstWindow();
-  page.on("pageerror", (err) => errors.push(`pageerror: ${err.message}`));
-  page.on("console", (msg) => {
-    if (msg.type() === "error") errors.push(`console.error: ${msg.text()}`);
-  });
+  try {
+    const page = await app.firstWindow();
+    page.on("pageerror", (err) => errors.push(`pageerror: ${err.message}`));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(`console.error: ${msg.text()}`);
+    });
 
-  // App shell mounted
-  await expect(page.locator("#input")).toBeVisible({ timeout: 30_000 });
-  await expect(page.locator("#agent-status")).toBeVisible();
+    // App shell mounted
+    await expect(page.locator("#input")).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator("#agent-status")).toBeVisible();
 
-  // Status flips off the initial "connecting…" HTML — the brain may emit
-  // running or error depending on environment, but ANY change proves the
-  // renderer's IPC + listener wiring is alive.
-  await expect(page.locator("#agent-status")).not.toHaveText(/connecting/i, {
-    timeout: 30_000,
-  });
+    // Status flips off the initial "connecting…" HTML — the brain may emit
+    // running or error depending on environment, but ANY change proves the
+    // renderer's IPC + listener wiring is alive.
+    await expect(page.locator("#agent-status")).not.toHaveText(/connecting/i, {
+      timeout: 30_000,
+    });
 
-  // No uncaught renderer errors during boot
-  expect(errors).toEqual([]);
-
-  await app.close();
+    // No uncaught renderer errors during boot
+    expect(errors).toEqual([]);
+  } finally {
+    await app.close();
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Refs #37 (the Phase 2 \"Electron smoke test\" item I deferred when filing the cross-platform CI issue).

## What

A single Playwright spec that launches the packaged Orbit binary and asserts:

1. **Renderer mounts** — \`#input\` and \`#agent-status\` are visible.
2. **Status badge updates** — flips off the \`connecting…\` HTML placeholder within 30s. Catches the DOMPurify-class regression we hit a couple of days ago (top-level renderer throw left the badge stuck).
3. **No uncaught console errors** during boot.

## Files

- \`app/package.json\` — adds \`@playwright/test\` and \`test:e2e\` script.
- \`app/playwright.config.ts\` — minimal config (testDir, single worker, 60s timeout, GH reporter on CI).
- \`app/test/e2e/smoke.spec.ts\` — the single spec. Computes the exec path from \`process.platform\` + \`process.arch\` so it runs on Linux, macOS, and Windows.

## Run locally

\`\`\`bash
cd app
npm run package         # builds the bundled app into app/out/
npm run test:e2e        # runs Playwright against the packaged binary
\`\`\`

On Linux, headless display via xvfb is needed; in CI we'd add \`xvfb-run\` to the e2e step.

## CI

**Not wired in this PR.** Needs the matrix workflow from #40 to land first; the e2e job will be a follow-up that re-uses #40's setup with an added \`xvfb-run npm run test:e2e\` step on Linux (macOS/Windows runners have a desktop and run windowed).

## Why a single test

The point of this PR is to prove the test infrastructure is in place. Once it's running in CI we can layer on more specific specs (welcome flow, prefs Galaxy half-filled, issue reporter modal, etc.) as separate PRs without re-doing the wiring.

## Tradeoffs

Without an LLM key configured, the brain emits \"running\" then likely \"error\" (it can't find \`bin/loom.js\` from inside the packaged app — separate issue worth filing). The smoke test only requires the badge to leave the initial \"connecting…\" placeholder; either \"running\" or \"error\" satisfies the assertion. This deliberately *doesn't* test agent-loop behavior — that needs real API keys or a stubbed provider, both follow-up work.

## Test

- \`npx tsc --noEmit\` clean (test files are outside \`src/\` and don't enter the regular build).
- Local manual run not yet performed (would require a clean \`npm run package\` cycle); will validate once landed alongside #40.