### PR TITLE
Packaging: self-contained Orbit + @galaxyproject/loom on npm

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Galaxy Project contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ An AI research harness for [Galaxy](https://galaxyproject.org) bioinformatics, b
 
 Loom turns a working directory into a co-scientist project: ad-hoc exploration, plans, executed steps, interpretations, and follow-up plans all accumulate as markdown in a single, durable, git-tracked `notebook.md`. The agent reads and writes that notebook directly; there is no parallel structured-state store. When Galaxy is configured the agent surveys the workflow registry and tool catalog while drafting plans and routes individual steps to Galaxy or local execution as appropriate.
 
-**Loom** is the agent brain — the Pi.dev runtime in [`extensions/loom/`](extensions/loom/), the system-prompt context, Galaxy invocation tracking, the skills system, and the RPC contract. Run it directly from the terminal with `loom` (`npm install -g loom`) or through **Orbit** (in [`app/`](app/)), the Electron desktop shell with a chat + tabbed-artifact layout.
+**Loom** is the agent brain — the Pi.dev runtime in [`extensions/loom/`](extensions/loom/), the system-prompt context, Galaxy invocation tracking, the skills system, and the RPC contract. Run it directly from the terminal with `loom` (`npm install -g @galaxyproject/loom`) or through **Orbit** (in [`app/`](app/)), the Electron desktop shell with a chat + tabbed-artifact layout.
+
+The names trace real cosmology. The universe's large-scale structure is the *cosmic web* -- galaxies strung along filaments of dark matter, woven into sheets and voids. Loom weaves your research record the way the cosmic web weaves galaxies; Orbit is the electron shell you observe it from.
 
 Future shells — a Galaxy-embedded web UI, a hosted server mode, anything else — talk to the same brain over RPC.
 
@@ -204,13 +206,13 @@ Fetched files cache to `~/.loom/cache/skills/<repo-name>/<path>` with a 24-hour 
 ### Quick path — CLI only
 
 ```bash
-npm install -g loom
+npm install -g @galaxyproject/loom
 ```
 
 Or run without installing:
 
 ```bash
-npx loom
+npx @galaxyproject/loom
 ```
 
 You'll also need [uv](https://docs.astral.sh/uv/) for the Galaxy MCP server (invoked automatically via `uvx`):

--- a/README.md
+++ b/README.md
@@ -203,10 +203,19 @@ Fetched files cache to `~/.loom/cache/skills/<repo-name>/<path>` with a 24-hour 
 
 ## Install
 
-### Quick path — CLI only
+Three paths, depending on what you want.
+
+### Desktop app (Orbit)
+
+Orbit ships as a native installer (signed DMG on macOS, AppImage/deb on Linux, installer on Windows) and bundles its own Node runtime, `uv`, and Loom -- so there are no separate prerequisites. Once a build is signed and published, install it from the [Releases page](https://github.com/galaxyproject/pi-galaxy-analyst/releases). Until then, use the developer install below.
+
+### Loom CLI from npm
+
+Run the brain on the command line without Orbit. Requires Node 20+ and (for Galaxy MCP) [uv](https://docs.astral.sh/uv/).
 
 ```bash
 npm install -g @galaxyproject/loom
+loom
 ```
 
 Or run without installing:
@@ -215,13 +224,13 @@ Or run without installing:
 npx @galaxyproject/loom
 ```
 
-You'll also need [uv](https://docs.astral.sh/uv/) for the Galaxy MCP server (invoked automatically via `uvx`):
+Install `uv` if you don't already have it:
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-### Full install — CLI + Orbit
+### Developer install (build from source)
 
 Clone the repo and install both workspaces:
 
@@ -244,6 +253,8 @@ Or use the CLI:
 node bin/loom.js                       # from repo root
 ```
 
+The developer install needs Node 20+ and `uv` on `PATH`. Per-OS bootstrap below.
+
 #### Linux (Ubuntu/Debian)
 
 ```bash
@@ -259,7 +270,7 @@ nvm install --lts
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-Then the "Full install" steps above.
+Then the developer install steps above.
 
 #### macOS
 
@@ -270,7 +281,7 @@ Then the "Full install" steps above.
 brew install node git uv
 ```
 
-Then the "Full install" steps above.
+Then the developer install steps above.
 
 #### Windows (WSL2)
 

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .vite/
 out/
 dist/
+.loom-stage/

--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
 import fs from "node:fs";
+import https from "node:https";
+import { pipeline } from "node:stream/promises";
 import { execSync } from "node:child_process";
 import type { ForgeConfig } from "@electron-forge/shared-types";
 import { VitePlugin } from "@electron-forge/plugin-vite";
@@ -8,6 +10,8 @@ const APP_DIR = __dirname;
 const REPO_ROOT = path.resolve(APP_DIR, "..");
 const LOOM_STAGE_PARENT = path.resolve(APP_DIR, ".loom-stage");
 const LOOM_STAGE_DIR = path.join(LOOM_STAGE_PARENT, "loom");
+const NODE_STAGE_DIR = path.join(LOOM_STAGE_PARENT, "node");
+const TARBALL_CACHE_DIR = path.join(LOOM_STAGE_PARENT, "cache");
 
 // Files copied verbatim from the Loom repo root into the staged bundle.
 // Mirrors the npm `files` allowlist plus package-lock.json (used by npm ci).
@@ -22,8 +26,7 @@ const LOOM_BUNDLE_FILES = [
 ];
 
 function stageLoomBundle(): void {
-  // Wipe + recreate stage so removed files don't linger between runs.
-  fs.rmSync(LOOM_STAGE_PARENT, { recursive: true, force: true });
+  fs.rmSync(LOOM_STAGE_DIR, { recursive: true, force: true });
   fs.mkdirSync(LOOM_STAGE_DIR, { recursive: true });
 
   for (const item of LOOM_BUNDLE_FILES) {
@@ -40,18 +43,84 @@ function stageLoomBundle(): void {
   execSync(installCmd, { cwd: LOOM_STAGE_DIR, stdio: "inherit" });
 }
 
+function downloadFile(url: string, dest: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, (res) => {
+        const status = res.statusCode ?? 0;
+        if (status === 301 || status === 302 || status === 307 || status === 308) {
+          const redirect = res.headers.location;
+          if (!redirect) {
+            reject(new Error(`redirect without Location header: ${url}`));
+            return;
+          }
+          res.resume();
+          downloadFile(redirect, dest).then(resolve, reject);
+          return;
+        }
+        if (status !== 200) {
+          reject(new Error(`HTTP ${status} for ${url}`));
+          return;
+        }
+        const file = fs.createWriteStream(dest);
+        pipeline(res, file).then(resolve, reject);
+      })
+      .on("error", reject);
+  });
+}
+
+// Bundle the Node runtime that ran `npm ci` so native module ABI stays
+// aligned with what we just built. Targeting the build platform/arch only;
+// cross-platform packaging will need a per-target hook or download matrix.
+async function stageNodeBundle(): Promise<void> {
+  const nodeVersion = process.versions.node;
+  const platform = process.platform === "win32" ? "win" : process.platform;
+  const arch = process.arch;
+  const ext = process.platform === "win32" ? "zip" : "tar.xz";
+  const distName = `node-v${nodeVersion}-${platform}-${arch}`;
+  const filename = `${distName}.${ext}`;
+  const url = `https://nodejs.org/dist/v${nodeVersion}/${filename}`;
+
+  fs.rmSync(NODE_STAGE_DIR, { recursive: true, force: true });
+  fs.mkdirSync(TARBALL_CACHE_DIR, { recursive: true });
+
+  const tarballPath = path.join(TARBALL_CACHE_DIR, filename);
+
+  if (fs.existsSync(tarballPath)) {
+    console.log(`[loom-stage] reusing cached ${filename}`);
+  } else {
+    console.log(`[loom-stage] downloading ${url}`);
+    await downloadFile(url, tarballPath);
+  }
+
+  console.log(`[loom-stage] extracting ${filename}`);
+  if (process.platform === "win32") {
+    execSync(
+      `powershell -Command "Expand-Archive -Path '${tarballPath}' -DestinationPath '${LOOM_STAGE_PARENT}'"`,
+      { stdio: "inherit" },
+    );
+  } else {
+    execSync(`tar -xf "${tarballPath}" -C "${LOOM_STAGE_PARENT}"`, { stdio: "inherit" });
+  }
+
+  const extractedPath = path.join(LOOM_STAGE_PARENT, distName);
+  fs.renameSync(extractedPath, NODE_STAGE_DIR);
+}
+
 const config: ForgeConfig = {
   packagerConfig: {
     name: "Orbit",
     executableName: "orbit",
     icon: "resources/icon",
-    // Copies the staged Loom bundle to Contents/Resources/loom/ in the
-    // packaged app. agent.ts resolves process.resourcesPath/loom/bin/loom.js.
-    extraResource: [LOOM_STAGE_DIR],
+    // Copies the staged Loom bundle and Node runtime to Contents/Resources/
+    // in the packaged app. agent.ts resolves process.resourcesPath/loom/bin/
+    // loom.js + process.resourcesPath/node/bin/node.
+    extraResource: [LOOM_STAGE_DIR, NODE_STAGE_DIR],
   },
   hooks: {
     prePackage: async () => {
       stageLoomBundle();
+      await stageNodeBundle();
     },
   },
   makers: [

--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -218,12 +218,37 @@ const config: ForgeConfig = {
   makers: [
     {
       name: "@electron-forge/maker-zip",
-      platforms: ["darwin", "linux"],
+      platforms: ["darwin", "linux", "win32"],
     },
     {
       name: "@electron-forge/maker-dmg",
       config: {
         format: "ULFO",
+      },
+    },
+    {
+      name: "@electron-forge/maker-squirrel",
+      config: {
+        name: "Orbit",
+        // Squirrel is happy unsigned for dev/internal builds; production
+        // distribution will need a code-signing cert configured here.
+      },
+    },
+    {
+      name: "@electron-forge/maker-deb",
+      config: {
+        options: {
+          maintainer: "Galaxy Project contributors",
+          homepage: "https://galaxyproject.org",
+        },
+      },
+    },
+    {
+      name: "@electron-forge/maker-rpm",
+      config: {
+        options: {
+          homepage: "https://galaxyproject.org",
+        },
       },
     },
   ],

--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -1,11 +1,58 @@
+import path from "node:path";
+import fs from "node:fs";
+import { execSync } from "node:child_process";
 import type { ForgeConfig } from "@electron-forge/shared-types";
 import { VitePlugin } from "@electron-forge/plugin-vite";
+
+const APP_DIR = __dirname;
+const REPO_ROOT = path.resolve(APP_DIR, "..");
+const LOOM_STAGE_PARENT = path.resolve(APP_DIR, ".loom-stage");
+const LOOM_STAGE_DIR = path.join(LOOM_STAGE_PARENT, "loom");
+
+// Files copied verbatim from the Loom repo root into the staged bundle.
+// Mirrors the npm `files` allowlist plus package-lock.json (used by npm ci).
+const LOOM_BUNDLE_FILES = [
+  "bin",
+  "extensions",
+  "shared",
+  "package.json",
+  "package-lock.json",
+  "README.md",
+  "LICENSE",
+];
+
+function stageLoomBundle(): void {
+  // Wipe + recreate stage so removed files don't linger between runs.
+  fs.rmSync(LOOM_STAGE_PARENT, { recursive: true, force: true });
+  fs.mkdirSync(LOOM_STAGE_DIR, { recursive: true });
+
+  for (const item of LOOM_BUNDLE_FILES) {
+    const src = path.join(REPO_ROOT, item);
+    if (!fs.existsSync(src)) continue;
+    fs.cpSync(src, path.join(LOOM_STAGE_DIR, item), { recursive: true });
+  }
+
+  // Install runtime deps only (no devDependencies) into the staged bundle.
+  // npm ci is faster + deterministic when the lockfile is present.
+  const installCmd = fs.existsSync(path.join(LOOM_STAGE_DIR, "package-lock.json"))
+    ? "npm ci --omit=dev --no-audit --no-fund"
+    : "npm install --omit=dev --omit=optional --no-audit --no-fund";
+  execSync(installCmd, { cwd: LOOM_STAGE_DIR, stdio: "inherit" });
+}
 
 const config: ForgeConfig = {
   packagerConfig: {
     name: "Orbit",
     executableName: "orbit",
     icon: "resources/icon",
+    // Copies the staged Loom bundle to Contents/Resources/loom/ in the
+    // packaged app. agent.ts resolves process.resourcesPath/loom/bin/loom.js.
+    extraResource: [LOOM_STAGE_DIR],
+  },
+  hooks: {
+    prePackage: async () => {
+      stageLoomBundle();
+    },
   },
   makers: [
     {

--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -11,7 +11,18 @@ const REPO_ROOT = path.resolve(APP_DIR, "..");
 const LOOM_STAGE_PARENT = path.resolve(APP_DIR, ".loom-stage");
 const LOOM_STAGE_DIR = path.join(LOOM_STAGE_PARENT, "loom");
 const NODE_STAGE_DIR = path.join(LOOM_STAGE_PARENT, "node");
+const UV_STAGE_DIR = path.join(LOOM_STAGE_PARENT, "uv");
 const TARBALL_CACHE_DIR = path.join(LOOM_STAGE_PARENT, "cache");
+
+// uv release target triple per (platform, arch). Mirrors astral-sh/uv's
+// asset names on its GitHub releases.
+const UV_TARGETS: Record<string, string> = {
+  "darwin-arm64": "aarch64-apple-darwin",
+  "darwin-x64": "x86_64-apple-darwin",
+  "linux-x64": "x86_64-unknown-linux-gnu",
+  "linux-arm64": "aarch64-unknown-linux-gnu",
+  "win32-x64": "x86_64-pc-windows-msvc",
+};
 
 // Files copied verbatim from the Loom repo root into the staged bundle.
 // Mirrors the npm `files` allowlist plus package-lock.json (used by npm ci).
@@ -107,20 +118,67 @@ async function stageNodeBundle(): Promise<void> {
   fs.renameSync(extractedPath, NODE_STAGE_DIR);
 }
 
+// Bundle uv/uvx so Galaxy MCP (`uvx galaxy-mcp>=1.4.0`) doesn't need a
+// system-installed uv. Pulls the latest release tarball from astral-sh/uv.
+// "latest" resolves to a specific tag at fetch time -- the cached tarball
+// won't auto-refresh; remove `.loom-stage/cache/` to pick up newer uv.
+async function stageUvBundle(): Promise<void> {
+  const key = `${process.platform}-${process.arch}`;
+  const target = UV_TARGETS[key];
+  if (!target) {
+    throw new Error(
+      `[loom-stage] no uv target mapping for ${key}; add it to UV_TARGETS.`,
+    );
+  }
+  const isWin = process.platform === "win32";
+  const ext = isWin ? "zip" : "tar.gz";
+  const filename = `uv-${target}.${ext}`;
+  const url = `https://github.com/astral-sh/uv/releases/latest/download/${filename}`;
+
+  fs.rmSync(UV_STAGE_DIR, { recursive: true, force: true });
+  fs.mkdirSync(UV_STAGE_DIR, { recursive: true });
+  fs.mkdirSync(TARBALL_CACHE_DIR, { recursive: true });
+
+  const tarballPath = path.join(TARBALL_CACHE_DIR, filename);
+
+  if (fs.existsSync(tarballPath)) {
+    console.log(`[loom-stage] reusing cached ${filename}`);
+  } else {
+    console.log(`[loom-stage] downloading ${url}`);
+    await downloadFile(url, tarballPath);
+  }
+
+  console.log(`[loom-stage] extracting ${filename}`);
+  if (isWin) {
+    execSync(
+      `powershell -Command "Expand-Archive -Path '${tarballPath}' -DestinationPath '${UV_STAGE_DIR}'"`,
+      { stdio: "inherit" },
+    );
+  } else {
+    // Tarball lays out as uv-<target>/uv + uv-<target>/uvx; --strip-components=1
+    // flattens that into UV_STAGE_DIR/uv + UV_STAGE_DIR/uvx.
+    execSync(
+      `tar -xzf "${tarballPath}" -C "${UV_STAGE_DIR}" --strip-components=1`,
+      { stdio: "inherit" },
+    );
+  }
+}
+
 const config: ForgeConfig = {
   packagerConfig: {
     name: "Orbit",
     executableName: "orbit",
     icon: "resources/icon",
-    // Copies the staged Loom bundle and Node runtime to Contents/Resources/
-    // in the packaged app. agent.ts resolves process.resourcesPath/loom/bin/
-    // loom.js + process.resourcesPath/node/bin/node.
-    extraResource: [LOOM_STAGE_DIR, NODE_STAGE_DIR],
+    // Copies the staged Loom bundle, Node runtime, and uv binary to
+    // Contents/Resources/ in the packaged app. agent.ts resolves
+    // process.resourcesPath/{loom,node,uv}/... at brain spawn time.
+    extraResource: [LOOM_STAGE_DIR, NODE_STAGE_DIR, UV_STAGE_DIR],
   },
   hooks: {
     prePackage: async () => {
       stageLoomBundle();
       await stageNodeBundle();
+      await stageUvBundle();
     },
   },
   makers: [

--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -52,6 +52,25 @@ function stageLoomBundle(): void {
     ? "npm ci --omit=dev --no-audit --no-fund"
     : "npm install --omit=dev --omit=optional --no-audit --no-fund";
   execSync(installCmd, { cwd: LOOM_STAGE_DIR, stdio: "inherit" });
+
+  pruneLoomNodeModules();
+}
+
+// Trim runtime-irrelevant chunks from the staged Loom node_modules. Targets
+// only known-safe heavy directories; keeps everything that might be loaded.
+function pruneLoomNodeModules(): void {
+  // koffi ships prebuilt .node binaries for ~18 platforms (darwin/linux/
+  // win32/freebsd/openbsd/musl x ia32/x64/arm64/...). We only need the
+  // build platform's. Keeping just `<platform>_<arch>` saves ~30MB.
+  const koffiBuild = path.join(LOOM_STAGE_DIR, "node_modules", "koffi", "build", "koffi");
+  if (fs.existsSync(koffiBuild)) {
+    const keepDir = `${process.platform}_${process.arch}`;
+    for (const entry of fs.readdirSync(koffiBuild)) {
+      if (entry !== keepDir) {
+        fs.rmSync(path.join(koffiBuild, entry), { recursive: true, force: true });
+      }
+    }
+  }
 }
 
 function downloadFile(url: string, dest: string): Promise<void> {
@@ -116,6 +135,21 @@ async function stageNodeBundle(): Promise<void> {
 
   const extractedPath = path.join(LOOM_STAGE_PARENT, distName);
   fs.renameSync(extractedPath, NODE_STAGE_DIR);
+
+  pruneNodeBundle();
+}
+
+// Drop pieces of the Node distribution that aren't used at runtime: C/C++
+// headers for native module compilation (~60MB), man pages, top-level docs.
+// `lib/node_modules/{npm,corepack}` stays so Pi's bash tool can still run
+// `npm install` if a user/agent invokes it.
+function pruneNodeBundle(): void {
+  for (const subdir of ["include", "share"]) {
+    fs.rmSync(path.join(NODE_STAGE_DIR, subdir), { recursive: true, force: true });
+  }
+  for (const file of ["CHANGELOG.md", "README.md"]) {
+    fs.rmSync(path.join(NODE_STAGE_DIR, file), { force: true });
+  }
 }
 
 // Bundle uv/uvx so Galaxy MCP (`uvx galaxy-mcp>=1.4.0`) doesn't need a

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -18,7 +18,10 @@
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.6.0",
+        "@electron-forge/maker-deb": "^7.6.0",
         "@electron-forge/maker-dmg": "^7.6.0",
+        "@electron-forge/maker-rpm": "^7.6.0",
+        "@electron-forge/maker-squirrel": "^7.6.0",
         "@electron-forge/maker-zip": "^7.6.0",
         "@electron-forge/plugin-vite": "^7.6.0",
         "@types/react": "^19.2.14",
@@ -496,6 +499,23 @@
         "node": ">= 16.4.0"
       }
     },
+    "node_modules/@electron-forge/maker-deb": {
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-7.11.1.tgz",
+      "integrity": "sha512-QTYiryQLYPDkq6pIfBmx0GQ6D8QatUkowH7rTlW5MnCUa0uumX0Xu7yGIjesuwW37fxT3Lv4xi+FSXMCm2eC1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/maker-base": "7.11.1",
+        "@electron-forge/shared-types": "7.11.1"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      },
+      "optionalDependencies": {
+        "electron-installer-debian": "^3.2.0"
+      }
+    },
     "node_modules/@electron-forge/maker-dmg": {
       "version": "7.11.1",
       "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.11.1.tgz",
@@ -512,6 +532,41 @@
       },
       "optionalDependencies": {
         "electron-installer-dmg": "^5.0.1"
+      }
+    },
+    "node_modules/@electron-forge/maker-rpm": {
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-rpm/-/maker-rpm-7.11.1.tgz",
+      "integrity": "sha512-iEfJPRQQyaTqk2EbUfZgulChNWvxGXeYUH0xBX/r5cj1pL4vcJXt3jLMQBVn3mk/0Ytv9UWRs8R/XuNWX6sf2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/maker-base": "7.11.1",
+        "@electron-forge/shared-types": "7.11.1"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      },
+      "optionalDependencies": {
+        "electron-installer-redhat": "^3.2.0"
+      }
+    },
+    "node_modules/@electron-forge/maker-squirrel": {
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.11.1.tgz",
+      "integrity": "sha512-oSg7fgad6l+X0DjtRkSpMzB0AjzyDO4mb2gzM4kTodkP1ADeiMi08bxy0ZeCESqLm5+fG72cAPmEr3BAPvI1yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-forge/maker-base": "7.11.1",
+        "@electron-forge/shared-types": "7.11.1",
+        "fs-extra": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 16.4.0"
+      },
+      "optionalDependencies": {
+        "electron-winstaller": "^5.3.0"
       }
     },
     "node_modules/@electron-forge/maker-zip": {
@@ -2493,6 +2548,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -3996,6 +4062,242 @@
         "node": ">= 12.20.55"
       }
     },
+    "node_modules/electron-installer-common": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/electron-installer-common/-/electron-installer-common-0.10.4.tgz",
+      "integrity": "sha512-8gMNPXfAqUE5CfXg8RL0vXpLE9HAaPkgLXVoHE3BMUzogMWenf4LmwQ27BdCUrEhkjrKl+igs2IHJibclR3z3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@electron/asar": "^3.2.5",
+        "@malept/cross-spawn-promise": "^1.0.0",
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "glob": "^7.1.4",
+        "lodash": "^4.17.15",
+        "parse-author": "^2.0.0",
+        "semver": "^7.1.1",
+        "tmp-promise": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/electron-userland/electron-installer-common?sponsor=1"
+      },
+      "optionalDependencies": {
+        "@types/fs-extra": "^9.0.1"
+      }
+    },
+    "node_modules/electron-installer-common/node_modules/@malept/cross-spawn-promise": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/electron-installer-common/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-installer-debian": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/electron-installer-debian/-/electron-installer-debian-3.2.0.tgz",
+      "integrity": "sha512-58ZrlJ1HQY80VucsEIG9tQ//HrTlG6sfofA3nRGr6TmkX661uJyu4cMPPh6kXW+aHdq/7+q25KyQhDrXvRL7jw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^1.0.0",
+        "debug": "^4.1.1",
+        "electron-installer-common": "^0.10.2",
+        "fs-extra": "^9.0.0",
+        "get-folder-size": "^2.0.1",
+        "lodash": "^4.17.4",
+        "word-wrap": "^1.2.3",
+        "yargs": "^16.0.2"
+      },
+      "bin": {
+        "electron-installer-debian": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/@malept/cross-spawn-promise": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/electron-installer-debian/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-installer-debian/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/electron-installer-dmg": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/electron-installer-dmg/-/electron-installer-dmg-5.0.1.tgz",
@@ -4018,12 +4320,238 @@
         "appdmg": "^0.6.4"
       }
     },
+    "node_modules/electron-installer-redhat": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/electron-installer-redhat/-/electron-installer-redhat-3.4.0.tgz",
+      "integrity": "sha512-gEISr3U32Sgtj+fjxUAlSDo3wyGGq6OBx7rF5UdpIgbnpUvMN4W5uYb0ThpnAZ42VEJh/3aODQXHbFS4f5J3Iw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^1.0.0",
+        "debug": "^4.1.1",
+        "electron-installer-common": "^0.10.2",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.15",
+        "word-wrap": "^1.2.3",
+        "yargs": "^16.0.2"
+      },
+      "bin": {
+        "electron-installer-redhat": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/@malept/cross-spawn-promise": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
+      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/electron-installer-redhat/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-installer-redhat/node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.307",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
       "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/electron-winstaller": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
+      "integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@electron/asar": "^3.2.1",
+        "debug": "^4.1.1",
+        "fs-extra": "^7.0.1",
+        "lodash": "^4.17.21",
+        "temp": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@electron/windows-sign": "^1.1.2"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/electron/node_modules/@electron/get": {
       "version": "2.0.3",
@@ -4770,6 +5298,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/gar": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.4.tgz",
+      "integrity": "sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -4810,6 +5347,21 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-folder-size": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-2.0.1.tgz",
+      "integrity": "sha512-+CEb+GDCM7tkOS2wdMKTn9vU7DgnKUTuDlehkNJKNSovdCOVxs14OfKCk4cvSaR3za4gj+OBdl9opPN9xrJ0zA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "gar": "^1.0.4",
+        "tiny-each-async": "2.0.3"
+      },
+      "bin": {
+        "get-folder-size": "bin/get-folder-size"
       }
     },
     "node_modules/get-package-info": {
@@ -7793,6 +8345,50 @@
         "node": ">=8"
       }
     },
+    "node_modules/temp": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
+      "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1",
+        "rimraf": "~2.6.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/temp/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/temp/node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/terser": {
       "version": "5.46.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
@@ -7853,6 +8449,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-each-async": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-each-async/-/tiny-each-async-2.0.3.tgz",
+      "integrity": "sha512-5ROII7nElnAirvFn8g7H7MtpfV1daMcyfTGQwsn/x2VtyV+VPiO5CjReCJtWLvoKTDEDmZocf3cNPraiMnBXLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -7912,6 +8516,28 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/tmp-promise/node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/tn1150": {
@@ -8353,6 +8979,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,10 @@
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.6.0",
+    "@electron-forge/maker-deb": "^7.6.0",
     "@electron-forge/maker-dmg": "^7.6.0",
+    "@electron-forge/maker-rpm": "^7.6.0",
+    "@electron-forge/maker-squirrel": "^7.6.0",
     "@electron-forge/maker-zip": "^7.6.0",
     "@electron-forge/plugin-vite": "^7.6.0",
     "@types/react": "^19.2.14",

--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -3,7 +3,7 @@ import { createInterface } from "node:readline";
 import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
-import type { BrowserWindow } from "electron";
+import { app, type BrowserWindow } from "electron";
 import { loadConfig } from "./config.js";
 import { resolveLlmApiKey, resolveGalaxyApiKey } from "./secure-config.js";
 import { loadSessionHistory } from "./session-replay.js";
@@ -37,8 +37,20 @@ function buildSecretEnv(): Record<string, string> {
   return env;
 }
 
-// Resolve the loom entry point relative to the app
-const LOOM_BIN = path.resolve(__dirname, "../../../bin/loom.js");
+// Resolve the loom entry point. In dev (`electron-forge start`), Loom lives at
+// the repo root next to app/. In packaged builds, the prePackage hook stages
+// Loom into Resources/loom/ via electron-packager's extraResource so the brain
+// runs out of an installed bundle, not a path that walks up out of the .app.
+// `app` is undefined when this module is imported outside an Electron runtime
+// (e.g. vitest), so optional-chain through `app.isPackaged` to fall back to dev.
+function resolveLoomBin(): string {
+  if (app?.isPackaged) {
+    return path.join(process.resourcesPath, "loom", "bin", "loom.js");
+  }
+  return path.resolve(__dirname, "../../../bin/loom.js");
+}
+
+const LOOM_BIN = resolveLoomBin();
 
 export type AgentStatus = "running" | "stopped" | "error";
 

--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -50,7 +50,20 @@ function resolveLoomBin(): string {
   return path.resolve(__dirname, "../../../bin/loom.js");
 }
 
+// Resolve the Node binary the brain runs under. Dev assumes Node 20+ on PATH.
+// Packaged Orbit ships its own Node next to Loom (Resources/node/) so users
+// don't need to have Node installed; this also keeps native module ABI in sync
+// with whatever Node ran `npm ci` during prePackage staging.
+function resolveNodeBin(): string {
+  if (app?.isPackaged) {
+    const nodeName = process.platform === "win32" ? "node.exe" : path.join("bin", "node");
+    return path.join(process.resourcesPath, "node", nodeName);
+  }
+  return "node";
+}
+
 const LOOM_BIN = resolveLoomBin();
+const NODE_BIN = resolveNodeBin();
 
 export type AgentStatus = "running" | "stopped" | "error";
 
@@ -242,14 +255,14 @@ export class AgentManager {
 
     const fresh = this.nextStartIsFresh;
     this.nextStartIsFresh = false;
-    log("starting agent", { bin: LOOM_BIN, cwd: this.cwd, continue: args.includes("--continue"), fresh });
+    log("starting agent", { node: NODE_BIN, bin: LOOM_BIN, cwd: this.cwd, continue: args.includes("--continue"), fresh });
 
     try {
       // Decrypted API keys flow to the brain via env so the child never reads
       // plaintext from disk. buildSecretEnv re-reads config each spawn so
       // key rotation in the settings UI takes effect on restart without
       // needing to plumb explicit invalidation.
-      this.process = spawn("node", args, {
+      this.process = spawn(NODE_BIN, args, {
         stdio: ["pipe", "pipe", "pipe"],
         cwd: this.cwd,
         env: {

--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -62,8 +62,19 @@ function resolveNodeBin(): string {
   return "node";
 }
 
+// Bundled uv directory (contains uv + uvx). When packaged, prepend this to
+// the brain's PATH so `command: "uvx"` in mcp.json resolves the shipped
+// binary rather than depending on the user's system uv install.
+function resolveUvDir(): string | null {
+  if (app?.isPackaged) {
+    return path.join(process.resourcesPath, "uv");
+  }
+  return null;
+}
+
 const LOOM_BIN = resolveLoomBin();
 const NODE_BIN = resolveNodeBin();
+const UV_DIR = resolveUvDir();
 
 export type AgentStatus = "running" | "stopped" | "error";
 
@@ -140,6 +151,12 @@ function buildBrainEnv(fresh: boolean): NodeJS.ProcessEnv {
   // fresh-session sentinel for /new flows.
   env.LOOM_SHELL_KIND = "orbit";
   if (fresh) env.LOOM_FRESH_SESSION = "1";
+  // Prepend the bundled uv directory to PATH when packaged so MCP servers
+  // configured with `command: "uvx"` (Galaxy MCP) find the shipped binary.
+  if (UV_DIR) {
+    const sep = process.platform === "win32" ? ";" : ":";
+    env.PATH = `${UV_DIR}${sep}${env.PATH ?? ""}`;
+  }
   return env;
 }
 

--- a/app/vite.renderer.config.ts
+++ b/app/vite.renderer.config.ts
@@ -1,8 +1,21 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default defineConfig({
   root: "src/renderer",
+  // electron-forge's plugin-vite defaults outDir to `.vite/renderer/<name>`
+  // relative to vite root. Because we override root to `src/renderer`, the
+  // default would land at `src/renderer/.vite/renderer/main_window/` -- but
+  // the packaged loader (and MAIN_WINDOW_VITE_NAME) looks under the app dir.
+  // Pin outDir to an absolute path to keep the two sides in agreement.
+  build: {
+    outDir: path.resolve(__dirname, ".vite/renderer/main_window"),
+    emptyOutDir: true,
+  },
   plugins: [react()],
   server: {
     port: 5199,

--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ fi
 
 # Install loom
 info "Installing loom..."
-npm install -g loom
+npm install -g @galaxyproject/loom
 success "loom installed"
 
 echo ""

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "smoke:pack": "node scripts/smoke-pack.mjs",
+    "prepublishOnly": "npm run typecheck && npm test && npm run smoke:pack"
   },
   "devDependencies": {
     "@mariozechner/pi-ai": "^0.70.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "loom",
+  "name": "@galaxyproject/loom",
   "version": "0.1.0",
   "type": "module",
   "description": "AI co-scientist for Galaxy bioinformatics, built on Pi.dev",
@@ -15,6 +15,16 @@
     "type": "git",
     "url": "https://github.com/galaxyproject/pi-galaxy-analyst"
   },
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "bin/",
+    "extensions/",
+    "shared/",
+    "README.md",
+    "LICENSE"
+  ],
   "bin": {
     "loom": "./bin/loom.js"
   },

--- a/scripts/smoke-pack.mjs
+++ b/scripts/smoke-pack.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Tarball smoke test: npm-pack the Loom package, extract into a tmpdir,
+// install runtime deps, and run `node bin/loom.js --help` to verify the
+// published surface is self-contained and at least starts up.
+//
+// Usage: `npm run smoke:pack` (also wired as `prepublishOnly`).
+
+import { execFileSync, execSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const tmp = mkdtempSync(join(tmpdir(), "loom-smoke-"));
+let ok = false;
+
+try {
+  console.log(`[smoke] tmp dir: ${tmp}`);
+
+  // 1. Pack into the tmp dir.
+  console.log(`[smoke] npm pack`);
+  const packOutput = execSync(`npm pack --pack-destination ${JSON.stringify(tmp)}`, {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  }).trim();
+  // npm pack prints the tarball filename on its last line.
+  const tarball = packOutput.split("\n").pop().trim();
+  const tarballPath = join(tmp, tarball);
+  console.log(`[smoke] tarball: ${tarballPath}`);
+
+  // 2. Extract.
+  const extractDir = join(tmp, "extracted");
+  execSync(`mkdir -p ${JSON.stringify(extractDir)}`);
+  execSync(
+    `tar -xzf ${JSON.stringify(tarballPath)} -C ${JSON.stringify(extractDir)}`,
+  );
+  const pkgDir = join(extractDir, "package");
+  console.log(`[smoke] extracted to ${pkgDir}`);
+
+  // 3. Install runtime deps -- mirrors what `npm install -g` would do.
+  console.log(`[smoke] npm install (runtime deps only) -- this takes ~30s`);
+  execSync("npm install --omit=dev --omit=optional --no-audit --no-fund", {
+    cwd: pkgDir,
+    stdio: "inherit",
+  });
+
+  // 4. Run loom --help.
+  console.log(`[smoke] node bin/loom.js --help`);
+  const out = execFileSync("node", ["bin/loom.js", "--help"], {
+    cwd: pkgDir,
+    encoding: "utf8",
+  });
+  if (!out || out.trim().length < 20) {
+    throw new Error(`empty/short output from --help: ${JSON.stringify(out)}`);
+  }
+  console.log(`[smoke] --help output: ${out.split("\n").length} lines`);
+
+  ok = true;
+  console.log(`[smoke] OK`);
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+  process.exit(ok ? 0 : 1);
+}


### PR DESCRIPTION
## Summary

Packaging milestone -- a fresh-box install of Orbit now bootstraps a
working brain end-to-end, and Loom is ready to publish to npm as
`@galaxyproject/loom`.

Two coupled things land together:

**Orbit is self-contained.** A user with no Node, no uv, and no
toolchain can install a packaged Orbit and the brain spawns + Galaxy
MCP works. The `prePackage` hook stages Loom (`bin/extensions/shared/`
+ a clean `npm ci --omit=dev`), downloads a matching Node from
nodejs.org (matching `process.versions.node` so native module ABI from
`npm ci` aligns with the bundled binary), and downloads the latest
astral-sh/uv release tarball -- all into
`Contents/Resources/{loom,node,uv}/`. `agent.ts` resolves the brain
via `process.resourcesPath` when `app.isPackaged` and prepends the
bundled uv directory to the brain's PATH so Pi's MCP runtime finds the
shipped uvx.

**Loom is publishable.** Renamed to `@galaxyproject/loom`, files
allowlist trims the published surface from 138 files / 1.5MB to 39
files / 66KB, `engines.node>=20` declared, MIT LICENSE in place.
`npm run smoke:pack` packs/extracts/installs/runs as a `prepublishOnly`
gate so a broken allowlist or bin entry can't sneak past `npm publish`.

## Issues fixed

- Closes #50 -- `agent.ts` walked `__dirname` up out of `app/` looking
  for `bin/loom.js`, which works in dev but isn't a path that exists
  in a packaged Orbit. Now keys off `app.isPackaged`.
- Closes #51 -- `vite.renderer.config.ts` had `root: "src/renderer"`
  so plugin-vite's default outDir landed the build at
  `app/src/renderer/.vite/renderer/main_window/` while the packaged
  loader still expected `app/.vite/renderer/main_window/`. Pinned
  outDir to an absolute path.

## Bundle size

After trim: `Resources/` at 417MB
- `loom/` -- 238MB (mostly node_modules)
- `node/` -- 131MB (Node 22, ABI-aligned with built natives)
- `uv/` -- 46MB (uv 0.11.8)

Trim landed ~91MB of known-safe drops: Node `include/` headers (~59MB,
compile-time-only), docs/man, and koffi's 17 unused platform prebuilt
slots (~33MB).

## Cross-platform

Bundle side works cross-platform -- `stageNodeBundle` and
`stageUvBundle` derive URLs from `process.platform`/`process.arch`,
and Windows asset layouts were verified. Forge maker config covers
darwin (DMG + ZIP), linux (deb + rpm + ZIP), and win32 (Squirrel +
ZIP), each platform-filtered.

**Untested on Windows/Linux** -- needs a real `npm run make` on those
platforms before we trust it. macOS make is verified.

## Out of scope

- Code signing / notarization -- needs Apple Developer keys.
- Auto-update -- needs a release feed.
- npm workspace migration -- explicitly deferred until packaging is
  stable.

## Test plan

- [x] `npm test` -- 130 tests pass
- [x] `npm run typecheck` -- clean
- [x] `cd app && npx tsc --noEmit` -- clean
- [x] `npm run smoke:pack` -- pack/extract/install/run cycle in ~11s
- [x] `cd app && npm run make` on macOS -- DMG + ZIP, brain RPC-streams
  cleanly from the bundle
- [ ] `npm run make` on Windows -- pending (you offered to test)
- [ ] `npm run make` on Linux -- pending
- [ ] Real DMG install on a fresh macOS box
- [ ] `npm publish --dry-run` confirms the tarball shape

## Naming aside

Small README paragraph about the cosmic-web naming -- galactic
filaments are the universe's woven structure of dark matter linking
galaxies, so Loom and Orbit name what they actually do.