### PR TITLE
Harden Galaxy credential paths post-PR-#35

### DIFF
--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -9,6 +9,7 @@ import { AgentManager } from "./agent.js";
 import { registerFilesIpc, startFilesWatcher, stopFilesWatcher } from "./files-handler.js";
 import { ProcMonitor } from "./proc-monitor.js";
 import { migratePlaintextSecrets, isAvailable as safeStorageAvailable } from "./secure-config.js";
+import { getConfigDir, getConfigPath } from "../../../shared/loom-config.js";
 
 // Workaround for systems where chrome-sandbox isn't suid root
 app.commandLine.appendSwitch("no-sandbox");
@@ -70,6 +71,44 @@ function saveWindowState(win: BrowserWindow): void {
 let mainWindow: BrowserWindow | null = null;
 let agentManager: AgentManager | null = null;
 let procMonitor: ProcMonitor | null = null;
+let configWatcher: fs.FSWatcher | null = null;
+let configMigrationTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Watch ~/.loom/config.json for plaintext writes from the brain process
+ * (e.g. /connect saves a new profile) and re-encrypt them. Only called
+ * when safeStorage is available -- otherwise plaintext is the best we
+ * can do anyway.
+ *
+ * fs.watch on the directory (not the file) survives the atomic
+ * tmp+rename pattern saveConfig uses: a file-level watch loses its
+ * inode after the rename. Filename filter keeps it cheap.
+ */
+function startConfigWatcher(): void {
+  const dir = getConfigDir();
+  const targetFile = path.basename(getConfigPath()); // "config.json"
+  try {
+    mkdirSync(dir, { recursive: true });
+    configWatcher = fs.watch(dir, { persistent: false }, (_event, filename) => {
+      if (filename !== targetFile) return;
+      // Debounce: atomic tmp+rename can produce two events back-to-back,
+      // and migratePlaintextSecrets does its own write that re-fires the
+      // watcher. 100ms collapses these into one migration pass.
+      if (configMigrationTimer) clearTimeout(configMigrationTimer);
+      configMigrationTimer = setTimeout(() => {
+        configMigrationTimer = null;
+        try {
+          const result = migratePlaintextSecrets();
+          if (result.migrated) log("re-encrypted plaintext secrets after config change");
+        } catch (err) {
+          log("config-change migration failed:", err);
+        }
+      }, 100);
+    });
+  } catch (err) {
+    log("config watcher failed to start:", err);
+  }
+}
 
 function getDefaultCwd(): string {
   // Priority: env var > brain config.defaultCwd > hardcoded default
@@ -404,6 +443,11 @@ app.whenReady().then(() => {
     } catch (err) {
       log("secret migration failed:", err);
     }
+    // Close the plaintext-write window from /connect mid-session: the brain
+    // process can't encrypt (no safeStorage), so it persists keys plaintext
+    // and we re-encrypt as soon as the file changes. fs.watch on the
+    // directory survives the atomic tmp+rename pattern in saveConfig().
+    startConfigWatcher();
   } else {
     log("safeStorage unavailable — keys remain plaintext on disk");
   }

--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -28,10 +28,13 @@ import {
   saveProfile,
   switchProfile,
   profileNameFromUrl,
+  warnOnUnusableActiveProfile,
 } from "./profiles";
 import { LoomWidgetKey, encodeMarkdownWidget } from "../../shared/loom-shell-contract.js";
 
 export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
+
+  warnOnUnusableActiveProfile();
 
   setupUIBridge(pi);
   registerSessionLifecycle(pi);

--- a/extensions/loom/profiles.ts
+++ b/extensions/loom/profiles.ts
@@ -2,8 +2,10 @@
  * Galaxy server profile management
  *
  * Stores named profiles in the `galaxy` section of ~/.loom/config.json.
- * Each profile holds a URL + API key. The active profile's credentials
- * are synced to mcp.json's env block so the Galaxy MCP server sees them.
+ * Each profile holds a URL + API key. The active profile's URL is synced
+ * to mcp.json's env block; the API key is referenced as the literal
+ * `${GALAXY_API_KEY}` env interpolation (resolved by pi-mcp-adapter at
+ * spawn time) so plaintext keys never land on disk in mcp.json.
  */
 
 import * as fs from "fs";
@@ -17,6 +19,25 @@ export interface GalaxyProfile {
   apiKey?: string;
   /** Base64 ciphertext produced by Electron safeStorage (Orbit-only). */
   apiKeyEncrypted?: string;
+}
+
+/**
+ * Thrown when the brain process is asked to use a profile that only has
+ * `apiKeyEncrypted` set. The brain runs without Electron's safeStorage,
+ * so it cannot decrypt the key itself -- the shell must inject the
+ * decrypted value as `GALAXY_API_KEY` in the brain's env (Orbit does
+ * this in `app/src/main/agent.ts:buildSecretEnv`). When the env
+ * injection is also missing, callers see this error instead of a
+ * silent fallback that would 401 against Galaxy.
+ */
+export class EncryptedProfileUnavailableError extends Error {
+  constructor(public profileName: string) {
+    super(
+      `Profile "${profileName}" has only an encrypted API key; this process can't decrypt it. ` +
+      `Run from Orbit (auto-injects the key) or export GALAXY_API_KEY explicitly.`,
+    );
+    this.name = "EncryptedProfileUnavailableError";
+  }
 }
 
 export interface GalaxyProfiles {
@@ -101,6 +122,12 @@ export function validateGalaxyUrl(url: string): { ok: true } | { ok: false; reas
 
 /**
  * Save a profile (insert or update), mark it active, and sync to mcp.json.
+ *
+ * The brain process can't encrypt (no Electron safeStorage), so the
+ * plaintext key lands on disk briefly. Orbit's main process watches
+ * `~/.loom/config.json` and re-encrypts on change, closing the plaintext
+ * window to milliseconds. CLI users without safeStorage get plaintext
+ * persistence -- there's no other option, but they're warned at load time.
  */
 export function saveProfile(name: string, url: string, apiKey: string): void {
   const v = validateGalaxyUrl(url);
@@ -121,12 +148,58 @@ export function saveProfile(name: string, url: string, apiKey: string): void {
   profiles.profiles[name] = { url, apiKey };
   profiles.active = name;
   writeProfiles(profiles);
-  syncMcpConfig(url, apiKey);
+  syncMcpConfig(url);
+}
+
+/**
+ * Resolve a profile's plaintext API key for in-process use (Galaxy HTTP
+ * calls inside the brain). Returns the plaintext value when available,
+ * or throws `EncryptedProfileUnavailableError` for encrypted-only
+ * profiles -- callers must surface that to the user rather than firing
+ * the wrong key at the server.
+ */
+export function resolveProfileApiKey(name: string, profile: GalaxyProfile): string {
+  if (profile.apiKey) return profile.apiKey;
+  if (profile.apiKeyEncrypted) {
+    throw new EncryptedProfileUnavailableError(name);
+  }
+  throw new Error(`Profile "${name}" has no API key configured.`);
+}
+
+/**
+ * Called once at brain startup. If the active profile is encrypted-only
+ * and the shell hasn't injected `GALAXY_API_KEY`, log a clear stderr
+ * line so the user knows why Galaxy calls won't work -- otherwise the
+ * brain would silently 401 against every request.
+ */
+export function warnOnUnusableActiveProfile(): void {
+  const { active, profiles } = loadProfiles();
+  if (!active) return;
+  const profile = profiles[active];
+  if (!profile) return;
+  if (profile.apiKey) return;
+  if (process.env.GALAXY_API_KEY) return;
+  if (!profile.apiKeyEncrypted) return;
+  console.error(
+    `[galaxy] Active profile "${active}" has only an encrypted API key and ` +
+    `GALAXY_API_KEY is not set in the environment. Galaxy calls will fail. ` +
+    `Run from Orbit (auto-injects the decrypted key) or export GALAXY_API_KEY explicitly.`,
+  );
 }
 
 /**
  * Switch to an existing profile. Updates active marker, syncs mcp.json,
  * and sets process.env so the current session picks it up immediately.
+ *
+ * Two paths for the API key:
+ *   1) plaintext `apiKey` -> set env to it.
+ *   2) encrypted-only -> CLEAR `process.env.GALAXY_API_KEY`. The brain
+ *      can't decrypt to verify whether any value already in env matches
+ *      *this* profile's ciphertext (the env was injected for whatever
+ *      profile was active at brain spawn). Better to fail loud than to
+ *      silently send the previous profile's key to the new URL. The
+ *      shell will re-inject on the next brain restart from the now-active
+ *      encrypted profile.
  */
 export function switchProfile(name: string): boolean {
   const profiles = loadProfiles();
@@ -137,14 +210,21 @@ export function switchProfile(name: string): boolean {
   writeProfiles(profiles);
 
   process.env.GALAXY_URL = profile.url;
-  // If the profile only has an encrypted key, the brain can't decrypt it —
-  // leave GALAXY_API_KEY alone so the Orbit-injected env value keeps working.
   if (profile.apiKey) {
     process.env.GALAXY_API_KEY = profile.apiKey;
-    syncMcpConfig(profile.url, profile.apiKey);
-  } else if (process.env.GALAXY_API_KEY) {
-    syncMcpConfig(profile.url, process.env.GALAXY_API_KEY);
+  } else if (profile.apiKeyEncrypted) {
+    // Always invalidate; let the shell restart re-inject the right value.
+    delete process.env.GALAXY_API_KEY;
+    console.warn(
+      `[galaxy] Profile "${name}" has only an encrypted API key. Cleared ` +
+      `GALAXY_API_KEY in this session; restart the shell so Orbit can ` +
+      `re-inject the decrypted key for this profile.`,
+    );
   }
+  // mcp.json holds a literal "${GALAXY_API_KEY}" reference; pi-mcp-adapter
+  // resolves it at MCP spawn time. So the only thing we sync per-profile
+  // is the URL.
+  syncMcpConfig(profile.url);
   return true;
 }
 
@@ -165,9 +245,15 @@ export function deleteProfile(name: string): boolean {
 }
 
 /**
- * Keep mcp.json's galaxy env block in sync with the given credentials.
+ * Keep mcp.json's galaxy URL in sync with the active profile.
+ *
+ * The API key is written as the literal `${GALAXY_API_KEY}` reference,
+ * which pi-mcp-adapter (`server-manager.ts:resolveEnv`) interpolates from
+ * the live process env at spawn time. That keeps plaintext keys off disk
+ * in mcp.json -- the env is populated by Orbit's safeStorage decrypt or
+ * by the user's explicit `export GALAXY_API_KEY=...`.
  */
-export function syncMcpConfig(url: string, apiKey: string): void {
+export function syncMcpConfig(url: string): void {
   try {
     const agentDir = process.env.PI_CODING_AGENT_DIR || path.join(os.homedir(), ".pi", "agent");
     const mcpPath = path.join(agentDir, "mcp.json");
@@ -177,7 +263,7 @@ export function syncMcpConfig(url: string, apiKey: string): void {
     if (config.mcpServers?.galaxy) {
       config.mcpServers.galaxy.env = {
         GALAXY_URL: url,
-        GALAXY_API_KEY: apiKey,
+        GALAXY_API_KEY: "${GALAXY_API_KEY}",
       };
       // 0600 first so a concurrent reader can't catch the file with a
       // wider mode between writeFile and chmod.

--- a/tests/profiles.test.ts
+++ b/tests/profiles.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import {
+  EncryptedProfileUnavailableError,
+  resolveProfileApiKey,
+  saveProfile,
+  switchProfile,
+  loadProfiles,
+  warnOnUnusableActiveProfile,
+} from "../extensions/loom/profiles";
+
+// All loom-config / profiles paths derive from os.homedir() at call time
+// (POSIX reads HOME), so swapping HOME per test sandboxes the on-disk state
+// without touching the real ~/.loom/config.json.
+let prevHome: string | undefined;
+let sandboxHome: string;
+
+beforeEach(() => {
+  prevHome = process.env.HOME;
+  sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), "loom-profiles-test-"));
+  process.env.HOME = sandboxHome;
+  delete process.env.GALAXY_URL;
+  delete process.env.GALAXY_API_KEY;
+  delete process.env.PI_CODING_AGENT_DIR;
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  try { fs.rmSync(sandboxHome, { recursive: true, force: true }); } catch {}
+});
+
+describe("EncryptedProfileUnavailableError", () => {
+  it("names the profile in the message and tags the error name", () => {
+    const err = new EncryptedProfileUnavailableError("usegalaxy");
+    expect(err.profileName).toBe("usegalaxy");
+    expect(err.name).toBe("EncryptedProfileUnavailableError");
+    expect(err.message).toContain("usegalaxy");
+    expect(err.message).toMatch(/orbit|GALAXY_API_KEY/i);
+  });
+});
+
+describe("resolveProfileApiKey", () => {
+  it("returns plaintext when apiKey is set", () => {
+    const got = resolveProfileApiKey("p", { url: "https://x.galaxyproject.org", apiKey: "plain-key" });
+    expect(got).toBe("plain-key");
+  });
+
+  it("throws EncryptedProfileUnavailableError for encrypted-only profiles", () => {
+    expect(() =>
+      resolveProfileApiKey("usegalaxy", { url: "https://usegalaxy.org", apiKeyEncrypted: "ZW5j" }),
+    ).toThrow(EncryptedProfileUnavailableError);
+  });
+
+  it("throws a plain Error when no key field is set", () => {
+    expect(() =>
+      resolveProfileApiKey("empty", { url: "https://usegalaxy.org" }),
+    ).toThrow(/no API key/i);
+    expect(() =>
+      resolveProfileApiKey("empty", { url: "https://usegalaxy.org" }),
+    ).not.toThrow(EncryptedProfileUnavailableError);
+  });
+});
+
+describe("switchProfile env handling", () => {
+  it("sets GALAXY_API_KEY from plaintext profile", () => {
+    saveProfile("a", "https://a.galaxyproject.org", "key-A");
+    delete process.env.GALAXY_API_KEY;
+    expect(switchProfile("a")).toBe(true);
+    expect(process.env.GALAXY_URL).toBe("https://a.galaxyproject.org");
+    expect(process.env.GALAXY_API_KEY).toBe("key-A");
+  });
+
+  it("returns false for an unknown profile", () => {
+    expect(switchProfile("does-not-exist")).toBe(false);
+  });
+
+  it("does not reuse a stale env key when switching to an encrypted-only profile with no env injection", () => {
+    saveProfile("a", "https://a.galaxyproject.org", "key-A");
+    const cfgPath = path.join(sandboxHome, ".loom/config.json");
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    cfg.galaxy.profiles.b = { url: "https://b.galaxyproject.org", apiKeyEncrypted: "ZW5jLWZvci1i" };
+    fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+    expect(switchProfile("a")).toBe(true);
+    expect(process.env.GALAXY_API_KEY).toBe("key-A");
+    delete process.env.GALAXY_API_KEY;
+    expect(switchProfile("b")).toBe(true);
+    expect(process.env.GALAXY_URL).toBe("https://b.galaxyproject.org");
+    expect(process.env.GALAXY_API_KEY).toBeUndefined();
+    expect(loadProfiles().active).toBe("b");
+  });
+
+  it("clears GALAXY_API_KEY even when env was previously injected (forces shell-side re-injection)", () => {
+    // Brain can't verify a pre-injected env matches THIS profile's
+    // ciphertext, so the safer move is to fail loud and require a
+    // restart. This is the security-sensitive path.
+    saveProfile("a", "https://a.galaxyproject.org", "key-A");
+    const cfgPath = path.join(sandboxHome, ".loom/config.json");
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    cfg.galaxy.profiles.b = { url: "https://b.galaxyproject.org", apiKeyEncrypted: "ZW5jLWZvci1i" };
+    fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+    process.env.GALAXY_API_KEY = "stale-from-previous-profile";
+    expect(switchProfile("b")).toBe(true);
+    expect(process.env.GALAXY_API_KEY).toBeUndefined();
+    expect(process.env.GALAXY_URL).toBe("https://b.galaxyproject.org");
+  });
+});
+
+describe("syncMcpConfig", () => {
+  it("writes ${GALAXY_API_KEY} as a literal env reference, never plaintext", () => {
+    const agentDir = path.join(sandboxHome, ".pi", "agent");
+    fs.mkdirSync(agentDir, { recursive: true });
+    const mcpPath = path.join(agentDir, "mcp.json");
+    fs.writeFileSync(
+      mcpPath,
+      JSON.stringify({ mcpServers: { galaxy: { command: "x", env: {} } } }, null, 2),
+    );
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    saveProfile("a", "https://a.galaxyproject.org", "should-not-leak");
+    const written = JSON.parse(fs.readFileSync(mcpPath, "utf-8"));
+    expect(written.mcpServers.galaxy.env.GALAXY_URL).toBe("https://a.galaxyproject.org");
+    expect(written.mcpServers.galaxy.env.GALAXY_API_KEY).toBe("${GALAXY_API_KEY}");
+    const raw = fs.readFileSync(mcpPath, "utf-8");
+    expect(raw).not.toContain("should-not-leak");
+  });
+});
+
+describe("warnOnUnusableActiveProfile", () => {
+  function captureErrors(fn: () => void): string[] {
+    const errors: string[] = [];
+    const orig = console.error;
+    console.error = (msg: string) => errors.push(msg);
+    try { fn(); } finally { console.error = orig; }
+    return errors;
+  }
+
+  it("warns when active profile is encrypted-only and env is unset", () => {
+    saveProfile("a", "https://a.galaxyproject.org", "plain-A");
+    const cfgPath = path.join(sandboxHome, ".loom/config.json");
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    cfg.galaxy.profiles.a = { url: "https://a.galaxyproject.org", apiKeyEncrypted: "ZW5j" };
+    fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+    delete process.env.GALAXY_API_KEY;
+    const errors = captureErrors(() => warnOnUnusableActiveProfile());
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain("Active profile \"a\"");
+    expect(errors[0]).toMatch(/GALAXY_API_KEY/);
+  });
+
+  it("does not warn when active profile has plaintext key", () => {
+    saveProfile("a", "https://a.galaxyproject.org", "plain-A");
+    delete process.env.GALAXY_API_KEY;
+    const errors = captureErrors(() => warnOnUnusableActiveProfile());
+    expect(errors.length).toBe(0);
+  });
+
+  it("does not warn when env injection is present (Orbit path)", () => {
+    saveProfile("a", "https://a.galaxyproject.org", "plain-A");
+    const cfgPath = path.join(sandboxHome, ".loom/config.json");
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
+    cfg.galaxy.profiles.a = { url: "https://a.galaxyproject.org", apiKeyEncrypted: "ZW5j" };
+    fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+    process.env.GALAXY_API_KEY = "injected-by-orbit";
+    const errors = captureErrors(() => warnOnUnusableActiveProfile());
+    expect(errors.length).toBe(0);
+  });
+
+  it("does not warn when there is no active profile", () => {
+    const errors = captureErrors(() => warnOnUnusableActiveProfile());
+    expect(errors.length).toBe(0);
+  });
+});


### PR DESCRIPTION
PR 1 of the post-PR-#35 cleanup plan (`brain/plans/loom-post-pr35-cleanup`),
addressing four credential regressions Codex flagged in the post-merge review
of `55e9875`.

## What this fixes

**Brain-side credential resolution had silent fall-throughs.** The brain runs
in a child process without Electron safeStorage, so it can't decrypt
`apiKeyEncrypted` directly -- Orbit injects the decrypted value as
`GALAXY_API_KEY` at brain spawn time. A few paths assumed the env was always
trustworthy:

- `switchProfile` would silently reuse the *previous* profile's key against
  the *new* profile's URL when switching from plaintext-A to encrypted-only-B.
- The CLI sent unauthenticated requests when the active profile had only
  `apiKeyEncrypted` and the user hadn't exported `GALAXY_API_KEY`.
- `~/.pi/agent/mcp.json` persisted the plaintext Galaxy API key on disk.
- `/connect` mid-session wrote plaintext to `~/.loom/config.json`, and the
  existing `migratePlaintextSecrets()` only ran at Orbit boot, so plaintext
  sat on disk until the next app restart.

## What changes

**`profiles.ts`:** New `resolveProfileApiKey()` that throws a typed
`EncryptedProfileUnavailableError` instead of silently failing.
`switchProfile` now clears stale env on encrypted-only switches so calls
fail loud rather than cross-firing keys at the wrong server.
`warnOnUnusableActiveProfile()` runs at extension boot so CLI users see a
stderr line naming the profile they need to fix. `mcp.json` stores
`GALAXY_API_KEY` as the literal `${GALAXY_API_KEY}` env reference
(pi-mcp-adapter resolves at spawn time per `server-manager.ts:resolveEnv`)
instead of the plaintext key.

**`app/src/main/main.ts`:** A `fs.watch` on `~/.loom/config.json` re-runs
`migratePlaintextSecrets()` whenever the file changes, with a 100ms debounce
to handle the atomic tmp+rename pattern. The plaintext window drops from
"until next Orbit boot" to milliseconds. Watching the directory (not the
file) is what survives the rename.

## What's deliberately not changed

- Galaxy MCP servers spawned before the switch keep their old env until the
  shell restarts. mcp.json now resolves to empty on the next spawn cycle, so
  reload paths fail loud rather than continuing with a stale key.
- CLI plaintext persistence remains the best we can do without safeStorage;
  the new boot warning makes that visible.

## Test plan

- [x] `npm test` -- 130/130 pass (was 117; +13 for new `tests/profiles.test.ts`)
- [x] `npm run typecheck` clean
- [x] `cd app && npx tsc --noEmit` clean
- [ ] Manual: in Orbit, save a profile via `/connect`, inspect
      `~/.loom/config.json` -- only `apiKeyEncrypted` should be present
      after the watcher fires (~ms after save).
- [ ] Manual: switch from a plaintext profile to an encrypted-only profile,
      verify subsequent Galaxy calls in-session fail loud (env cleared) and
      that the CLI banner appears at next launch.
- [ ] Manual: confirm `~/.pi/agent/mcp.json` no longer contains a literal
      Galaxy API key after running `/connect`.

## Follow-ups

PR 2 (docs / scripts cleanup) is the other half of the post-PR-#35 plan and
will land separately. After both, the v2 sprint sequence (research-question
block, BRC context, literature) is unblocked.