### PR TITLE
Add ESLint and Prettier hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run precommit

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+node_modules/
+app/node_modules/
+web/node_modules/
+
+dist/
+**/.vite/
+app/dist/
+app/out/
+web/dist/
+coverage/
+
+.worktrees/
+.claude/
+
+*.jsonl
+*-notebook.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "endOfLine": "lf",
+  "printWidth": 100,
+  "proseWrap": "preserve",
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@
 - Each project directory gets a `notebook.md` and `activity.jsonl`,
   auto-initialized on session start. The notebook is git-tracked
   (auto-committed when Loom owns the repo, i.e. `git config
-  loom.managed true` -- set automatically when Loom runs `git init`,
+loom.managed true` -- set automatically when Loom runs `git init`,
   manual opt-in for pre-existing repos). `activity.jsonl` is a
   per-session sidecar and is gitignored.
 
@@ -77,18 +77,18 @@ Question: how do mtDNA variants distribute across tissues in this dataset?
 ### Steps
 
 - [ ] 1. **QC FASTQ** {#plan-a-step-1} — fastp adapter trim + per-base QC
-       Routing: local
+     Routing: local
 - [ ] 2. **Reference index** {#plan-a-step-2} — bwa index of chrM
-       Routing: local
+     Routing: local
 - [ ] 3. **Read alignment** {#plan-a-step-3} — bwa mem PE 4 samples
-       Routing: Galaxy (bwa-mem2/2.2.1)
+     Routing: Galaxy (bwa-mem2/2.2.1)
 - ...
 
 ### Parameters
 
 | Step | Parameter | Value |
-| --- | --- | --- |
-| 1   | min_qual  | 20    |
+| ---- | --------- | ----- |
+| 1    | min_qual  | 20    |
 ```
 
 Conventions:
@@ -108,8 +108,9 @@ driven (e.g. "draft a plan for variant calling on this data").
 
 ## Galaxy integration
 
-Three operating modes are an *outcome* of the plan you draft, not a
+Three operating modes are an _outcome_ of the plan you draft, not a
 configuration setting:
+
 - **local** — every step runs locally
 - **hybrid** — some local, some Galaxy
 - **remote** — entire plan is one Galaxy workflow invocation
@@ -192,12 +193,12 @@ quick commands, 3600 s short pipelines, 86400 s overnight. Prefer
 
 Loom registers a small set of tools at the extension layer:
 
-| Category | Tools |
-|----------|-------|
-| GTN tutorials | `gtn_search`, `gtn_fetch` |
-| Skills | `skills_fetch` (fetch SKILL.md / reference docs from configured repos) |
-| Galaxy invocations | `galaxy_invocation_record`, `galaxy_invocation_check_all`, `galaxy_invocation_check_one` |
-| Multi-agent (experimental) | `team_dispatch` (gated by `LOOM_TEAM_DISPATCH=1`) |
+| Category                     | Tools                                                                                           |
+| ---------------------------- | ----------------------------------------------------------------------------------------------- |
+| GTN tutorials                | `gtn_search`, `gtn_fetch`                                                                       |
+| Skills                       | `skills_fetch` (fetch SKILL.md / reference docs from configured repos)                          |
+| Galaxy invocations           | `galaxy_invocation_record`, `galaxy_invocation_check_all`, `galaxy_invocation_check_one`        |
+| Multi-agent (experimental)   | `team_dispatch` (gated by `LOOM_TEAM_DISPATCH=1`)                                               |
 | Session index (experimental) | `chat_search`, `chat_session_context`, `chat_find_tool_calls` (gated by `LOOM_SESSION_INDEX=1`) |
 
 Galaxy MCP (separately registered when credentials are present)
@@ -212,12 +213,12 @@ There are no `analysis_*` plan tools. Plans are markdown sections.
 
 ## Slash commands
 
-| Command | What it does |
-|---------|-------------|
-| `/notebook` | View current notebook content |
-| `/status` | Galaxy connection + notebook path summary |
-| `/connect [name]` | Connect to Galaxy (prompts for credentials, or switches profile) |
-| `/profiles` | List saved Galaxy server profiles |
+| Command                   | What it does                                                           |
+| ------------------------- | ---------------------------------------------------------------------- |
+| `/notebook`               | View current notebook content                                          |
+| `/status`                 | Galaxy connection + notebook path summary                              |
+| `/connect [name]`         | Connect to Galaxy (prompts for credentials, or switches profile)       |
+| `/profiles`               | List saved Galaxy server profiles                                      |
 | `/execute` (alias `/run`) | Tell the agent to run the next pending step in the latest plan section |
 
 ## Communication Style

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Loom turns a working directory into a co-scientist project: ad-hoc exploration, 
 
 **Loom** is the agent brain — the Pi.dev runtime in [`extensions/loom/`](extensions/loom/), the system-prompt context, Galaxy invocation tracking, the skills system, and the RPC contract. Run it directly from the terminal with `loom` (`npm install -g @galaxyproject/loom`) or through **Orbit** (in [`app/`](app/)), the Electron desktop shell with a chat + tabbed-artifact layout.
 
-The names trace real cosmology. The universe's large-scale structure is the *cosmic web* -- galaxies strung along filaments of dark matter, woven into sheets and voids. Loom weaves your research record the way the cosmic web weaves galaxies; Orbit is the electron shell you observe it from.
+The names trace real cosmology. The universe's large-scale structure is the _cosmic web_ -- galaxies strung along filaments of dark matter, woven into sheets and voids. Loom weaves your research record the way the cosmic web weaves galaxies; Orbit is the electron shell you observe it from.
 
 Future shells — a Galaxy-embedded web UI, a hosted server mode, anything else — talk to the same brain over RPC.
 
@@ -108,9 +108,9 @@ frequencies across tissues.
 
 ### Parameters
 
-| Step | Tool | Parameter | Default | Value | Description |
-| --- | --- | --- | --- | --- | --- |
-| 1 | fastp | min_qual | 20 | 20 | minimum base quality |
+| Step | Tool  | Parameter | Default | Value | Description          |
+| ---- | ----- | --------- | ------- | ----- | -------------------- |
+| 1    | fastp | min_qual  | 20      | 20    | minimum base quality |
 ```
 
 Conventions:
@@ -138,7 +138,7 @@ When Galaxy is connected, the agent surveys Galaxy resources before drafting:
 - A full IWC workflow match → propose the plan as a single Galaxy invocation (mode: **remote**).
 - Otherwise step-by-step: heavy compute (alignment, large variant calling, big assemblies) → Galaxy if the tool is available; light/exploratory (parsing, awk/sed/jq, small scripts) → local.
 
-The three operating modes (**local** / **hybrid** / **remote**) are an *outcome* of the plan, not a configuration setting.
+The three operating modes (**local** / **hybrid** / **remote**) are an _outcome_ of the plan, not a configuration setting.
 
 ### Galaxy invocation tracking
 
@@ -192,8 +192,17 @@ Add your own repos in **Preferences → Skills**. Each entry is `{ name, url, br
 {
   "skills": {
     "repos": [
-      { "name": "galaxy-skills", "url": "https://github.com/galaxyproject/galaxy-skills", "enabled": true },
-      { "name": "galaxy-genome-skills", "url": "https://github.com/galaxyproject/galaxy-genome-skills", "branch": "main", "enabled": true }
+      {
+        "name": "galaxy-skills",
+        "url": "https://github.com/galaxyproject/galaxy-skills",
+        "enabled": true
+      },
+      {
+        "name": "galaxy-genome-skills",
+        "url": "https://github.com/galaxyproject/galaxy-genome-skills",
+        "branch": "main",
+        "enabled": true
+      }
     ]
   }
 }
@@ -415,7 +424,12 @@ Loom uses a single brain-level config at `~/.loom/config.json`. Every consumer (
   },
   "skills": {
     "repos": [
-      { "name": "galaxy-skills", "url": "https://github.com/galaxyproject/galaxy-skills", "branch": "main", "enabled": true }
+      {
+        "name": "galaxy-skills",
+        "url": "https://github.com/galaxyproject/galaxy-skills",
+        "branch": "main",
+        "enabled": true
+      }
     ]
   },
   "defaultCwd": "~/analyses",
@@ -483,47 +497,47 @@ CodeBurn auto-detects Loom/Pi sessions under `~/.pi/agent/sessions/` (Pi is a fi
 
 Type `/` in the chat to open the autocomplete popup. Tab to accept; Enter still submits past it.
 
-| Command | What it does |
-|---------|-------------|
-| `/model <name>` | Switch the LLM model (e.g. `/model sonnet`, `/model claude-opus-4-6`) |
-| `/new` | Start a fresh session (Orbit only). Confirms before deleting the existing notebook |
-| `/resume` | Restart the agent and replay the prior session's chat |
-| `/chat` | Restore the chat pane from the session transcript without restarting the agent |
-| `/notebook` | Show the notebook content in the Notebook tab |
-| `/status` | Galaxy connection + notebook path summary |
-| `/summarize [N [M]]` | Append a summary of prompts N..M into the notebook |
-| `/cost` | Append the session token/cost breakdown to the notebook |
-| `/connect [name]` | Open Galaxy connection settings (or switch to an existing profile) |
-| `/profiles` | List saved Galaxy server profiles |
-| `/execute` (alias `/run`) | Tell the agent to advance the next pending step in the latest plan section |
-| `/help` | Show this list |
+| Command                   | What it does                                                                       |
+| ------------------------- | ---------------------------------------------------------------------------------- |
+| `/model <name>`           | Switch the LLM model (e.g. `/model sonnet`, `/model claude-opus-4-6`)              |
+| `/new`                    | Start a fresh session (Orbit only). Confirms before deleting the existing notebook |
+| `/resume`                 | Restart the agent and replay the prior session's chat                              |
+| `/chat`                   | Restore the chat pane from the session transcript without restarting the agent     |
+| `/notebook`               | Show the notebook content in the Notebook tab                                      |
+| `/status`                 | Galaxy connection + notebook path summary                                          |
+| `/summarize [N [M]]`      | Append a summary of prompts N..M into the notebook                                 |
+| `/cost`                   | Append the session token/cost breakdown to the notebook                            |
+| `/connect [name]`         | Open Galaxy connection settings (or switch to an existing profile)                 |
+| `/profiles`               | List saved Galaxy server profiles                                                  |
+| `/execute` (alias `/run`) | Tell the agent to advance the next pending step in the latest plan section         |
+| `/help`                   | Show this list                                                                     |
 
 ## Tool reference
 
 Loom registers a small set of extension tools. Plans, decisions, results, and interpretation all live as markdown sections in `notebook.md` — the agent maintains them via the standard `Edit`/`Write` tools.
 
-| Category | Tools |
-|----------|-------|
-| **GTN tutorials** | `gtn_search`, `gtn_fetch` |
-| **Galaxy invocations** | `galaxy_invocation_record`, `galaxy_invocation_check_all`, `galaxy_invocation_check_one` |
-| **Skills** | `skills_fetch` (fetch SKILL.md / reference docs from configured repos) |
-| **Multi-agent (experimental)** | `team_dispatch` (gated by `LOOM_TEAM_DISPATCH=1`) |
+| Category                       | Tools                                                                                    |
+| ------------------------------ | ---------------------------------------------------------------------------------------- |
+| **GTN tutorials**              | `gtn_search`, `gtn_fetch`                                                                |
+| **Galaxy invocations**         | `galaxy_invocation_record`, `galaxy_invocation_check_all`, `galaxy_invocation_check_one` |
+| **Skills**                     | `skills_fetch` (fetch SKILL.md / reference docs from configured repos)                   |
+| **Multi-agent (experimental)** | `team_dispatch` (gated by `LOOM_TEAM_DISPATCH=1`)                                        |
 
 Galaxy MCP (registered separately when credentials are present) provides `galaxy_connect`, `galaxy_search_tools_by_name`, `galaxy_run_tool`, `galaxy_invoke_workflow`, `galaxy_search_iwc`, `get_iwc_workflows`, `import_workflow_from_iwc`, user-defined tool lifecycle (`galaxy_create_user_tool`, `galaxy_list_user_tools`, `galaxy_run_user_tool`, `galaxy_delete_user_tool`), history/dataset operations, and more.
 
 ## Tech stack
 
-| Component | Technology |
-|---|---|
-| Agent | Pi.dev (`@mariozechner/pi-coding-agent`) |
-| MCP bridge | `pi-mcp-adapter`, `uvx galaxy-mcp` |
-| Language | TypeScript (strict) |
-| Tests | Vitest |
-| Desktop | Electron 35 |
-| Build | Vite + electron-forge |
-| Markdown | `marked` |
-| Fonts | Inter (body), JetBrains Mono (code) |
-| Theme | Galaxy brand dark (`#2c3143` + gold accent `#ffd700`) |
+| Component  | Technology                                            |
+| ---------- | ----------------------------------------------------- |
+| Agent      | Pi.dev (`@mariozechner/pi-coding-agent`)              |
+| MCP bridge | `pi-mcp-adapter`, `uvx galaxy-mcp`                    |
+| Language   | TypeScript (strict)                                   |
+| Tests      | Vitest                                                |
+| Desktop    | Electron 35                                           |
+| Build      | Vite + electron-forge                                 |
+| Markdown   | `marked`                                              |
+| Fonts      | Inter (body), JetBrains Mono (code)                   |
+| Theme      | Galaxy brand dark (`#2c3143` + gold accent `#ffd700`) |
 
 ## Terminal-only validation
 

--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -160,9 +160,7 @@ async function stageUvBundle(): Promise<void> {
   const key = `${process.platform}-${process.arch}`;
   const target = UV_TARGETS[key];
   if (!target) {
-    throw new Error(
-      `[loom-stage] no uv target mapping for ${key}; add it to UV_TARGETS.`,
-    );
+    throw new Error(`[loom-stage] no uv target mapping for ${key}; add it to UV_TARGETS.`);
   }
   const isWin = process.platform === "win32";
   const ext = isWin ? "zip" : "tar.gz";
@@ -191,10 +189,9 @@ async function stageUvBundle(): Promise<void> {
   } else {
     // Tarball lays out as uv-<target>/uv + uv-<target>/uvx; --strip-components=1
     // flattens that into UV_STAGE_DIR/uv + UV_STAGE_DIR/uvx.
-    execSync(
-      `tar -xzf "${tarballPath}" -C "${UV_STAGE_DIR}" --strip-components=1`,
-      { stdio: "inherit" },
-    );
+    execSync(`tar -xzf "${tarballPath}" -C "${UV_STAGE_DIR}" --strip-components=1`, {
+      stdio: "inherit",
+    });
   }
 }
 

--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -170,11 +170,11 @@ export class AgentManager {
   private pendingResponses = new Map<string, PendingResponse>();
   private idCounter = 0;
   private cwd: string;
-  private hasStartedBefore = false;  // → use --continue on restart to preserve chat history
+  private hasStartedBefore = false; // → use --continue on restart to preserve chat history
   private nextStartSkipContinue = false; // → restart in a new cwd without resuming old chat
-  private nextStartIsFresh = false;  // → tells extension to skip notebook auto-load on next start
+  private nextStartIsFresh = false; // → tells extension to skip notebook auto-load on next start
   private mcpBootstrapRestartDone = false; // → guard: only auto-restart once per app lifetime
-  private silentRestarting = false;  // → suppresses status flicker during MCP bootstrap restart
+  private silentRestarting = false; // → suppresses status flicker during MCP bootstrap restart
 
   /**
    * Crash-restart bookkeeping. We allow up to MAX_RESTARTS_PER_WINDOW
@@ -245,7 +245,7 @@ export class AgentManager {
       const encoded = `--${this.cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
       const sessionsDir = path.join(os.homedir(), ".pi", "agent", "sessions", encoded);
       if (!fs.existsSync(sessionsDir)) return false;
-      const files = fs.readdirSync(sessionsDir).filter(f => f.endsWith(".jsonl"));
+      const files = fs.readdirSync(sessionsDir).filter((f) => f.endsWith(".jsonl"));
       return files.length > 0;
     } catch {
       return false;
@@ -273,7 +273,13 @@ export class AgentManager {
 
     const fresh = this.nextStartIsFresh;
     this.nextStartIsFresh = false;
-    log("starting agent", { node: NODE_BIN, bin: LOOM_BIN, cwd: this.cwd, continue: args.includes("--continue"), fresh });
+    log("starting agent", {
+      node: NODE_BIN,
+      bin: LOOM_BIN,
+      cwd: this.cwd,
+      continue: args.includes("--continue"),
+      fresh,
+    });
 
     try {
       // Decrypted API keys flow to the brain via env so the child never reads
@@ -346,15 +352,24 @@ export class AgentManager {
       // Crash. Try a bounded silent restart before surfacing to the user.
       if (this.shouldAutoRestart()) {
         const attempt = this.crashRestartTimes.length;
-        log(`agent crashed (code ${code}); silent restart ${attempt}/${AgentManager.MAX_RESTARTS_PER_WINDOW}`);
-        this.appendShellNote(`[orbit] brain exited with code ${code}; restarting (attempt ${attempt}/${AgentManager.MAX_RESTARTS_PER_WINDOW})`);
+        log(
+          `agent crashed (code ${code}); silent restart ${attempt}/${AgentManager.MAX_RESTARTS_PER_WINDOW}`,
+        );
+        this.appendShellNote(
+          `[orbit] brain exited with code ${code}; restarting (attempt ${attempt}/${AgentManager.MAX_RESTARTS_PER_WINDOW})`,
+        );
         // Defer to next tick so listeners fully unwind before we spawn.
         setTimeout(() => this.start(), 100);
         return;
       }
       log(`agent crashed (code ${code}) and exhausted restart budget`);
-      this.appendShellNote(`[orbit] brain has crashed too many times in 60s; auto-restart disabled`);
-      this.setStatus("error", `Agent crashed repeatedly (code ${code}). Click status badge to open Preferences.`);
+      this.appendShellNote(
+        `[orbit] brain has crashed too many times in 60s; auto-restart disabled`,
+      );
+      this.setStatus(
+        "error",
+        `Agent crashed repeatedly (code ${code}). Click status badge to open Preferences.`,
+      );
     });
 
     spawnedProcess.on("error", (err) => {
@@ -437,7 +452,11 @@ export class AgentManager {
       if (descendants.length === 0) return;
       log(`abort: SIGTERM ${descendants.length} descendant(s)`);
       for (const p of descendants) {
-        try { process.kill(p.pid, "SIGTERM"); } catch { /* already gone */ }
+        try {
+          process.kill(p.pid, "SIGTERM");
+        } catch {
+          /* already gone */
+        }
       }
       // After 3s, SIGKILL anything still alive.
       setTimeout(() => {
@@ -445,8 +464,14 @@ export class AgentManager {
           try {
             process.kill(p.pid, 0); // probe
             log(`abort: SIGKILL stuck pid ${p.pid}`);
-            try { process.kill(p.pid, "SIGKILL"); } catch { /* gone now */ }
-          } catch { /* already exited */ }
+            try {
+              process.kill(p.pid, "SIGKILL");
+            } catch {
+              /* gone now */
+            }
+          } catch {
+            /* already exited */
+          }
         }
       }, 3000);
     } catch (err) {

--- a/app/src/main/files-handler.ts
+++ b/app/src/main/files-handler.ts
@@ -14,10 +14,10 @@ import * as path from "node:path";
 
 export interface FileNode {
   name: string;
-  relPath: string;              // always "" for root, otherwise relative to cwd with forward slashes
+  relPath: string; // always "" for root, otherwise relative to cwd with forward slashes
   type: "file" | "directory";
-  size?: number;                // files only
-  children?: FileNode[];        // directories only
+  size?: number; // files only
+  children?: FileNode[]; // directories only
 }
 
 const FS_BLOCKLIST = new Set([
@@ -37,7 +37,7 @@ const FS_BLOCKLIST = new Set([
 ]);
 
 const MAX_DEPTH = 8;
-const MAX_ENTRIES_PER_DIR = 2000;    // refuse to enumerate pathological dirs
+const MAX_ENTRIES_PER_DIR = 2000; // refuse to enumerate pathological dirs
 const MAX_READ_BYTES = 5 * 1024 * 1024; // 5 MB — full read up to here
 const MAX_PREVIEW_BYTES = 1024 * 1024 * 1024; // 1 GB — hard refuse above this
 const PREVIEW_LINE_COUNT = 10;
@@ -50,20 +50,58 @@ const PREVIEW_BYTE_BUDGET = 64 * 1024; // 64 KB cap on the head we read
 // the user. Files outside this set in the (5 MB, 1 GB] band get the same
 // "too large" rejection they got before head-preview existed.
 const TEXT_PREVIEW_EXTS = new Set([
-  ".md", ".txt", ".log", ".rst",
-  ".py", ".js", ".ts", ".tsx", ".jsx", ".sh", ".rb", ".pl", ".r", ".go", ".rs",
-  ".json", ".jsonl", ".yml", ".yaml", ".toml", ".ini", ".cfg", ".conf",
-  ".xml", ".html", ".htm", ".css",
-  ".csv", ".tsv", ".tab",
-  ".fa", ".fasta", ".fna", ".faa", ".ffn",
-  ".fastq", ".fq",
+  ".md",
+  ".txt",
+  ".log",
+  ".rst",
+  ".py",
+  ".js",
+  ".ts",
+  ".tsx",
+  ".jsx",
+  ".sh",
+  ".rb",
+  ".pl",
+  ".r",
+  ".go",
+  ".rs",
+  ".json",
+  ".jsonl",
+  ".yml",
+  ".yaml",
+  ".toml",
+  ".ini",
+  ".cfg",
+  ".conf",
+  ".xml",
+  ".html",
+  ".htm",
+  ".css",
+  ".csv",
+  ".tsv",
+  ".tab",
+  ".fa",
+  ".fasta",
+  ".fna",
+  ".faa",
+  ".ffn",
+  ".fastq",
+  ".fq",
   ".vcf",
-  ".bed", ".bedgraph", ".wig",
-  ".gff", ".gff3", ".gtf",
+  ".bed",
+  ".bedgraph",
+  ".wig",
+  ".gff",
+  ".gff3",
+  ".gtf",
   ".sam",
-  ".pdb", ".cif",
-  ".nwk", ".newick", ".tree",
-  ".phy", ".phylip",
+  ".pdb",
+  ".cif",
+  ".nwk",
+  ".newick",
+  ".tree",
+  ".phy",
+  ".phylip",
 ]);
 
 function isTextLikeForPreview(name: string): boolean {
@@ -269,7 +307,8 @@ export function registerFilesIpc(getCwd: () => string): void {
         const head = headBuf.subarray(0, bytesRead).toString("utf-8");
         const lines = head.split("\n").slice(0, PREVIEW_LINE_COUNT);
         const previewText = lines.join("\n");
-        const truncatedAtByteBudget = bytesRead === PREVIEW_BYTE_BUDGET && lines.length < PREVIEW_LINE_COUNT;
+        const truncatedAtByteBudget =
+          bytesRead === PREVIEW_BYTE_BUDGET && lines.length < PREVIEW_LINE_COUNT;
         return {
           ok: true,
           size: stat.size,

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -45,7 +45,7 @@ function maskConfig(cfg: LoomConfig): MaskedLoomConfig {
         Object.entries(cfg.galaxy.profiles).map(([k, v]) => [
           k,
           { url: v.url, hasApiKey: Boolean(v.apiKey || v.apiKeyEncrypted) },
-        ])
+        ]),
       ),
     };
   }
@@ -296,37 +296,43 @@ export function registerIpcHandlers(agent: AgentManager): void {
     }
   });
 
-  ipcMain.handle("notebook:clear-artifacts", async (): Promise<{ cleared: boolean; error?: string }> => {
-    const cwd = agent.getCwd();
-    const targets = ["notebook.md", "activity.jsonl", "session.jsonl"];
-    const removed: string[] = [];
-    try {
-      for (const name of targets) {
-        const p = path.join(cwd, name);
-        try {
-          const stat = fs.lstatSync(p);
-          if (stat.isSymbolicLink() || stat.isFile()) {
-            fs.rmSync(p);
-            removed.push(name);
+  ipcMain.handle(
+    "notebook:clear-artifacts",
+    async (): Promise<{ cleared: boolean; error?: string }> => {
+      const cwd = agent.getCwd();
+      const targets = ["notebook.md", "activity.jsonl", "session.jsonl"];
+      const removed: string[] = [];
+      try {
+        for (const name of targets) {
+          const p = path.join(cwd, name);
+          try {
+            const stat = fs.lstatSync(p);
+            if (stat.isSymbolicLink() || stat.isFile()) {
+              fs.rmSync(p);
+              removed.push(name);
+            }
+          } catch {
+            // file didn't exist -- skip
           }
-        } catch {
-          // file didn't exist -- skip
         }
-      }
-      if (removed.length > 0) {
-        try {
-          execSync(`git add -A ${removed.map((n) => `"${n}"`).join(" ")}`, { cwd, stdio: "ignore" });
-          execSync('git commit -m "Cleared previous analysis"', { cwd, stdio: "ignore" });
-        } catch {
-          // git not available or nothing to commit -- best effort
+        if (removed.length > 0) {
+          try {
+            execSync(`git add -A ${removed.map((n) => `"${n}"`).join(" ")}`, {
+              cwd,
+              stdio: "ignore",
+            });
+            execSync('git commit -m "Cleared previous analysis"', { cwd, stdio: "ignore" });
+          } catch {
+            // git not available or nothing to commit -- best effort
+          }
         }
+        return { cleared: true };
+      } catch (err) {
+        log("notebook:clear-artifacts failed:", err);
+        return { cleared: false, error: String(err) };
       }
-      return { cleared: true };
-    } catch (err) {
-      log("notebook:clear-artifacts failed:", err);
-      return { cleared: false, error: String(err) };
-    }
-  });
+    },
+  );
 
   ipcMain.handle("file:open", async (_e, filePath: string) => {
     log("open file:", filePath);
@@ -383,17 +389,14 @@ export function registerIpcHandlers(agent: AgentManager): void {
   // Issue reporter: opens a pre-filled GitHub "new issue" URL in the user's
   // browser. The renderer never gets a generic openExternal capability —
   // we hard-code the repo here so a compromised renderer can't redirect.
-  ipcMain.handle(
-    "report:open-issue",
-    async (_e, payload: { title?: unknown; body?: unknown }) => {
-      const title = typeof payload?.title === "string" ? payload.title : "";
-      const body = typeof payload?.body === "string" ? payload.body : "";
-      const params = new URLSearchParams({ title, body });
-      const url = `https://github.com/galaxyproject/loom/issues/new?${params.toString()}`;
-      await shell.openExternal(url);
-      return { opened: true };
-    },
-  );
+  ipcMain.handle("report:open-issue", async (_e, payload: { title?: unknown; body?: unknown }) => {
+    const title = typeof payload?.title === "string" ? payload.title : "";
+    const body = typeof payload?.body === "string" ? payload.body : "";
+    const params = new URLSearchParams({ title, body });
+    const url = `https://github.com/galaxyproject/loom/issues/new?${params.toString()}`;
+    await shell.openExternal(url);
+    return { opened: true };
+  });
 
   // Model registry — pulls from pi-ai's bundled list so the dropdown stays
   // current with the brain's actual capabilities. Replaces the hand-edited

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -1,4 +1,14 @@
-import { app, BrowserWindow, Menu, dialog, powerMonitor, nativeImage, protocol, net, shell } from "electron";
+import {
+  app,
+  BrowserWindow,
+  Menu,
+  dialog,
+  powerMonitor,
+  nativeImage,
+  protocol,
+  net,
+  shell,
+} from "electron";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import * as fs from "node:fs";
 import path from "node:path";
@@ -244,9 +254,7 @@ function createWindow(cwd: string): void {
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
     mainWindow.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);
   } else {
-    mainWindow.loadFile(
-      path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`)
-    );
+    mainWindow.loadFile(path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`));
   }
 
   agentManager = new AgentManager(mainWindow, cwd);
@@ -295,11 +303,23 @@ function createWindow(cwd: string): void {
     // `activate` would create a new AgentManager while the previous brain
     // subprocess kept running — leaking processes and keeping stale FS
     // watchers / proc-monitor timers alive.
-    try { agentManager?.stop(); } catch (err) { log("agentManager.stop on close failed:", err); }
+    try {
+      agentManager?.stop();
+    } catch (err) {
+      log("agentManager.stop on close failed:", err);
+    }
     agentManager = null;
-    try { procMonitor?.stop(); } catch (err) { log("procMonitor.stop on close failed:", err); }
+    try {
+      procMonitor?.stop();
+    } catch (err) {
+      log("procMonitor.stop on close failed:", err);
+    }
     procMonitor = null;
-    try { stopFilesWatcher(); } catch (err) { log("stopFilesWatcher on close failed:", err); }
+    try {
+      stopFilesWatcher();
+    } catch (err) {
+      log("stopFilesWatcher on close failed:", err);
+    }
     mainWindow = null;
   });
 }

--- a/app/src/main/proc-monitor.ts
+++ b/app/src/main/proc-monitor.ts
@@ -89,52 +89,52 @@ export class ProcMonitor {
  * SIGTERM the brain's tool subprocesses on Stop.
  */
 export async function collectDescendantsOf(agentPid: number): Promise<ProcInfo[]> {
-    // Get all processes with their PID and PPID so we can walk the tree.
-    // Note: macOS ps doesn't support `nlwp` (thread count) — don't request it.
-    const { stdout: psOut } = await execFileP("ps", [
-      "-ax",
-      "-o",
-      "pid=,ppid=,pcpu=,pmem=,rss=,etime=,comm=",
-    ]);
+  // Get all processes with their PID and PPID so we can walk the tree.
+  // Note: macOS ps doesn't support `nlwp` (thread count) — don't request it.
+  const { stdout: psOut } = await execFileP("ps", [
+    "-ax",
+    "-o",
+    "pid=,ppid=,pcpu=,pmem=,rss=,etime=,comm=",
+  ]);
 
-    const all = new Map<number, ProcInfo>();
-    for (const line of psOut.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      // Fields: pid ppid pcpu pmem rss etime command
-      const m = trimmed.match(/^(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+)$/);
-      if (!m) continue;
-      const pid = parseInt(m[1], 10);
-      const ppid = parseInt(m[2], 10);
-      let command = m[7].trim();
-      if (command.length > MAX_COMMAND_LEN) {
-        command = command.slice(0, MAX_COMMAND_LEN - 1) + "…";
-      }
-      all.set(pid, {
-        pid,
-        ppid,
-        pcpu: parseFloat(m[3]) || 0,
-        pmem: parseFloat(m[4]) || 0,
-        rss: parseInt(m[5], 10) || 0,
-        etime: m[6],
-        command,
-      });
+  const all = new Map<number, ProcInfo>();
+  for (const line of psOut.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    // Fields: pid ppid pcpu pmem rss etime command
+    const m = trimmed.match(/^(\d+)\s+(\d+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+)$/);
+    if (!m) continue;
+    const pid = parseInt(m[1], 10);
+    const ppid = parseInt(m[2], 10);
+    let command = m[7].trim();
+    if (command.length > MAX_COMMAND_LEN) {
+      command = command.slice(0, MAX_COMMAND_LEN - 1) + "…";
     }
+    all.set(pid, {
+      pid,
+      ppid,
+      pcpu: parseFloat(m[3]) || 0,
+      pmem: parseFloat(m[4]) || 0,
+      rss: parseInt(m[5], 10) || 0,
+      etime: m[6],
+      command,
+    });
+  }
 
-    // Walk descendants breadth-first from agentPid
-    const descendants: ProcInfo[] = [];
-    const queue = [agentPid];
-    const seen = new Set<number>();
-    while (queue.length > 0) {
-      const parent = queue.shift()!;
-      if (seen.has(parent)) continue;
-      seen.add(parent);
-      for (const [pid, info] of all) {
-        if (info.ppid === parent && pid !== agentPid) {
-          descendants.push(info);
-          queue.push(pid);
-        }
+  // Walk descendants breadth-first from agentPid
+  const descendants: ProcInfo[] = [];
+  const queue = [agentPid];
+  const seen = new Set<number>();
+  while (queue.length > 0) {
+    const parent = queue.shift()!;
+    if (seen.has(parent)) continue;
+    seen.add(parent);
+    for (const [pid, info] of all) {
+      if (info.ppid === parent && pid !== agentPid) {
+        descendants.push(info);
+        queue.push(pid);
       }
     }
-    return descendants;
+  }
+  return descendants;
 }

--- a/app/src/main/session-replay.ts
+++ b/app/src/main/session-replay.ts
@@ -86,7 +86,9 @@ export function loadSessionHistory(
     const msg = evt.message as { role?: string; content?: unknown } | undefined;
     const role = msg?.role;
     if (role !== "user" && role !== "assistant") continue;
-    const blocks: ContentBlock[] = Array.isArray(msg?.content) ? (msg!.content as ContentBlock[]) : [];
+    const blocks: ContentBlock[] = Array.isArray(msg?.content)
+      ? (msg!.content as ContentBlock[])
+      : [];
 
     // Tool results travel in role=user messages; stash them for attachment.
     if (role === "user") {

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -50,10 +50,9 @@ export interface OrbitAPI {
   getState(): Promise<unknown>;
   getCwd(): Promise<string>;
   openFile(filePath: string): Promise<{ opened: boolean; error?: string }>;
-  listFiles(opts?: { includeHidden?: boolean }): Promise<
-    | { ok: true; root: FileNode; cwd: string }
-    | { ok: false; error: string }
-  >;
+  listFiles(opts?: {
+    includeHidden?: boolean;
+  }): Promise<{ ok: true; root: FileNode; cwd: string } | { ok: false; error: string }>;
   readFile(relPath: string): Promise<
     | {
         ok: true;
@@ -79,7 +78,7 @@ export interface OrbitAPI {
   onAgentEvent(callback: (event: AgentEvent) => void): () => void;
   onUiRequest(callback: (request: UiRequest) => void): () => void;
   onAgentStatus(
-    callback: (status: "running" | "stopped" | "error", msg?: string) => void
+    callback: (status: "running" | "stopped" | "error", msg?: string) => void,
   ): () => void;
   getAgentStatus(): Promise<{ status: "running" | "stopped" | "error"; message?: string }>;
   onCwdChanged(callback: (dir: string) => void): () => void;
@@ -98,11 +97,17 @@ export interface OrbitAPI {
   }>;
   openIssueReport(payload: { title: string; body: string }): Promise<{ opened: boolean }>;
   listAllModels(): Promise<
-    | { ok: true; providers: Record<string, Array<{
-        id: string;
-        label: string;
-        pricing: { input: number; output: number; cacheRead?: number; cacheWrite?: number };
-      }>> }
+    | {
+        ok: true;
+        providers: Record<
+          string,
+          Array<{
+            id: string;
+            label: string;
+            pricing: { input: number; output: number; cacheRead?: number; cacheWrite?: number };
+          }>
+        >;
+      }
     | { ok: false; error: string }
   >;
 }
@@ -154,11 +159,8 @@ const api: OrbitAPI = {
   },
 
   onAgentStatus: (callback) => {
-    const handler = (
-      _e: unknown,
-      status: "running" | "stopped" | "error",
-      msg?: string
-    ) => callback(status, msg);
+    const handler = (_e: unknown, status: "running" | "stopped" | "error", msg?: string) =>
+      callback(status, msg);
     ipcRenderer.on("agent:status", handler);
     return () => ipcRenderer.removeListener("agent:status", handler);
   },

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -4,14 +4,8 @@ import { ArtifactPanel } from "./artifacts/artifact-panel.js";
 import { FilesPanel } from "./files/files-panel.js";
 import { FileViewer } from "./files/file-viewer.js";
 import { refreshGalaxyInvocations } from "./galaxy-invocations.js";
-import {
-  LoomWidgetKey,
-  decodeMarkdownWidget,
-} from "../../../shared/loom-shell-contract.js";
-import {
-  ALLOWED_SKILLS_PREFIX,
-  isAllowedSkillUrl,
-} from "../../../shared/loom-config.js";
+import { LoomWidgetKey, decodeMarkdownWidget } from "../../../shared/loom-shell-contract.js";
+import { ALLOWED_SKILLS_PREFIX, isAllowedSkillUrl } from "../../../shared/loom-config.js";
 
 declare global {
   interface Window {
@@ -74,27 +68,28 @@ let streaming = false;
 // Fallback only — populateDynamicModelData() at startup overwrites this from
 // pi-ai's bundled registry (via main IPC) so new models like Opus 4.7 don't
 // require a hand-edit. Update as providers change pricing or add models.
-let PRICING: Record<string, { in: number; out: number; cacheRead?: number; cacheWrite?: number }> = {
-  // Anthropic
-  "claude-opus-4-7":      { in: 15, out: 75, cacheRead: 1.5, cacheWrite: 18.75 },
-  "claude-opus-4-6":      { in: 15, out: 75, cacheRead: 1.5, cacheWrite: 18.75 },
-  "claude-opus-4-5":      { in: 15, out: 75, cacheRead: 1.5, cacheWrite: 18.75 },
-  "claude-sonnet-4-6":    { in: 3, out: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-  "claude-sonnet-4-5":    { in: 3, out: 15, cacheRead: 0.3, cacheWrite: 3.75 },
-  "claude-haiku-4-5":     { in: 1, out: 5, cacheRead: 0.1, cacheWrite: 1.25 },
-  // OpenAI
-  "gpt-4o":               { in: 2.5, out: 10, cacheRead: 1.25 },
-  "gpt-4o-mini":          { in: 0.15, out: 0.6, cacheRead: 0.075 },
-  "gpt-4-turbo":          { in: 10, out: 30 },
-  "o1":                   { in: 15, out: 60, cacheRead: 7.5 },
-  "o1-mini":              { in: 3, out: 12, cacheRead: 1.5 },
-  // Google
-  "gemini-2.5-pro":       { in: 1.25, out: 10 },
-  "gemini-2.5-flash":     { in: 0.15, out: 0.6 },
-  // Ollama (local) — free
-  "qwen3-coder:30b":      { in: 0, out: 0 },
-  "qwen3:8b":             { in: 0, out: 0 },
-};
+let PRICING: Record<string, { in: number; out: number; cacheRead?: number; cacheWrite?: number }> =
+  {
+    // Anthropic
+    "claude-opus-4-7": { in: 15, out: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+    "claude-opus-4-6": { in: 15, out: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+    "claude-opus-4-5": { in: 15, out: 75, cacheRead: 1.5, cacheWrite: 18.75 },
+    "claude-sonnet-4-6": { in: 3, out: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+    "claude-sonnet-4-5": { in: 3, out: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+    "claude-haiku-4-5": { in: 1, out: 5, cacheRead: 0.1, cacheWrite: 1.25 },
+    // OpenAI
+    "gpt-4o": { in: 2.5, out: 10, cacheRead: 1.25 },
+    "gpt-4o-mini": { in: 0.15, out: 0.6, cacheRead: 0.075 },
+    "gpt-4-turbo": { in: 10, out: 30 },
+    o1: { in: 15, out: 60, cacheRead: 7.5 },
+    "o1-mini": { in: 3, out: 12, cacheRead: 1.5 },
+    // Google
+    "gemini-2.5-pro": { in: 1.25, out: 10 },
+    "gemini-2.5-flash": { in: 0.15, out: 0.6 },
+    // Ollama (local) — free
+    "qwen3-coder:30b": { in: 0, out: 0 },
+    "qwen3:8b": { in: 0, out: 0 },
+  };
 
 interface Usage {
   input: number;
@@ -119,7 +114,9 @@ let sessionCostFromPi: number | null = null;
 let turnCostFromPi: number = 0;
 
 /** Match a model ID against the pricing table (handles date suffixes). */
-function findPricing(model: string): { in: number; out: number; cacheRead?: number; cacheWrite?: number } | null {
+function findPricing(
+  model: string,
+): { in: number; out: number; cacheRead?: number; cacheWrite?: number } | null {
   // Exact match first
   if (PRICING[model]) return PRICING[model];
   // Strip date suffix (e.g. claude-opus-4-6-20250514)
@@ -151,7 +148,8 @@ function computeCost(u: Usage, model: string | null): number | null {
 }
 
 function renderUsage(): void {
-  const total = sessionUsage.input + sessionUsage.output + sessionUsage.cacheRead + sessionUsage.cacheWrite;
+  const total =
+    sessionUsage.input + sessionUsage.output + sessionUsage.cacheRead + sessionUsage.cacheWrite;
   usageTokensEl.textContent = `${formatTokens(total)} tok`;
   usageTokensEl.title =
     `Session usage:\n` +
@@ -291,7 +289,10 @@ document.addEventListener("keydown", (e) => {
     // Allow native Ctrl+B (bold) inside any editable text field — only
     // intercept when focus is outside inputs/textareas/contenteditable.
     const target = e.target as HTMLElement | null;
-    if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) {
+    if (
+      target &&
+      (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
+    ) {
       return;
     }
     e.preventDefault();
@@ -396,7 +397,9 @@ async function refreshGalaxyStatus(): Promise<void> {
   // `hasApiKey: boolean`, never the plaintext apiKey. Checking
   // `profile.apiKey` here used to make the dot stay red even when a key
   // was set, because the field is undefined in the masked shape.
-  const galaxy = cfg.galaxy as { active?: string; profiles?: Record<string, { url?: string; hasApiKey?: boolean }> } | undefined;
+  const galaxy = cfg.galaxy as
+    | { active?: string; profiles?: Record<string, { url?: string; hasApiKey?: boolean }> }
+    | undefined;
   const active = galaxy?.active;
   const profile = active ? galaxy?.profiles?.[active] : undefined;
   const connected = !!(profile?.url && profile?.hasApiKey);
@@ -431,7 +434,10 @@ const execLocalBtn = document.getElementById("exec-mode-local") as HTMLButtonEle
 const execCloudBtn = document.getElementById("exec-mode-cloud") as HTMLButtonElement;
 
 function applyExecModeUi(mode: "local" | "cloud"): void {
-  for (const [btn, btnMode] of [[execLocalBtn, "local"], [execCloudBtn, "cloud"]] as const) {
+  for (const [btn, btnMode] of [
+    [execLocalBtn, "local"],
+    [execCloudBtn, "cloud"],
+  ] as const) {
     const active = btnMode === mode;
     btn.classList.toggle("active", active);
     btn.setAttribute("aria-checked", active ? "true" : "false");
@@ -495,12 +501,15 @@ function wireApiKeyValidation(
   const validateNow = async () => {
     const provider = providerEl.value;
     const key = keyEl.value.trim();
-    if (!key) { setStatus("", ""); return; }
+    if (!key) {
+      setStatus("", "");
+      return;
+    }
     const mySeq = ++seq;
     setStatus("checking", "Checking…");
     try {
       const res = await window.orbit.validateApiKey(provider, key);
-      if (mySeq !== seq) return;  // a newer request superseded this one
+      if (mySeq !== seq) return; // a newer request superseded this one
       if (res.valid) setStatus("valid", "\u2713 Valid");
       else setStatus("invalid", `\u2717 ${res.error || "Invalid"}`);
     } catch (err) {
@@ -549,8 +558,7 @@ welcomeSave.addEventListener("click", async () => {
   const galaxyUrl = welcomeGalaxyUrl.value.trim();
   const galaxyKey = welcomeGalaxyKey.value.trim();
   if (Boolean(galaxyUrl) !== Boolean(galaxyKey)) {
-    welcomeError.textContent =
-      "Galaxy: provide both URL and API key, or leave both blank.";
+    welcomeError.textContent = "Galaxy: provide both URL and API key, or leave both blank.";
     return;
   }
 
@@ -585,7 +593,7 @@ welcomeSkip.addEventListener("click", () => {
   welcomeOverlay.classList.add("hidden");
   chat.addInfoMessage(
     `<i>No LLM provider configured yet. Open <code>Preferences</code> ` +
-    `(Cmd/Ctrl+,) when you're ready to add an API key.</i>`,
+      `(Cmd/Ctrl+,) when you're ready to add an API key.</i>`,
   );
 });
 
@@ -625,10 +633,12 @@ async function populateDynamicModelData(): Promise<void> {
         };
       }
     }
-    if (Object.keys(newModels).length === 0) return;  // never replace with empty
+    if (Object.keys(newModels).length === 0) return; // never replace with empty
     MODELS_BY_PROVIDER = newModels;
     PRICING = newPricing;
-  } catch { /* keep hardcoded fallback */ }
+  } catch {
+    /* keep hardcoded fallback */
+  }
 }
 void populateDynamicModelData();
 
@@ -662,7 +672,12 @@ function commitTurnUsage(): void {
   sessionUsage.cacheRead += turnUsage.cacheRead;
   sessionUsage.cacheWrite += turnUsage.cacheWrite;
   if (currentModel) {
-    const m = perModelUsage.get(currentModel) ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+    const m = perModelUsage.get(currentModel) ?? {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    };
     m.input += turnUsage.input;
     m.output += turnUsage.output;
     m.cacheRead += turnUsage.cacheRead;
@@ -698,12 +713,14 @@ renderUsage();
 // Populate model indicator from config at startup so it shows before the first message
 void (async () => {
   try {
-    const cfg = await window.orbit.getConfig() as { llm?: { model?: string } };
+    const cfg = (await window.orbit.getConfig()) as { llm?: { model?: string } };
     if (cfg.llm?.model) {
       currentModel = cfg.llm.model;
       renderModelIndicator();
     }
-  } catch { /* getConfig may not be available yet */ }
+  } catch {
+    /* getConfig may not be available yet */
+  }
 })();
 
 // ── CWD Display ──────────────────────────────────────────────────────────────
@@ -714,7 +731,9 @@ async function refreshCwd(): Promise<void> {
     cwdPathEl.textContent = cwd;
     cwdPathEl.title = cwd;
     chat.setCwd(cwd);
-  } catch { /* getCwd not available yet */ }
+  } catch {
+    /* getCwd not available yet */
+  }
 }
 
 function resetUiForFreshContext(): void {
@@ -743,7 +762,9 @@ function applyCwdChange(dir: string): void {
   chat.setCwd(dir);
   cwdPathEl.textContent = dir;
   cwdPathEl.title = dir;
-  chat.addInfoMessage(`<i>Switched analysis directory to <code>${dir.replace(/</g, "&lt;")}</code>.</i>`);
+  chat.addInfoMessage(
+    `<i>Switched analysis directory to <code>${dir.replace(/</g, "&lt;")}</code>.</i>`,
+  );
   hasShownStartupWelcome = false;
   // Re-root the file tree, close any open viewer, hide the File tab — the
   // old relPath is meaningless in the new cwd.
@@ -839,15 +860,15 @@ function maybeShowCheaperModelNudge(text: string): void {
   if (!EXEC_COMMAND_RE.test(text)) return;
   if (!currentModel) return;
   const pricing = findPricing(currentModel);
-  if (!pricing || pricing.in < 10) return;  // mid-tier or cheaper — no nudge
+  if (!pricing || pricing.in < 10) return; // mid-tier or cheaper — no nudge
   cheaperNudgeShownThisSession = true;
   chat.addInfoMessage(
     `<i><strong>Heads up:</strong> running plan execution on ` +
-    `<code>${currentModel}</code> ($${pricing.in}/$${pricing.out} per 1M tokens). ` +
-    `Sonnet/Haiku-class models usually do equally well for execution at 5–20× ` +
-    `lower cost — try <code>/model sonnet</code> or <code>/model haiku</code> ` +
-    `before this turn if you want to save. ` +
-    `<a href="#" class="cheaper-nudge-dismiss">Don't show again</a></i>`
+      `<code>${currentModel}</code> ($${pricing.in}/$${pricing.out} per 1M tokens). ` +
+      `Sonnet/Haiku-class models usually do equally well for execution at 5–20× ` +
+      `lower cost — try <code>/model sonnet</code> or <code>/model haiku</code> ` +
+      `before this turn if you want to save. ` +
+      `<a href="#" class="cheaper-nudge-dismiss">Don't show again</a></i>`,
   );
 }
 
@@ -911,7 +932,9 @@ messagesEl.addEventListener("plan-draft-action", (e) => {
   } else if (action === "edit") {
     inputEl.value =
       "Here is the plan with my edits — please revise your draft accordingly:\n\n" +
-      "```plan\n" + body + "\n```";
+      "```plan\n" +
+      body +
+      "\n```";
     inputEl.focus();
     inputEl.dispatchEvent(new Event("input"));
   }
@@ -943,7 +966,9 @@ function formatArgsPreview(args: Record<string, unknown> | undefined): string | 
   if (!args || typeof args !== "object") return undefined;
   const cmd = (args as { command?: unknown }).command;
   if (typeof cmd === "string" && cmd.length > 0) return `$ ${cmd}`;
-  const path = (args as { path?: unknown; file_path?: unknown }).path ?? (args as { file_path?: unknown }).file_path;
+  const path =
+    (args as { path?: unknown; file_path?: unknown }).path ??
+    (args as { file_path?: unknown }).file_path;
   if (typeof path === "string") return path;
   try {
     return JSON.stringify(args);
@@ -959,18 +984,25 @@ interface SlashCommand {
 }
 
 const SLASH_COMMANDS: SlashCommand[] = [
-  { name: "model",     usage: "/model <name>",         description: "switch LLM model" },
-  { name: "new",       description: "start a fresh session" },
-  { name: "resume",    description: "restart agent and replay prior session" },
-  { name: "chat",      description: "restore the chat pane from the session transcript (no agent restart)" },
-  { name: "plan",      description: "show current plan summary" },
-  { name: "status",    description: "show Galaxy connection status" },
-  { name: "notebook",  description: "show notebook info" },
-  { name: "summarize", usage: "/summarize [N [M]]",    description: "summarize prompts N–M into the notebook" },
-  { name: "cost",      description: "append session token/cost breakdown to the notebook" },
+  { name: "model", usage: "/model <name>", description: "switch LLM model" },
+  { name: "new", description: "start a fresh session" },
+  { name: "resume", description: "restart agent and replay prior session" },
+  {
+    name: "chat",
+    description: "restore the chat pane from the session transcript (no agent restart)",
+  },
+  { name: "plan", description: "show current plan summary" },
+  { name: "status", description: "show Galaxy connection status" },
+  { name: "notebook", description: "show notebook info" },
+  {
+    name: "summarize",
+    usage: "/summarize [N [M]]",
+    description: "summarize prompts N–M into the notebook",
+  },
+  { name: "cost", description: "append session token/cost breakdown to the notebook" },
   { name: "decisions", description: "show decision log" },
-  { name: "connect",   description: "open Galaxy connection settings" },
-  { name: "help",      description: "show this help" },
+  { name: "connect", description: "open Galaxy connection settings" },
+  { name: "help", description: "show this help" },
 ];
 
 function escapeHtmlBasic(s: string): string {
@@ -994,7 +1026,7 @@ function handleSlashCommand(text: string): boolean {
       chat.addUserMessage(text);
       chat.addErrorMessage(
         "Usage: /model <name>. Examples: /model sonnet, /model haiku, /model opus, " +
-        "or /model claude-sonnet-4-6 for an exact id."
+          "or /model claude-sonnet-4-6 for an exact id.",
       );
       return true;
     }
@@ -1031,7 +1063,13 @@ function handleSlashCommand(text: string): boolean {
   }
 
   // Loom commands — pass through to agent
-  if (cmd === "plan" || cmd === "status" || cmd === "notebook" || cmd === "decisions" || cmd === "profiles") {
+  if (
+    cmd === "plan" ||
+    cmd === "status" ||
+    cmd === "notebook" ||
+    cmd === "decisions" ||
+    cmd === "profiles"
+  ) {
     chat.addUserMessage(text);
     window.orbit.prompt(`/${cmd}`);
     return true;
@@ -1080,9 +1118,15 @@ function handleSummarize(raw: string, argStr: string): void {
 
   const nums = (argStr.match(/\d+/g) ?? []).map(Number);
   let from: number, to: number;
-  if (nums.length === 0) { from = 1; to = total; }
-  else if (nums.length === 1) { from = to = nums[0]; }
-  else { from = Math.min(nums[0], nums[1]); to = Math.max(nums[0], nums[1]); }
+  if (nums.length === 0) {
+    from = 1;
+    to = total;
+  } else if (nums.length === 1) {
+    from = to = nums[0];
+  } else {
+    from = Math.min(nums[0], nums[1]);
+    to = Math.max(nums[0], nums[1]);
+  }
 
   if (from < 1 || to > total) {
     chat.addUserMessage(raw);
@@ -1145,17 +1189,20 @@ function handleCost(raw: string): void {
     totals.cacheWrite += u.cacheWrite;
     const cost = computeCost(u, model);
     const costStr = cost === null ? "unknown (no pricing entry)" : `$${cost.toFixed(4)}`;
-    if (cost === null) totalCostKnown = false; else grandCost += cost;
+    if (cost === null) totalCostKnown = false;
+    else grandCost += cost;
     rows.push(
       `| \`${model}\` | ${u.input.toLocaleString()} | ${u.output.toLocaleString()} | ` +
-      `${u.cacheRead.toLocaleString()} | ${u.cacheWrite.toLocaleString()} | ${costStr} |`
+        `${u.cacheRead.toLocaleString()} | ${u.cacheWrite.toLocaleString()} | ${costStr} |`,
     );
   }
 
-  const totalCostStr = totalCostKnown ? `$${grandCost.toFixed(4)}` : `≥$${grandCost.toFixed(4)} (some models unpriced)`;
+  const totalCostStr = totalCostKnown
+    ? `$${grandCost.toFixed(4)}`
+    : `≥$${grandCost.toFixed(4)} (some models unpriced)`;
   rows.push(
     `| **Total** | **${totals.input.toLocaleString()}** | **${totals.output.toLocaleString()}** | ` +
-    `**${totals.cacheRead.toLocaleString()}** | **${totals.cacheWrite.toLocaleString()}** | **${totalCostStr}** |`
+      `**${totals.cacheRead.toLocaleString()}** | **${totals.cacheWrite.toLocaleString()}** | **${totalCostStr}** |`,
   );
 
   const table =
@@ -1180,7 +1227,7 @@ function handleCost(raw: string): void {
   chat.addUserMessage(raw);
   chat.addInfoMessage(
     `<i>Asking the agent to append the session cost breakdown to ` +
-    `<code>notebook.md</code>…</i>`,
+      `<code>notebook.md</code>…</i>`,
   );
   chat.showThinking();
   setStatusBadge("thinking", "thinking...");
@@ -1204,7 +1251,9 @@ async function confirmAndResetSession(): Promise<void> {
   }
 
   if (!status.hasContent) {
-    const ok = confirm("Start a fresh session? This will erase the current chat and notebook view.");
+    const ok = confirm(
+      "Start a fresh session? This will erase the current chat and notebook view.",
+    );
     if (!ok) return;
     await resetSession();
     return;
@@ -1266,18 +1315,20 @@ async function showCwdWelcome(prefix?: string): Promise<void> {
   let cwd = "~";
   try {
     cwd = await window.orbit.getCwd();
-  } catch { /* getCwd unavailable */ }
+  } catch {
+    /* getCwd unavailable */
+  }
   // Optional prefix lets callers (e.g. resetSession) merge their own
   // "Started fresh session" line into the same info card so the user
   // doesn't see a stack of three near-identical messages on /new.
   const prefixHtml = prefix ? `<i>${prefix}</i><br>` : "";
   chat.addInfoMessage(
     prefixHtml +
-    `<b>Current working directory:</b> <code>${cwd.replace(/</g, "&lt;")}</code><br>` +
-    // Class instead of id so multiple cwd-welcome cards don't all share
-    // an id, and so the delegated listener wired once below works on
-    // every link regardless of how many welcomes have been shown.
-    `For a new project you may want to <a href="#" class="switch-dir-link">switch to a new directory</a> to keep everything clean.`
+      `<b>Current working directory:</b> <code>${cwd.replace(/</g, "&lt;")}</code><br>` +
+      // Class instead of id so multiple cwd-welcome cards don't all share
+      // an id, and so the delegated listener wired once below works on
+      // every link regardless of how many welcomes have been shown.
+      `For a new project you may want to <a href="#" class="switch-dir-link">switch to a new directory</a> to keep everything clean.`,
   );
 }
 
@@ -1309,7 +1360,7 @@ async function resetSession(): Promise<void> {
 async function switchModelByAlias(originalText: string, alias: string): Promise<void> {
   chat.addUserMessage(originalText);
 
-  const cfg = await window.orbit.getConfig() as { llm?: { provider?: string } };
+  const cfg = (await window.orbit.getConfig()) as { llm?: { provider?: string } };
   const currentProvider = cfg.llm?.provider || "anthropic";
 
   // Search strategy: prefer current provider, then search all providers.
@@ -1319,9 +1370,9 @@ async function switchModelByAlias(originalText: string, alias: string): Promise<
   const search = (p: string): ModelChoice | undefined => {
     const cat = MODELS_BY_PROVIDER[p] || [];
     return (
-      cat.find(m => m.id === alias) ||
-      cat.find(m => m.id.toLowerCase().includes(alias)) ||
-      cat.find(m => m.label.toLowerCase().includes(alias))
+      cat.find((m) => m.id === alias) ||
+      cat.find((m) => m.id.toLowerCase().includes(alias)) ||
+      cat.find((m) => m.label.toLowerCase().includes(alias))
     );
   };
 
@@ -1334,23 +1385,27 @@ async function switchModelByAlias(originalText: string, alias: string): Promise<
     for (const p of Object.keys(MODELS_BY_PROVIDER)) {
       if (p === currentProvider) continue;
       const m = search(p);
-      if (m) { chosen = { provider: p, model: m }; break; }
+      if (m) {
+        chosen = { provider: p, model: m };
+        break;
+      }
     }
   }
 
   if (!chosen) {
     const all = Object.entries(MODELS_BY_PROVIDER)
-      .map(([p, models]) => `  ${p}: ${models.map(m => m.id).join(", ")}`)
+      .map(([p, models]) => `  ${p}: ${models.map((m) => m.id).join(", ")}`)
       .join("\n");
-    chat.addErrorMessage(
-      `No model matches "${alias}". Available models:\n${all}`
-    );
+    chat.addErrorMessage(`No model matches "${alias}". Available models:\n${all}`);
     return;
   }
 
   // Save updated config
-  const current = await window.orbit.getConfig() as Record<string, unknown>;
-  const llm = ((current.llm as Record<string, unknown> | undefined) || {}) as Record<string, unknown>;
+  const current = (await window.orbit.getConfig()) as Record<string, unknown>;
+  const llm = ((current.llm as Record<string, unknown> | undefined) || {}) as Record<
+    string,
+    unknown
+  >;
 
   const switchingProvider = chosen.provider !== currentProvider;
   if (switchingProvider) {
@@ -1373,11 +1428,13 @@ async function switchModelByAlias(originalText: string, alias: string): Promise<
   if (switchingProvider) {
     chat.addInfoMessage(
       `<i>Changed model to <code>${chosen.model.id}</code> ` +
-      `(provider: ${chosen.provider}). Agent restarting…</i><br>` +
-      `<small>If you don't have a ${chosen.provider} API key set in Preferences, the agent will fail to start.</small>`
+        `(provider: ${chosen.provider}). Agent restarting…</i><br>` +
+        `<small>If you don't have a ${chosen.provider} API key set in Preferences, the agent will fail to start.</small>`,
     );
   } else {
-    chat.addInfoMessage(`<i>Changed model to <code>${chosen.model.id}</code>. Agent restarting…</i>`);
+    chat.addInfoMessage(
+      `<i>Changed model to <code>${chosen.model.id}</code>. Agent restarting…</i>`,
+    );
   }
 }
 
@@ -1400,12 +1457,14 @@ function loadPromptHistory(): string[] {
 function savePromptHistory(): void {
   try {
     localStorage.setItem(HISTORY_KEY, JSON.stringify(promptHistory));
-  } catch { /* ignore quota errors */ }
+  } catch {
+    /* ignore quota errors */
+  }
 }
 
 const promptHistory: string[] = loadPromptHistory();
-let historyCursor: number = promptHistory.length;  // index of NEXT slot
-let historyDraft: string = "";  // user's pre-recall buffer
+let historyCursor: number = promptHistory.length; // index of NEXT slot
+let historyDraft: string = ""; // user's pre-recall buffer
 
 function appendHistoryEntry(text: string): void {
   if (!text.trim()) return;
@@ -1577,10 +1636,26 @@ inputEl.addEventListener("keydown", (e) => {
   // within it, Esc dismisses. Enter still submits whatever the user
   // typed — the popup auto-closes as a side effect of submit.
   if (isSlashPopupOpen()) {
-    if (e.key === "ArrowUp")    { e.preventDefault(); moveSlashPopup("up"); return; }
-    if (e.key === "ArrowDown")  { e.preventDefault(); moveSlashPopup("down"); return; }
-    if (e.key === "Tab")        { e.preventDefault(); acceptSlashPopup(slashPopupActive); return; }
-    if (e.key === "Escape")     { e.preventDefault(); closeSlashPopup(); return; }
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      moveSlashPopup("up");
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      moveSlashPopup("down");
+      return;
+    }
+    if (e.key === "Tab") {
+      e.preventDefault();
+      acceptSlashPopup(slashPopupActive);
+      return;
+    }
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeSlashPopup();
+      return;
+    }
     // Enter falls through to the regular submit path below.
   }
 
@@ -1590,7 +1665,11 @@ inputEl.addEventListener("keydown", (e) => {
     recallHistory("up");
     return;
   }
-  if (e.key === "ArrowDown" && shouldRecallOnArrow("down") && historyCursor < promptHistory.length) {
+  if (
+    e.key === "ArrowDown" &&
+    shouldRecallOnArrow("down") &&
+    historyCursor < promptHistory.length
+  ) {
     e.preventDefault();
     recallHistory("down");
     return;
@@ -1639,7 +1718,12 @@ window.orbit.onAgentEvent((event) => {
   tickHeartbeat();
 
   // Capture usage from any event that carries a message with usage
-  if (type === "message_start" || type === "message_update" || type === "message_end" || type === "turn_end") {
+  if (
+    type === "message_start" ||
+    type === "message_update" ||
+    type === "message_end" ||
+    type === "turn_end"
+  ) {
     captureUsage(event as Record<string, unknown>);
   }
 
@@ -1657,7 +1741,8 @@ window.orbit.onAgentEvent((event) => {
 
     case "message_update": {
       // Pi.dev wraps events in assistantMessageEvent
-      const ame = (event as { assistantMessageEvent?: Record<string, unknown> }).assistantMessageEvent;
+      const ame = (event as { assistantMessageEvent?: Record<string, unknown> })
+        .assistantMessageEvent;
       if (!ame) break;
 
       const ameType = ame.type as string;
@@ -1695,7 +1780,9 @@ window.orbit.onAgentEvent((event) => {
     case "message_end": {
       // Commit per-assistant-message usage to the session total
       // Each assistant message = one LLM call billed separately
-      const msg = (event as { message?: { role?: string; stopReason?: string; errorMessage?: string } }).message;
+      const msg = (
+        event as { message?: { role?: string; stopReason?: string; errorMessage?: string } }
+      ).message;
       if (msg?.role === "assistant") {
         commitTurnUsage();
         // Surface assistant-side errors (e.g. 401 invalid API key) so the user
@@ -1742,7 +1829,9 @@ window.orbit.onAgentEvent((event) => {
     case "tool_execution_end": {
       const id = (event as { toolCallId?: string }).toolCallId || "";
       const isError = Boolean((event as { isError?: boolean }).isError);
-      const result = (event as { result?: { content?: Array<{ text?: string }>; details?: unknown } }).result;
+      const result = (
+        event as { result?: { content?: Array<{ text?: string }>; details?: unknown } }
+      ).result;
       const text = result?.content?.[0]?.text;
       const details = (result as { details?: { kind?: string } } | undefined)?.details;
       chat.updateToolCard(id, isError ? "error" : "done", text, details);
@@ -1820,8 +1909,14 @@ function openExtInput(id: string, title: string, placeholder?: string): void {
     cleanup();
   };
   const onKey = (e: KeyboardEvent) => {
-    if (e.key === "Enter") { e.preventDefault(); respond(extInputEl.value); }
-    if (e.key === "Escape") { e.preventDefault(); respond(undefined); }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      respond(extInputEl.value);
+    }
+    if (e.key === "Escape") {
+      e.preventDefault();
+      respond(undefined);
+    }
   };
   const onOk = () => respond(extInputEl.value);
   const onCancel = () => respond(undefined);
@@ -1855,7 +1950,12 @@ function openExtSelect(id: string, title: string, options: string[]): void {
   });
 
   const onCancel = () => respond(undefined);
-  const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") { e.preventDefault(); respond(undefined); } };
+  const onKey = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      respond(undefined);
+    }
+  };
   const cleanup = () => {
     extCancelBtn.removeEventListener("click", onCancel);
     document.removeEventListener("keydown", onKey);
@@ -1873,14 +1973,22 @@ function openExtConfirm(id: string, title: string, message: string): void {
   extOverlay.classList.remove("hidden");
 
   const respond = (confirmed: boolean | undefined) => {
-    window.orbit.respondToUiRequest(id, confirmed === undefined ? { cancelled: true } : { confirmed });
+    window.orbit.respondToUiRequest(
+      id,
+      confirmed === undefined ? { cancelled: true } : { confirmed },
+    );
     hideExtModal();
     cleanup();
   };
   const onYes = () => respond(true);
   const onNo = () => respond(false);
   const onCancel = () => respond(undefined);
-  const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") { e.preventDefault(); respond(undefined); } };
+  const onKey = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      respond(undefined);
+    }
+  };
   const cleanup = () => {
     extAcceptBtn.removeEventListener("click", onYes);
     extDenyBtn.removeEventListener("click", onNo);
@@ -1894,7 +2002,11 @@ function openExtConfirm(id: string, title: string, message: string): void {
 }
 
 window.orbit.onUiRequest((request) => {
-  console.log("[orbit] UI request:", request.method, (request as Record<string, unknown>).widgetKey || "");
+  console.log(
+    "[orbit] UI request:",
+    request.method,
+    (request as Record<string, unknown>).widgetKey || "",
+  );
   const method = request.method;
   const id = (request as Record<string, unknown>).id as string;
 
@@ -2031,7 +2143,10 @@ function startTurnTimer(): void {
 
 function stopTurnTimer(): void {
   turnStartedAt = null;
-  if (elapsedTimer) { clearInterval(elapsedTimer); elapsedTimer = null; }
+  if (elapsedTimer) {
+    clearInterval(elapsedTimer);
+    elapsedTimer = null;
+  }
   renderBadgeText();
 }
 
@@ -2143,26 +2258,29 @@ const prefsApiKeyStatus = document.getElementById("prefs-api-key-status")!;
 // (in/out price per 1M tokens). Fallback only — populateDynamicModelData()
 // at startup overwrites this from pi-ai's bundled registry via main IPC,
 // so new models don't require hand-edits here.
-interface ModelChoice { id: string; label: string; }
+interface ModelChoice {
+  id: string;
+  label: string;
+}
 let MODELS_BY_PROVIDER: Record<string, ModelChoice[]> = {
   anthropic: [
-    { id: "claude-opus-4-7",   label: "Opus 4.7 — $15/$75 (most capable)" },
+    { id: "claude-opus-4-7", label: "Opus 4.7 — $15/$75 (most capable)" },
     { id: "claude-sonnet-4-6", label: "Sonnet 4.6 — $3/$15 (recommended)" },
-    { id: "claude-haiku-4-5",  label: "Haiku 4.5 — $1/$5 (cheapest)" },
-    { id: "claude-opus-4-6",   label: "Opus 4.6 — $15/$75" },
+    { id: "claude-haiku-4-5", label: "Haiku 4.5 — $1/$5 (cheapest)" },
+    { id: "claude-opus-4-6", label: "Opus 4.6 — $15/$75" },
     { id: "claude-sonnet-4-5", label: "Sonnet 4.5 — $3/$15" },
-    { id: "claude-opus-4-5",   label: "Opus 4.5 — $15/$75" },
+    { id: "claude-opus-4-5", label: "Opus 4.5 — $15/$75" },
   ],
   openai: [
     { id: "gpt-4o-mini", label: "GPT-4o mini — $0.15/$0.60 (cheapest)" },
-    { id: "gpt-4o",      label: "GPT-4o — $2.50/$10" },
+    { id: "gpt-4o", label: "GPT-4o — $2.50/$10" },
     { id: "gpt-4-turbo", label: "GPT-4 Turbo — $10/$30" },
-    { id: "o1-mini",     label: "o1-mini — $3/$12" },
-    { id: "o1",          label: "o1 — $15/$60" },
+    { id: "o1-mini", label: "o1-mini — $3/$12" },
+    { id: "o1", label: "o1 — $15/$60" },
   ],
   google: [
     { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash — $0.15/$0.60 (cheapest)" },
-    { id: "gemini-2.5-pro",   label: "Gemini 2.5 Pro — $1.25/$10" },
+    { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro — $1.25/$10" },
   ],
   mistral: [
     { id: "mistral-large-latest", label: "Mistral Large" },
@@ -2171,14 +2289,12 @@ let MODELS_BY_PROVIDER: Record<string, ModelChoice[]> = {
   ],
   groq: [
     { id: "llama-3.3-70b-versatile", label: "Llama 3.3 70B" },
-    { id: "llama-3.1-8b-instant",    label: "Llama 3.1 8B (fast)" },
+    { id: "llama-3.1-8b-instant", label: "Llama 3.1 8B (fast)" },
   ],
-  xai: [
-    { id: "grok-2-latest", label: "Grok 2" },
-  ],
+  xai: [{ id: "grok-2-latest", label: "Grok 2" }],
   ollama: [
     { id: "qwen3-coder:30b", label: "Qwen3-Coder 30B (local, A5000) — free" },
-    { id: "qwen3:8b",        label: "Qwen3 8B (local, fast) — free" },
+    { id: "qwen3:8b", label: "Qwen3 8B (local, fast) — free" },
   ],
 };
 
@@ -2193,7 +2309,7 @@ function populateModels(provider: string, selected?: string): void {
     prefsModel.appendChild(opt);
   }
   // If saved model isn't in the catalog (custom or older), add it as a free-form entry
-  if (selected && !models.find(m => m.id === selected)) {
+  if (selected && !models.find((m) => m.id === selected)) {
     const opt = document.createElement("option");
     opt.value = selected;
     opt.textContent = `${selected} (custom)`;
@@ -2211,7 +2327,9 @@ const prefsGalaxyUrl = document.getElementById("prefs-galaxy-url") as HTMLInputE
 const prefsGalaxyKey = document.getElementById("prefs-galaxy-key") as HTMLInputElement;
 const prefsGalaxyError = document.getElementById("prefs-galaxy-error")!;
 const prefsGalaxyActionsRow = document.getElementById("prefs-galaxy-actions-row")!;
-const prefsGalaxyDisconnect = document.getElementById("prefs-galaxy-disconnect") as HTMLButtonElement;
+const prefsGalaxyDisconnect = document.getElementById(
+  "prefs-galaxy-disconnect",
+) as HTMLButtonElement;
 const prefsDefaultCwd = document.getElementById("prefs-default-cwd") as HTMLInputElement;
 const prefsCondaBin = document.getElementById("prefs-conda-bin") as HTMLSelectElement;
 const prefsSkillsRows = document.getElementById("prefs-skills-rows")!;
@@ -2321,9 +2439,12 @@ prefsGalaxyUrl.addEventListener("input", updatePrefsGalaxyValidity);
 prefsGalaxyKey.addEventListener("input", updatePrefsGalaxyValidity);
 
 async function openPreferences(): Promise<void> {
-  const config = await window.orbit.getConfig() as {
+  const config = (await window.orbit.getConfig()) as {
     llm?: { provider?: string; model?: string; hasApiKey?: boolean };
-    galaxy?: { active: string | null; profiles: Record<string, { url: string; hasApiKey?: boolean }> };
+    galaxy?: {
+      active: string | null;
+      profiles: Record<string, { url: string; hasApiKey?: boolean }>;
+    };
     defaultCwd?: string;
     condaBin?: string;
     skills?: { repos?: Array<{ name?: string; url?: string; branch?: string; enabled?: boolean }> };
@@ -2380,8 +2501,8 @@ async function savePreferences(): Promise<void> {
   if (streaming) {
     const ok = confirm(
       "The agent is still working on your previous prompt. " +
-      "Saving Preferences will restart it and your in-flight prompt will be lost.\n\n" +
-      "Continue?"
+        "Saving Preferences will restart it and your in-flight prompt will be lost.\n\n" +
+        "Continue?",
     );
     if (!ok) return;
   }
@@ -2390,19 +2511,11 @@ async function savePreferences(): Promise<void> {
   // against what's on disk; the sentinel preserves a stored key when the
   // user left the input blank.
   const typedApiKey = prefsApiKey.value.trim();
-  const llmApiKey = typedApiKey
-    ? typedApiKey
-    : prefsLlmHadKey
-    ? UNCHANGED_SECRET
-    : "";
+  const llmApiKey = typedApiKey ? typedApiKey : prefsLlmHadKey ? UNCHANGED_SECRET : "";
 
   const typedGalaxyKey = prefsGalaxyKey.value.trim();
   const galaxyUrl = prefsGalaxyUrl.value.trim();
-  const galaxyApiKey = typedGalaxyKey
-    ? typedGalaxyKey
-    : prefsGalaxyHadKey
-    ? UNCHANGED_SECRET
-    : "";
+  const galaxyApiKey = typedGalaxyKey ? typedGalaxyKey : prefsGalaxyHadKey ? UNCHANGED_SECRET : "";
 
   const hasGalaxyUrl = Boolean(galaxyUrl);
   const hasGalaxyKey = Boolean(typedGalaxyKey || prefsGalaxyHadKey);
@@ -2457,8 +2570,8 @@ async function savePreferences(): Promise<void> {
     const list = disallowed.map((r) => `  • ${r.name}: ${r.url}`).join("\n");
     alert(
       `Skills repos must live under ${ALLOWED_SKILLS_PREFIX}* (alpha ` +
-      `restriction). Disallowed entries:\n\n${list}\n\n` +
-      `Fix or remove them before saving.`,
+        `restriction). Disallowed entries:\n\n${list}\n\n` +
+        `Fix or remove them before saving.`,
     );
     return;
   }
@@ -2482,7 +2595,7 @@ async function savePreferences(): Promise<void> {
     const modelChanged = selectedModel && selectedModel !== prevModel;
     if (modelChanged) {
       chat.addInfoMessage(
-        `<i>Preferences saved. Changed model to <code>${selectedModel}</code>. Agent restarted.</i>`
+        `<i>Preferences saved. Changed model to <code>${selectedModel}</code>. Agent restarted.</i>`,
       );
     } else {
       chat.addInfoMessage("<i>Preferences saved. Agent restarted.</i>");
@@ -2513,11 +2626,16 @@ prefsGalaxyDisconnect.addEventListener("click", async () => {
   if (streaming) {
     const ok = confirm(
       "The agent is still working. Disconnecting Galaxy will restart it " +
-      "and your in-flight prompt will be lost.\n\nContinue?"
+        "and your in-flight prompt will be lost.\n\nContinue?",
     );
     if (!ok) return;
   } else {
-    if (!confirm("Disconnect Galaxy and clear stored credentials? Other Preferences are saved as well.")) return;
+    if (
+      !confirm(
+        "Disconnect Galaxy and clear stored credentials? Other Preferences are saved as well.",
+      )
+    )
+      return;
   }
   prefsGalaxyDisconnect.disabled = true;
   try {
@@ -2604,14 +2722,16 @@ async function buildReportBody(userText: string): Promise<string> {
       // useful for debugging.
       sections.push(
         `## System info\n` +
-        `- Orbit: ${info.appVersion}\n` +
-        `- Platform: ${info.platform} ${info.arch}\n` +
-        `- Electron: ${info.electronVersion}, Chrome: ${info.chromeVersion}, Node: ${info.nodeVersion}\n` +
-        `- LLM: ${cfg.llm?.provider ?? "(none)"} / ${cfg.llm?.model ?? "(none)"}\n` +
-        `- Galaxy: ${cfg.galaxy?.active ? "configured" : "not configured"}`
+          `- Orbit: ${info.appVersion}\n` +
+          `- Platform: ${info.platform} ${info.arch}\n` +
+          `- Electron: ${info.electronVersion}, Chrome: ${info.chromeVersion}, Node: ${info.nodeVersion}\n` +
+          `- LLM: ${cfg.llm?.provider ?? "(none)"} / ${cfg.llm?.model ?? "(none)"}\n` +
+          `- Galaxy: ${cfg.galaxy?.active ? "configured" : "not configured"}`,
       );
     } catch (err) {
-      sections.push(`## System info\n(failed to collect: ${err instanceof Error ? err.message : String(err)})`);
+      sections.push(
+        `## System info\n(failed to collect: ${err instanceof Error ? err.message : String(err)})`,
+      );
     }
   }
 
@@ -2632,9 +2752,13 @@ async function buildReportBody(userText: string): Promise<string> {
             return line.slice(0, 80);
           }
         });
-        sections.push("## activity.jsonl (last 15 events, summarized)\n```\n" + summarized.join("\n") + "\n```");
+        sections.push(
+          "## activity.jsonl (last 15 events, summarized)\n```\n" + summarized.join("\n") + "\n```",
+        );
       }
-    } catch { /* file missing or unreadable — skip */ }
+    } catch {
+      /* file missing or unreadable — skip */
+    }
 
     // Shell tail (last ~80 lines of in-memory ShellPanel)
     const shellTail = shell.tail(80);
@@ -2865,12 +2989,15 @@ function renderProcs(procs: ProcInfo[]): void {
   procMonitorCountEl.classList.toggle("zero", procs.length === 0);
 
   if (procs.length === 0) {
-    procMonitorRowsEl.innerHTML = '<tr><td colspan="6" class="empty-procs">No subprocesses running</td></tr>';
+    procMonitorRowsEl.innerHTML =
+      '<tr><td colspan="6" class="empty-procs">No subprocesses running</td></tr>';
     return;
   }
 
   const sorted = [...procs].sort((a, b) => b.pcpu - a.pcpu);
-  procMonitorRowsEl.innerHTML = sorted.map((p) => `
+  procMonitorRowsEl.innerHTML = sorted
+    .map(
+      (p) => `
     <tr>
       <td class="col-num">${p.pid}</td>
       <td class="col-num">${p.pcpu.toFixed(1)}</td>
@@ -2879,7 +3006,9 @@ function renderProcs(procs: ProcInfo[]): void {
       <td class="col-num">${p.etime}</td>
       <td class="col-cmd" title="${escapeAttr(p.command)}">${escapeHtml(p.command)}</td>
     </tr>
-  `).join("");
+  `,
+    )
+    .join("");
 }
 
 function escapeHtml(s: string): string {

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -41,9 +41,13 @@ export class ChatPanel {
       else if (btn.classList.contains("plan-draft-reject")) action = "reject";
       if (action !== "edit" && card) {
         card.classList.add(action === "approve" ? "approved" : "rejected");
-        card.querySelectorAll<HTMLButtonElement>(
-          ".plan-draft-approve,.plan-draft-edit,.plan-draft-reject",
-        ).forEach((b) => { b.disabled = true; });
+        card
+          .querySelectorAll<HTMLButtonElement>(
+            ".plan-draft-approve,.plan-draft-edit,.plan-draft-reject",
+          )
+          .forEach((b) => {
+            b.disabled = true;
+          });
       }
       this.container.dispatchEvent(
         new CustomEvent("plan-draft-action", {
@@ -144,7 +148,8 @@ export class ChatPanel {
     this.hideThinking();
     const el = document.createElement("div");
     el.className = "message assistant thinking-indicator";
-    el.innerHTML = '<span class="thinking-dots"><span>.</span><span>.</span><span>.</span></span> thinking';
+    el.innerHTML =
+      '<span class="thinking-dots"><span>.</span><span>.</span><span>.</span></span> thinking';
     this.thinkingEl = el;
     this.container.appendChild(el);
     this.scrollToBottom();
@@ -194,7 +199,8 @@ export class ChatPanel {
         flush();
         const n = Number(el.dataset.promptNum);
         activeNum = Number.isFinite(n) ? n : null;
-        const userText = (el.querySelector(".message.user") as HTMLElement | null)?.textContent?.trim() ?? "";
+        const userText =
+          (el.querySelector(".message.user") as HTMLElement | null)?.textContent?.trim() ?? "";
         if (activeNum !== null) {
           buf.push(`[Prompt ${activeNum} — user]`);
           if (userText) buf.push(userText);
@@ -236,7 +242,7 @@ export class ChatPanel {
       this.renderCurrentMessage();
     }
     // Clean up any stray cursors across the whole container
-    this.container.querySelectorAll(".cursor-blink").forEach(c => c.remove());
+    this.container.querySelectorAll(".cursor-blink").forEach((c) => c.remove());
     this.currentMessage = null;
     this.currentText = "";
   }
@@ -388,18 +394,14 @@ function extractPlanFences(src: string): { text: string; planBlocks: string[] } 
   const openMatch = /```plan\b[^\n]*\n([\s\S]*)$/.exec(text);
   if (openMatch) {
     const idx = planBlocks.push(openMatch[1]) - 1;
-    text = text.slice(0, openMatch.index) +
-      `\n\n${PLAN_FENCE_PLACEHOLDER_PREFIX}${idx}\n\n`;
+    text = text.slice(0, openMatch.index) + `\n\n${PLAN_FENCE_PLACEHOLDER_PREFIX}${idx}\n\n`;
   }
   return { text, planBlocks };
 }
 
 function injectPlanFenceCards(html: string, planBlocks: string[]): string {
   if (planBlocks.length === 0) return html;
-  const re = new RegExp(
-    `<p>\\s*${PLAN_FENCE_PLACEHOLDER_PREFIX}(\\d+)\\s*</p>`,
-    "g",
-  );
+  const re = new RegExp(`<p>\\s*${PLAN_FENCE_PLACEHOLDER_PREFIX}(\\d+)\\s*</p>`, "g");
   return html.replace(re, (_m, idxStr: string) => {
     const idx = Number(idxStr);
     const body = planBlocks[idx] ?? "";

--- a/app/src/renderer/chat/shell-panel.ts
+++ b/app/src/renderer/chat/shell-panel.ts
@@ -6,13 +6,7 @@
  * now?" debugging during long-running steps.
  */
 
-export type ShellLineType =
-  | "tool-start"
-  | "tool-end"
-  | "tool-error"
-  | "status"
-  | "info"
-  | "stdout";
+export type ShellLineType = "tool-start" | "tool-end" | "tool-error" | "status" | "info" | "stdout";
 
 export class ShellPanel {
   private body: HTMLElement;

--- a/app/src/renderer/files/file-viewer.ts
+++ b/app/src/renderer/files/file-viewer.ts
@@ -12,23 +12,61 @@ type FileKind = "text" | "image" | "pdf" | "binary";
 
 const TEXT_EXTS = new Set([
   // generic
-  ".md", ".txt", ".log", ".rst",
+  ".md",
+  ".txt",
+  ".log",
+  ".rst",
   // code / config
-  ".py", ".js", ".ts", ".tsx", ".jsx", ".sh", ".rb", ".pl", ".r", ".go", ".rs",
-  ".json", ".jsonl", ".yml", ".yaml", ".toml", ".ini", ".cfg", ".conf",
-  ".xml", ".html", ".htm", ".css",
+  ".py",
+  ".js",
+  ".ts",
+  ".tsx",
+  ".jsx",
+  ".sh",
+  ".rb",
+  ".pl",
+  ".r",
+  ".go",
+  ".rs",
+  ".json",
+  ".jsonl",
+  ".yml",
+  ".yaml",
+  ".toml",
+  ".ini",
+  ".cfg",
+  ".conf",
+  ".xml",
+  ".html",
+  ".htm",
+  ".css",
   // tabular
-  ".csv", ".tsv", ".tab",
+  ".csv",
+  ".tsv",
+  ".tab",
   // bioinformatics text formats
-  ".fa", ".fasta", ".fna", ".faa", ".ffn",
-  ".fastq", ".fq",
+  ".fa",
+  ".fasta",
+  ".fna",
+  ".faa",
+  ".ffn",
+  ".fastq",
+  ".fq",
   ".vcf",
-  ".bed", ".bedgraph", ".wig",
-  ".gff", ".gff3", ".gtf",
+  ".bed",
+  ".bedgraph",
+  ".wig",
+  ".gff",
+  ".gff3",
+  ".gtf",
   ".sam",
-  ".pdb", ".cif",
-  ".nwk", ".newick", ".tree",
-  ".phy", ".phylip",
+  ".pdb",
+  ".cif",
+  ".nwk",
+  ".newick",
+  ".tree",
+  ".phy",
+  ".phylip",
 ]);
 
 const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"]);
@@ -48,7 +86,7 @@ function extOf(path: string): string {
 
 function kindOf(path: string): FileKind {
   const ext = extOf(path);
-  if (!ext) return "text";                    // no extension → treat as text
+  if (!ext) return "text"; // no extension → treat as text
   if (TEXT_EXTS.has(ext)) return "text";
   if (IMAGE_EXTS.has(ext)) return "image";
   if (PDF_EXTS.has(ext)) return "pdf";
@@ -57,13 +95,19 @@ function kindOf(path: string): FileKind {
 
 function mimeForImage(ext: string): string {
   switch (ext) {
-    case ".png":  return "image/png";
+    case ".png":
+      return "image/png";
     case ".jpg":
-    case ".jpeg": return "image/jpeg";
-    case ".gif":  return "image/gif";
-    case ".svg":  return "image/svg+xml";
-    case ".webp": return "image/webp";
-    default:      return "application/octet-stream";
+    case ".jpeg":
+      return "image/jpeg";
+    case ".gif":
+      return "image/gif";
+    case ".svg":
+      return "image/svg+xml";
+    case ".webp":
+      return "image/webp";
+    default:
+      return "application/octet-stream";
   }
 }
 
@@ -244,7 +288,10 @@ export class FileViewer {
   private reloadImage(bytes: Uint8Array): void {
     const img = this.container.querySelector<HTMLImageElement>("img.file-viewer-image");
     if (!img) return;
-    const buf = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+    const buf = bytes.buffer.slice(
+      bytes.byteOffset,
+      bytes.byteOffset + bytes.byteLength,
+    ) as ArrayBuffer;
     const blob = new Blob([buf]);
     const nextUrl = URL.createObjectURL(blob);
     const prev = this.currentImageUrl;
@@ -459,12 +506,7 @@ export class FileViewer {
     }
   }
 
-  private renderImage(
-    root: HTMLElement,
-    relPath: string,
-    bytes: Uint8Array,
-    size: number,
-  ): void {
+  private renderImage(root: HTMLElement, relPath: string, bytes: Uint8Array, size: number): void {
     const toolbar = document.createElement("div");
     toolbar.className = "file-viewer-toolbar";
     const filename = document.createElement("span");
@@ -500,12 +542,7 @@ export class FileViewer {
     root.appendChild(wrap);
   }
 
-  private renderPdf(
-    root: HTMLElement,
-    relPath: string,
-    bytes: Uint8Array,
-    size: number,
-  ): void {
+  private renderPdf(root: HTMLElement, relPath: string, bytes: Uint8Array, size: number): void {
     const toolbar = document.createElement("div");
     toolbar.className = "file-viewer-toolbar";
     const filename = document.createElement("span");

--- a/app/src/renderer/files/files-panel.ts
+++ b/app/src/renderer/files/files-panel.ts
@@ -16,10 +16,7 @@ export class FilesPanel {
   private showHidden = false;
   private loading = false;
 
-  constructor(
-    container: HTMLElement,
-    onFileOpen: (relPath: string) => void,
-  ) {
+  constructor(container: HTMLElement, onFileOpen: (relPath: string) => void) {
     this.container = container;
     this.onFileOpen = onFileOpen;
   }

--- a/app/src/renderer/galaxy-invocations.ts
+++ b/app/src/renderer/galaxy-invocations.ts
@@ -110,16 +110,18 @@ function renderRow(inv: Invocation): string {
   const failed = inv.failedJobs ?? 0;
   const pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : 0;
 
-  const stepsText = inv.totalSteps !== undefined
-    ? `${inv.completedSteps ?? 0}/${inv.totalSteps} steps`
-    : "";
-  const jobsText = total > 0
-    ? `${done}/${total} jobs${failed > 0 ? ` · ${failed} failed` : ""}`
-    : "";
+  const stepsText =
+    inv.totalSteps !== undefined ? `${inv.completedSteps ?? 0}/${inv.totalSteps} steps` : "";
+  const jobsText =
+    total > 0 ? `${done}/${total} jobs${failed > 0 ? ` · ${failed} failed` : ""}` : "";
   const counts = [stepsText, jobsText].filter(Boolean).join(" · ");
 
-  let host = "";
-  try { host = new URL(inv.galaxyServerUrl).host; } catch { host = inv.galaxyServerUrl; }
+  let host: string;
+  try {
+    host = new URL(inv.galaxyServerUrl).host;
+  } catch {
+    host = inv.galaxyServerUrl;
+  }
   const submitted = inv.submittedAt.replace("T", " ").replace(/\.\d+Z$/, "Z");
 
   return `
@@ -143,9 +145,9 @@ function renderRow(inv: Invocation): string {
  * when no invocations exist (with a linger after the last in-progress
  * one finishes so the final state is briefly visible).
  */
-export async function refreshGalaxyInvocations(
-  api: { readFile: (p: string) => Promise<{ ok: true; bytes: Uint8Array } | { ok: false }> },
-): Promise<void> {
+export async function refreshGalaxyInvocations(api: {
+  readFile: (p: string) => Promise<{ ok: true; bytes: Uint8Array } | { ok: false }>;
+}): Promise<void> {
   const section = document.getElementById("activity-galaxy-section");
   const body = document.getElementById("galaxy-invocations-body");
   const countEl = document.getElementById("galaxy-invocations-count");
@@ -158,7 +160,9 @@ export async function refreshGalaxyInvocations(
       const text = new TextDecoder("utf-8").decode(res.bytes);
       invocations = parseInvocationBlocks(text);
     }
-  } catch { /* notebook missing — leave invocations empty */ }
+  } catch {
+    /* notebook missing — leave invocations empty */
+  }
 
   const inProgress = invocations.filter((i) => i.status === "in_progress");
 

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <!--
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!--
     CSP: defense-in-depth alongside DOMPurify on every markdown sink.
     `default-src 'self'` blocks inline scripts; `'unsafe-inline'` on style is
     accepted because Vite injects styles inline during dev and we sanitize all
@@ -13,478 +13,635 @@
     object-src + frame-src allow blob: for the file-viewer PDF preview —
     Chromium's built-in PDF viewer creates an inner frame at the blob URL.
   -->
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' orbit-artifact: data: blob:; connect-src 'self' http://localhost:* ws://localhost:*; font-src 'self' data:; object-src blob:; frame-src blob:; base-uri 'self'; form-action 'none';" />
-  <title>orbit</title>
-  <link rel="stylesheet" href="./styles.css" />
-</head>
-<body>
-  <div id="app">
-    <div id="app-main">
-    <!-- Left pane: File tree sidebar -->
-    <div id="files-pane" class="pane">
-      <div class="pane-title" id="files-title">
-        <span class="files-title-label">Files</span>
-        <div class="files-title-actions">
-          <button id="files-refresh" class="files-header-btn" title="Refresh file tree">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <polyline points="23 4 23 10 17 10"/>
-              <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/>
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' orbit-artifact: data: blob:; connect-src 'self' http://localhost:* ws://localhost:*; font-src 'self' data:; object-src blob:; frame-src blob:; base-uri 'self'; form-action 'none';"
+    />
+    <title>orbit</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <div id="app">
+      <div id="app-main">
+        <!-- Left pane: File tree sidebar -->
+        <div id="files-pane" class="pane">
+          <div class="pane-title" id="files-title">
+            <span class="files-title-label">Files</span>
+            <div class="files-title-actions">
+              <button id="files-refresh" class="files-header-btn" title="Refresh file tree">
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <polyline points="23 4 23 10 17 10" />
+                  <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+                </svg>
+              </button>
+              <button
+                id="files-show-hidden"
+                class="files-header-btn"
+                title="Show hidden files"
+                aria-pressed="false"
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              </button>
+            </div>
+          </div>
+          <div id="files-tree"></div>
+        </div>
+
+        <!-- Draggable divider between files pane and chat -->
+        <div id="files-divider"></div>
+
+        <!-- Left pane: Chat -->
+        <div id="chat-pane" class="pane">
+          <div class="pane-title pane-title-with-controls" id="chat-title">
+            <button
+              id="files-toggle"
+              class="pane-title-btn"
+              title="Toggle files sidebar (Ctrl+B)"
+              aria-label="Toggle files sidebar"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path
+                  d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"
+                />
+              </svg>
+            </button>
+            <span class="pane-title-label">Chat</span>
+            <button
+              id="artifact-toggle"
+              class="pane-title-btn"
+              title="Toggle notebook pane (Ctrl+\)"
+              aria-label="Toggle notebook pane"
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <rect x="3" y="3" width="18" height="18" rx="2" />
+                <line x1="15" y1="3" x2="15" y2="21" />
+              </svg>
+            </button>
+          </div>
+          <div id="messages"></div>
+
+          <div id="input-area">
+            <div id="slash-popup" class="hidden" role="listbox" aria-label="Slash commands"></div>
+            <span
+              id="queued-indicator"
+              class="hidden"
+              title="Queued — will send when agent is ready"
+              >queued <span aria-hidden="true">↓</span></span
+            >
+            <textarea
+              id="input"
+              placeholder="Ask for a plan, drop a file path, or type / for commands"
+              rows="1"
+              aria-label="Chat input"
+              aria-haspopup="listbox"
+              aria-controls="slash-popup"
+              aria-autocomplete="list"
+              aria-expanded="false"
+            ></textarea>
+            <button id="send-btn" title="Send" aria-label="Send message">
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <path d="M22 2L11 13M22 2L15 22L11 13M22 2L2 9L11 13" />
+              </svg>
+            </button>
+            <button id="abort-btn" title="Stop" class="hidden" aria-label="Stop streaming response">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                <rect x="6" y="6" width="12" height="12" rx="2" />
+              </svg>
+            </button>
+          </div>
+          <div id="input-hint">
+            <span>Type <code>/</code> to see available commands</span>
+          </div>
+        </div>
+
+        <!-- Draggable divider -->
+        <div id="divider"></div>
+
+        <!-- Right pane: Notebook / Activity -->
+        <div id="artifact-pane" class="pane">
+          <div class="pane-title pane-tabs" id="artifact-tabs">
+            <button class="pane-tab active" data-tab="notebook">Notebook</button>
+            <button class="pane-tab" data-tab="activity">Activity</button>
+            <button class="pane-tab pane-tab-closeable" data-tab="file" hidden>
+              <span class="pane-tab-label">File</span>
+              <span class="pane-tab-close" id="file-tab-close" title="Close file">×</span>
+            </button>
+          </div>
+          <div id="artifact-content">
+            <div id="notebook-view" class="pane-body">
+              <div class="empty-state">
+                <p>
+                  The notebook is the running log of your analysis — plan, steps, decisions, and
+                  Galaxy references — persisted to a markdown file in your working directory and
+                  committed to git on every change.
+                </p>
+                <p>
+                  It'll appear here once the agent writes to <code>notebook.md</code>, or you can
+                  ask it to summarize the conversation so far.
+                </p>
+              </div>
+            </div>
+            <div id="activity-view" class="pane-body hidden">
+              <div id="activity-galaxy-section" class="hidden">
+                <div class="activity-section-header">
+                  <span
+                    >Galaxy invocations
+                    <span id="galaxy-invocations-count" class="zero">0</span></span
+                  >
+                </div>
+                <div id="galaxy-invocations-body"></div>
+              </div>
+              <div id="activity-shell-section">
+                <div class="activity-section-header">
+                  <span>Shell</span>
+                  <button id="agent-shell-clear" title="Clear shell">clear</button>
+                </div>
+                <div id="agent-shell-body"></div>
+              </div>
+              <div id="activity-proc-section">
+                <div class="activity-section-header">
+                  <span>Processes <span id="proc-monitor-count" class="zero">0</span></span>
+                </div>
+                <div id="proc-monitor-body">
+                  <table id="proc-monitor-table">
+                    <thead>
+                      <tr>
+                        <th>PID</th>
+                        <th>CPU%</th>
+                        <th>MEM%</th>
+                        <th>RSS</th>
+                        <th>Time</th>
+                        <th>Command</th>
+                      </tr>
+                    </thead>
+                    <tbody id="proc-monitor-rows">
+                      <tr>
+                        <td colspan="6" class="empty-procs">No subprocesses running</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+            <div id="file-view" class="pane-body hidden"></div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Footer bar — status indicators (pane toggles live in chat-title) -->
+      <div id="app-footer">
+        <span id="agent-status" class="footer-control status-badge">connecting...</span>
+        <span
+          id="agent-heartbeat"
+          class="agent-heartbeat"
+          aria-hidden="true"
+          title="Brain liveness — pulses on every event from the brain"
+        ></span>
+        <button
+          id="galaxy-status"
+          class="footer-control is-interactive status-dot status-dot-disconnected"
+          title="Galaxy: not configured"
+          aria-label="Galaxy connection: not configured. Click to open Preferences."
+        >
+          <span class="status-dot-label">Galaxy</span>
+        </button>
+        <button
+          id="report-issue-btn"
+          class="footer-control is-interactive"
+          title="Report an issue"
+          aria-label="Report an issue"
+        >
+          Report
+        </button>
+        <div
+          id="exec-mode-toggle"
+          class="footer-control footer-control-segmented"
+          role="radiogroup"
+          aria-label="Execution mode"
+          title="Execution mode: Local = everything runs locally; Cloud = agent decides per plan whether each step runs locally or on Galaxy."
+        >
+          <button
+            id="exec-mode-local"
+            class="exec-mode-btn"
+            data-mode="local"
+            role="radio"
+            aria-checked="false"
+          >
+            Local
+          </button>
+          <button
+            id="exec-mode-cloud"
+            class="exec-mode-btn active"
+            data-mode="cloud"
+            role="radio"
+            aria-checked="true"
+          >
+            Cloud
+          </button>
+        </div>
+        <button
+          id="model-indicator"
+          class="footer-control is-interactive hidden"
+          title="Click to change model"
+        >
+          <span id="model-indicator-name">—</span>
+        </button>
+        <div id="usage-bar" class="footer-control" title="Session token usage">
+          <span id="usage-tokens">0 tok</span>
+          <span id="usage-cost"></span>
+        </div>
+        <div id="cwd-bar" class="footer-control">
+          <span id="cwd-path" title="Analysis directory">~</span>
+          <button
+            id="cwd-change"
+            class="cwd-change-btn"
+            title="Change directory"
+            aria-label="Change analysis directory"
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path
+                d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"
+              />
             </svg>
           </button>
-          <button id="files-show-hidden" class="files-header-btn" title="Show hidden files" aria-pressed="false">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
-              <circle cx="12" cy="12" r="3"/>
-            </svg>
-          </button>
         </div>
       </div>
-      <div id="files-tree"></div>
     </div>
 
-    <!-- Draggable divider between files pane and chat -->
-    <div id="files-divider"></div>
+    <!-- Preferences Modal -->
+    <div id="prefs-overlay" class="modal-overlay hidden">
+      <div class="modal">
+        <div class="modal-header">
+          <h2>Preferences</h2>
+          <button id="prefs-close" class="modal-close" title="Close">×</button>
+        </div>
+        <div class="modal-body">
+          <section class="prefs-section">
+            <h3>LLM Provider</h3>
+            <div class="prefs-row">
+              <label for="prefs-provider">Provider</label>
+              <select id="prefs-provider">
+                <option value="anthropic">Anthropic</option>
+                <option value="openai">OpenAI</option>
+                <option value="google">Google (Gemini)</option>
+                <option value="mistral">Mistral</option>
+                <option value="groq">Groq</option>
+                <option value="xai">xAI</option>
+                <option value="ollama">Ollama (local)</option>
+              </select>
+            </div>
+            <div class="prefs-row">
+              <label for="prefs-model">Model</label>
+              <select id="prefs-model"></select>
+            </div>
+            <div class="prefs-row prefs-hint">
+              <span></span>
+              <span class="prefs-hint-text">
+                Cost guide: pick the cheapest model that handles your task. Mid-tier models (Sonnet
+                / GPT-4o / Gemini Flash class) are usually fine for plan drafting and routine
+                execution; reach for flagship (Opus / o1 class) only when you hit complex reasoning.
+                Prices in the dropdown are per 1M tokens (input/output).
+              </span>
+            </div>
+            <div class="prefs-row">
+              <label for="prefs-api-key">API Key</label>
+              <input id="prefs-api-key" type="password" placeholder="sk-..." />
+            </div>
+            <div class="prefs-row prefs-hint">
+              <span></span>
+              <span id="prefs-api-key-status" class="api-key-status"></span>
+            </div>
+          </section>
 
-    <!-- Left pane: Chat -->
-    <div id="chat-pane" class="pane">
-      <div class="pane-title pane-title-with-controls" id="chat-title">
-        <button id="files-toggle" class="pane-title-btn" title="Toggle files sidebar (Ctrl+B)" aria-label="Toggle files sidebar">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
-          </svg>
-        </button>
-        <span class="pane-title-label">Chat</span>
-        <button id="artifact-toggle" class="pane-title-btn" title="Toggle notebook pane (Ctrl+\)" aria-label="Toggle notebook pane">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <rect x="3" y="3" width="18" height="18" rx="2"/>
-            <line x1="15" y1="3" x2="15" y2="21"/>
-          </svg>
-        </button>
-      </div>
-      <div id="messages"></div>
+          <section class="prefs-section">
+            <h3>Galaxy</h3>
+            <div class="prefs-row">
+              <label for="prefs-galaxy-url">URL</label>
+              <input id="prefs-galaxy-url" type="text" placeholder="https://usegalaxy.org" />
+            </div>
+            <div class="prefs-row">
+              <label for="prefs-galaxy-key">API Key</label>
+              <input id="prefs-galaxy-key" type="password" placeholder="Galaxy API key" />
+            </div>
+            <div id="prefs-galaxy-error" class="prefs-galaxy-error"></div>
+            <div class="prefs-row prefs-galaxy-actions hidden" id="prefs-galaxy-actions-row">
+              <span></span>
+              <button id="prefs-galaxy-disconnect" class="plan-btn danger" type="button">
+                Disconnect Galaxy
+              </button>
+            </div>
+          </section>
 
-      <div id="input-area">
-        <div id="slash-popup" class="hidden" role="listbox" aria-label="Slash commands"></div>
-        <span id="queued-indicator" class="hidden" title="Queued — will send when agent is ready">queued <span aria-hidden="true">↓</span></span>
-        <textarea
-          id="input"
-          placeholder="Ask for a plan, drop a file path, or type / for commands"
-          rows="1"
-          aria-label="Chat input"
-          aria-haspopup="listbox"
-          aria-controls="slash-popup"
-          aria-autocomplete="list"
-          aria-expanded="false"
-        ></textarea>
-        <button id="send-btn" title="Send" aria-label="Send message">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M22 2L11 13M22 2L15 22L11 13M22 2L2 9L11 13"/>
-          </svg>
-        </button>
-        <button id="abort-btn" title="Stop" class="hidden" aria-label="Stop streaming response">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-            <rect x="6" y="6" width="12" height="12" rx="2"/>
-          </svg>
-        </button>
-      </div>
-      <div id="input-hint">
-        <span>Type <code>/</code> to see available commands</span>
-      </div>
-    </div>
+          <section class="prefs-section">
+            <h3>Analysis</h3>
+            <div class="prefs-row">
+              <label for="prefs-default-cwd">Default directory</label>
+              <div class="prefs-row-with-btn">
+                <input id="prefs-default-cwd" type="text" placeholder="~/.loom/analyses" />
+                <button id="prefs-browse-cwd" class="plan-btn">Browse</button>
+              </div>
+            </div>
+            <div class="prefs-row">
+              <label for="prefs-conda-bin">Package manager</label>
+              <select id="prefs-conda-bin">
+                <option value="auto">Auto (mamba if available)</option>
+                <option value="mamba">mamba</option>
+                <option value="conda">conda</option>
+              </select>
+            </div>
+          </section>
 
-    <!-- Draggable divider -->
-    <div id="divider"></div>
-
-    <!-- Right pane: Notebook / Activity -->
-    <div id="artifact-pane" class="pane">
-      <div class="pane-title pane-tabs" id="artifact-tabs">
-        <button class="pane-tab active" data-tab="notebook">Notebook</button>
-        <button class="pane-tab" data-tab="activity">Activity</button>
-        <button class="pane-tab pane-tab-closeable" data-tab="file" hidden>
-          <span class="pane-tab-label">File</span>
-          <span class="pane-tab-close" id="file-tab-close" title="Close file">×</span>
-        </button>
-      </div>
-      <div id="artifact-content">
-        <div id="notebook-view" class="pane-body">
-          <div class="empty-state">
-            <p>The notebook is the running log of your analysis — plan, steps, decisions, and Galaxy references — persisted to a markdown file in your working directory and committed to git on every change.</p>
-            <p>It'll appear here once the agent writes to <code>notebook.md</code>, or you can ask it to summarize the conversation so far.</p>
+          <section class="prefs-section">
+            <h3>Skills</h3>
+            <p class="prefs-help">
+              GitHub repos with Claude-Code-style skills (top-level
+              <code>AGENTS.md</code> + nested <code>SKILL.md</code> files). The agent fetches them
+              on demand via the <code>skills_fetch</code> tool.
+              <strong>Alpha restriction:</strong> only repos under
+              <code>github.com/galaxyproject/*</code> are accepted (the agent treats fetched skills
+              as authoritative instructions, so the allowlist limits prompt-injection surface).
+              <code>galaxy-skills</code> is the default and ships with Loom; you can disable or
+              remove it, but a default is re-seeded if all repos are removed.
+            </p>
+            <table id="prefs-skills-table" class="prefs-table">
+              <thead>
+                <tr>
+                  <th class="prefs-skills-name">Name</th>
+                  <th class="prefs-skills-url">GitHub URL</th>
+                  <th class="prefs-skills-branch">Branch</th>
+                  <th class="prefs-skills-enabled">Enabled</th>
+                  <th class="prefs-skills-actions"></th>
+                </tr>
+              </thead>
+              <tbody id="prefs-skills-rows"></tbody>
+            </table>
+            <div class="prefs-row">
+              <button id="prefs-skills-add" class="plan-btn">+ Add repo</button>
+            </div>
+          </section>
+        </div>
+        <div class="modal-footer">
+          <span id="prefs-restart-note">Changes will restart the agent session.</span>
+          <div class="modal-actions">
+            <button id="prefs-cancel" class="plan-btn">Cancel</button>
+            <button id="prefs-save" class="plan-btn execute">Save</button>
           </div>
         </div>
-        <div id="activity-view" class="pane-body hidden">
-          <div id="activity-galaxy-section" class="hidden">
-            <div class="activity-section-header">
-              <span>Galaxy invocations <span id="galaxy-invocations-count" class="zero">0</span></span>
-            </div>
-            <div id="galaxy-invocations-body"></div>
-          </div>
-          <div id="activity-shell-section">
-            <div class="activity-section-header">
-              <span>Shell</span>
-              <button id="agent-shell-clear" title="Clear shell">clear</button>
-            </div>
-            <div id="agent-shell-body"></div>
-          </div>
-          <div id="activity-proc-section">
-            <div class="activity-section-header">
-              <span>Processes <span id="proc-monitor-count" class="zero">0</span></span>
-            </div>
-            <div id="proc-monitor-body">
-              <table id="proc-monitor-table">
-                <thead>
-                  <tr>
-                    <th>PID</th>
-                    <th>CPU%</th>
-                    <th>MEM%</th>
-                    <th>RSS</th>
-                    <th>Time</th>
-                    <th>Command</th>
-                  </tr>
-                </thead>
-                <tbody id="proc-monitor-rows">
-                  <tr><td colspan="6" class="empty-procs">No subprocesses running</td></tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
+      </div>
+    </div>
+
+    <!-- First-run Welcome Overlay -->
+    <div id="welcome-overlay" class="modal-overlay hidden">
+      <div class="modal welcome-modal">
+        <div class="modal-header">
+          <h2>Welcome to orbit</h2>
         </div>
-        <div id="file-view" class="pane-body hidden"></div>
-      </div>
-    </div>
-    </div>
-
-    <!-- Footer bar — status indicators (pane toggles live in chat-title) -->
-    <div id="app-footer">
-      <span id="agent-status" class="footer-control status-badge">connecting...</span>
-      <span id="agent-heartbeat" class="agent-heartbeat" aria-hidden="true" title="Brain liveness — pulses on every event from the brain"></span>
-      <button id="galaxy-status" class="footer-control is-interactive status-dot status-dot-disconnected" title="Galaxy: not configured" aria-label="Galaxy connection: not configured. Click to open Preferences.">
-        <span class="status-dot-label">Galaxy</span>
-      </button>
-      <button id="report-issue-btn" class="footer-control is-interactive" title="Report an issue" aria-label="Report an issue">Report</button>
-      <div id="exec-mode-toggle" class="footer-control footer-control-segmented" role="radiogroup" aria-label="Execution mode" title="Execution mode: Local = everything runs locally; Cloud = agent decides per plan whether each step runs locally or on Galaxy.">
-        <button id="exec-mode-local" class="exec-mode-btn" data-mode="local" role="radio" aria-checked="false">Local</button>
-        <button id="exec-mode-cloud" class="exec-mode-btn active" data-mode="cloud" role="radio" aria-checked="true">Cloud</button>
-      </div>
-      <button id="model-indicator" class="footer-control is-interactive hidden" title="Click to change model">
-        <span id="model-indicator-name">—</span>
-      </button>
-      <div id="usage-bar" class="footer-control" title="Session token usage">
-        <span id="usage-tokens">0 tok</span>
-        <span id="usage-cost"></span>
-      </div>
-      <div id="cwd-bar" class="footer-control">
-        <span id="cwd-path" title="Analysis directory">~</span>
-        <button id="cwd-change" class="cwd-change-btn" title="Change directory" aria-label="Change analysis directory">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/>
-          </svg>
-        </button>
-      </div>
-    </div>
-  </div>
-
-  <!-- Preferences Modal -->
-  <div id="prefs-overlay" class="modal-overlay hidden">
-    <div class="modal">
-      <div class="modal-header">
-        <h2>Preferences</h2>
-        <button id="prefs-close" class="modal-close" title="Close">×</button>
-      </div>
-      <div class="modal-body">
-        <section class="prefs-section">
-          <h3>LLM Provider</h3>
-          <div class="prefs-row">
-            <label for="prefs-provider">Provider</label>
-            <select id="prefs-provider">
-              <option value="anthropic">Anthropic</option>
-              <option value="openai">OpenAI</option>
-              <option value="google">Google (Gemini)</option>
-              <option value="mistral">Mistral</option>
-              <option value="groq">Groq</option>
-              <option value="xai">xAI</option>
-              <option value="ollama">Ollama (local)</option>
-            </select>
-          </div>
-          <div class="prefs-row">
-            <label for="prefs-model">Model</label>
-            <select id="prefs-model"></select>
-          </div>
-          <div class="prefs-row prefs-hint">
-            <span></span>
-            <span class="prefs-hint-text">
-              Cost guide: pick the cheapest model that handles your task. Mid-tier
-              models (Sonnet / GPT-4o / Gemini Flash class) are usually fine for
-              plan drafting and routine execution; reach for flagship (Opus /
-              o1 class) only when you hit complex reasoning. Prices in the dropdown
-              are per 1M tokens (input/output).
-            </span>
-          </div>
-          <div class="prefs-row">
-            <label for="prefs-api-key">API Key</label>
-            <input id="prefs-api-key" type="password" placeholder="sk-..." />
-          </div>
-          <div class="prefs-row prefs-hint">
-            <span></span>
-            <span id="prefs-api-key-status" class="api-key-status"></span>
-          </div>
-        </section>
-
-        <section class="prefs-section">
-          <h3>Galaxy</h3>
-          <div class="prefs-row">
-            <label for="prefs-galaxy-url">URL</label>
-            <input id="prefs-galaxy-url" type="text" placeholder="https://usegalaxy.org" />
-          </div>
-          <div class="prefs-row">
-            <label for="prefs-galaxy-key">API Key</label>
-            <input id="prefs-galaxy-key" type="password" placeholder="Galaxy API key" />
-          </div>
-          <div id="prefs-galaxy-error" class="prefs-galaxy-error"></div>
-          <div class="prefs-row prefs-galaxy-actions hidden" id="prefs-galaxy-actions-row">
-            <span></span>
-            <button id="prefs-galaxy-disconnect" class="plan-btn danger" type="button">Disconnect Galaxy</button>
-          </div>
-        </section>
-
-        <section class="prefs-section">
-          <h3>Analysis</h3>
-          <div class="prefs-row">
-            <label for="prefs-default-cwd">Default directory</label>
-            <div class="prefs-row-with-btn">
-              <input id="prefs-default-cwd" type="text" placeholder="~/.loom/analyses" />
-              <button id="prefs-browse-cwd" class="plan-btn">Browse</button>
-            </div>
-          </div>
-          <div class="prefs-row">
-            <label for="prefs-conda-bin">Package manager</label>
-            <select id="prefs-conda-bin">
-              <option value="auto">Auto (mamba if available)</option>
-              <option value="mamba">mamba</option>
-              <option value="conda">conda</option>
-            </select>
-          </div>
-        </section>
-
-        <section class="prefs-section">
-          <h3>Skills</h3>
-          <p class="prefs-help">
-            GitHub repos with Claude-Code-style skills (top-level
-            <code>AGENTS.md</code> + nested <code>SKILL.md</code> files). The
-            agent fetches them on demand via the <code>skills_fetch</code>
-            tool. <strong>Alpha restriction:</strong> only repos under
-            <code>github.com/galaxyproject/*</code> are accepted (the agent
-            treats fetched skills as authoritative instructions, so the
-            allowlist limits prompt-injection surface).
-            <code>galaxy-skills</code> is the default and ships with Loom;
-            you can disable or remove it, but a default is re-seeded if
-            all repos are removed.
+        <div class="modal-body">
+          <img
+            class="welcome-badge"
+            src="./assets/badges/ask-me-about-loom.svg"
+            alt="Ask me about Loom"
+          />
+          <p class="welcome-intro">
+            orbit is an AI-driven bioinformatics analysis app. Configure your LLM provider to get
+            started. You can change settings later in Preferences.
           </p>
-          <table id="prefs-skills-table" class="prefs-table">
-            <thead>
-              <tr>
-                <th class="prefs-skills-name">Name</th>
-                <th class="prefs-skills-url">GitHub URL</th>
-                <th class="prefs-skills-branch">Branch</th>
-                <th class="prefs-skills-enabled">Enabled</th>
-                <th class="prefs-skills-actions"></th>
-              </tr>
-            </thead>
-            <tbody id="prefs-skills-rows"></tbody>
-          </table>
-          <div class="prefs-row">
-            <button id="prefs-skills-add" class="plan-btn">+ Add repo</button>
-          </div>
-        </section>
-      </div>
-      <div class="modal-footer">
-        <span id="prefs-restart-note">Changes will restart the agent session.</span>
-        <div class="modal-actions">
-          <button id="prefs-cancel" class="plan-btn">Cancel</button>
-          <button id="prefs-save" class="plan-btn execute">Save</button>
-        </div>
-      </div>
-    </div>
-  </div>
 
-  <!-- First-run Welcome Overlay -->
-  <div id="welcome-overlay" class="modal-overlay hidden">
-    <div class="modal welcome-modal">
-      <div class="modal-header">
-        <h2>Welcome to orbit</h2>
-      </div>
-      <div class="modal-body">
-        <img
-          class="welcome-badge"
-          src="./assets/badges/ask-me-about-loom.svg"
-          alt="Ask me about Loom"
-        />
-        <p class="welcome-intro">
-          orbit is an AI-driven bioinformatics analysis app. Configure your LLM provider
-          to get started. You can change settings later in Preferences.
-        </p>
-
-        <section class="prefs-section">
-          <h3>LLM Provider <span class="required">*required</span></h3>
-          <div class="prefs-row">
-            <label for="welcome-provider">Provider</label>
-            <select id="welcome-provider">
-              <option value="anthropic">Anthropic</option>
-              <option value="openai">OpenAI</option>
-              <option value="google">Google (Gemini)</option>
-              <option value="mistral">Mistral</option>
-              <option value="groq">Groq</option>
-              <option value="xai">xAI</option>
-              <option value="ollama">Ollama (local)</option>
-            </select>
-          </div>
-          <div class="prefs-row">
-            <label for="welcome-model">Model</label>
-            <select id="welcome-model"></select>
-          </div>
-          <div class="prefs-row">
-            <label for="welcome-api-key">API Key</label>
-            <input id="welcome-api-key" type="password" placeholder="sk-..." />
-          </div>
-          <div class="prefs-row prefs-hint">
-            <span></span>
-            <span id="welcome-api-key-status" class="api-key-status"></span>
-          </div>
-        </section>
-
-        <details class="welcome-details">
-          <summary>Galaxy server (optional)</summary>
-          <div class="prefs-row">
-            <label for="welcome-galaxy-url">URL</label>
-            <input id="welcome-galaxy-url" type="text" placeholder="https://usegalaxy.org" />
-          </div>
-          <div class="prefs-row">
-            <label for="welcome-galaxy-key">API Key</label>
-            <input id="welcome-galaxy-key" type="password" placeholder="Galaxy API key" />
-          </div>
-          <p class="welcome-hint">
-            Configure Galaxy to enable Remote execution mode. You can do this later in
-            Preferences.
-          </p>
-        </details>
-
-        <details class="welcome-details">
-          <summary>Working directory (optional)</summary>
-          <div class="prefs-row">
-            <label for="welcome-cwd">Default directory</label>
-            <div class="prefs-row-with-btn">
-              <input id="welcome-cwd" type="text" placeholder="~/orbit-analyses" />
-              <button id="welcome-browse-cwd" class="plan-btn">Browse</button>
+          <section class="prefs-section">
+            <h3>LLM Provider <span class="required">*required</span></h3>
+            <div class="prefs-row">
+              <label for="welcome-provider">Provider</label>
+              <select id="welcome-provider">
+                <option value="anthropic">Anthropic</option>
+                <option value="openai">OpenAI</option>
+                <option value="google">Google (Gemini)</option>
+                <option value="mistral">Mistral</option>
+                <option value="groq">Groq</option>
+                <option value="xai">xAI</option>
+                <option value="ollama">Ollama (local)</option>
+              </select>
             </div>
+            <div class="prefs-row">
+              <label for="welcome-model">Model</label>
+              <select id="welcome-model"></select>
+            </div>
+            <div class="prefs-row">
+              <label for="welcome-api-key">API Key</label>
+              <input id="welcome-api-key" type="password" placeholder="sk-..." />
+            </div>
+            <div class="prefs-row prefs-hint">
+              <span></span>
+              <span id="welcome-api-key-status" class="api-key-status"></span>
+            </div>
+          </section>
+
+          <details class="welcome-details">
+            <summary>Galaxy server (optional)</summary>
+            <div class="prefs-row">
+              <label for="welcome-galaxy-url">URL</label>
+              <input id="welcome-galaxy-url" type="text" placeholder="https://usegalaxy.org" />
+            </div>
+            <div class="prefs-row">
+              <label for="welcome-galaxy-key">API Key</label>
+              <input id="welcome-galaxy-key" type="password" placeholder="Galaxy API key" />
+            </div>
+            <p class="welcome-hint">
+              Configure Galaxy to enable Remote execution mode. You can do this later in
+              Preferences.
+            </p>
+          </details>
+
+          <details class="welcome-details">
+            <summary>Working directory (optional)</summary>
+            <div class="prefs-row">
+              <label for="welcome-cwd">Default directory</label>
+              <div class="prefs-row-with-btn">
+                <input id="welcome-cwd" type="text" placeholder="~/orbit-analyses" />
+                <button id="welcome-browse-cwd" class="plan-btn">Browse</button>
+              </div>
+            </div>
+          </details>
+        </div>
+        <div class="modal-footer">
+          <span id="welcome-error" class="welcome-error"></span>
+          <div class="modal-actions">
+            <button id="welcome-skip" class="plan-btn">Skip — set up later</button>
+            <button id="welcome-save" class="plan-btn execute">Save and continue</button>
           </div>
-        </details>
-      </div>
-      <div class="modal-footer">
-        <span id="welcome-error" class="welcome-error"></span>
-        <div class="modal-actions">
-          <button id="welcome-skip" class="plan-btn">Skip — set up later</button>
-          <button id="welcome-save" class="plan-btn execute">Save and continue</button>
         </div>
       </div>
     </div>
-  </div>
 
-  <!-- /new confirm modal: shown when user starts a fresh session in a dir with an existing notebook -->
-  <div id="new-session-overlay" class="modal-overlay hidden">
-    <div class="modal">
-      <div class="modal-header">
-        <h2>Start a new session?</h2>
-      </div>
-      <div class="modal-body">
-        <p>This directory already contains an analysis notebook.</p>
-        <p>
-          <strong>Keep notebook</strong> — start a fresh chat, but keep the existing
-          <code>notebook.md</code> and activity log so you can continue adding to them.
-        </p>
-        <p>
-          <strong>Start fresh</strong> — delete <code>notebook.md</code>, <code>activity.jsonl</code>,
-          and the session log, then begin a new analysis. The deletion is committed to git,
-          so the old notebook remains recoverable via <code>git log</code> / <code>git show</code>,
-          but from the UI the old analysis is gone.
-        </p>
-      </div>
-      <div class="modal-footer">
-        <div class="modal-actions">
-          <button id="new-session-cancel" class="plan-btn">Cancel</button>
-          <button id="new-session-keep" class="plan-btn primary">Keep notebook</button>
-          <button id="new-session-fresh" class="plan-btn danger">Start fresh</button>
+    <!-- /new confirm modal: shown when user starts a fresh session in a dir with an existing notebook -->
+    <div id="new-session-overlay" class="modal-overlay hidden">
+      <div class="modal">
+        <div class="modal-header">
+          <h2>Start a new session?</h2>
+        </div>
+        <div class="modal-body">
+          <p>This directory already contains an analysis notebook.</p>
+          <p>
+            <strong>Keep notebook</strong> — start a fresh chat, but keep the existing
+            <code>notebook.md</code> and activity log so you can continue adding to them.
+          </p>
+          <p>
+            <strong>Start fresh</strong> — delete <code>notebook.md</code>,
+            <code>activity.jsonl</code>, and the session log, then begin a new analysis. The
+            deletion is committed to git, so the old notebook remains recoverable via
+            <code>git log</code> / <code>git show</code>, but from the UI the old analysis is gone.
+          </p>
+        </div>
+        <div class="modal-footer">
+          <div class="modal-actions">
+            <button id="new-session-cancel" class="plan-btn">Cancel</button>
+            <button id="new-session-keep" class="plan-btn primary">Keep notebook</button>
+            <button id="new-session-fresh" class="plan-btn danger">Start fresh</button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <!-- Generic extension-request modal (input / select / confirm from the brain) -->
-  <div id="ext-overlay" class="modal-overlay hidden">
-    <div class="modal">
-      <div class="modal-header">
-        <h2 id="ext-title">Request</h2>
-      </div>
-      <div class="modal-body">
-        <div id="ext-message" class="ext-message hidden"></div>
-        <input id="ext-input" type="text" class="ext-input hidden" />
-        <div id="ext-options" class="ext-options hidden"></div>
-      </div>
-      <div class="modal-footer">
-        <div class="modal-actions">
-          <button id="ext-cancel" class="plan-btn">Cancel</button>
-          <button id="ext-confirm" class="plan-btn primary hidden">OK</button>
-          <button id="ext-deny" class="plan-btn hidden">No</button>
-          <button id="ext-accept" class="plan-btn primary hidden">Yes</button>
+    <!-- Generic extension-request modal (input / select / confirm from the brain) -->
+    <div id="ext-overlay" class="modal-overlay hidden">
+      <div class="modal">
+        <div class="modal-header">
+          <h2 id="ext-title">Request</h2>
+        </div>
+        <div class="modal-body">
+          <div id="ext-message" class="ext-message hidden"></div>
+          <input id="ext-input" type="text" class="ext-input hidden" />
+          <div id="ext-options" class="ext-options hidden"></div>
+        </div>
+        <div class="modal-footer">
+          <div class="modal-actions">
+            <button id="ext-cancel" class="plan-btn">Cancel</button>
+            <button id="ext-confirm" class="plan-btn primary hidden">OK</button>
+            <button id="ext-deny" class="plan-btn hidden">No</button>
+            <button id="ext-accept" class="plan-btn primary hidden">Yes</button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <!-- Report-issue modal -->
-  <div id="report-overlay" class="modal-overlay hidden">
-    <div class="modal">
-      <div class="modal-header">
-        <h2>Report an issue</h2>
-        <button id="report-close" class="modal-close" title="Close" aria-label="Close">×</button>
-      </div>
-      <div class="modal-body">
-        <div class="report-account-note">
-          You'll need a GitHub account to submit this — your default browser
-          will open the pre-filled issue page on
-          <a href="https://github.com/galaxyproject/loom" target="_blank" rel="noopener noreferrer">github.com/galaxyproject/loom</a>,
-          and you click <em>Submit</em> there. No GitHub account?
-          <a href="https://github.com/signup" target="_blank" rel="noopener noreferrer">Create one</a>
-          — if you're serious about data analysis, you'll want one anyway
-          (code, notebooks, collaboration all live there).
+    <!-- Report-issue modal -->
+    <div id="report-overlay" class="modal-overlay hidden">
+      <div class="modal">
+        <div class="modal-header">
+          <h2>Report an issue</h2>
+          <button id="report-close" class="modal-close" title="Close" aria-label="Close">×</button>
         </div>
-        <div class="prefs-row">
-          <label for="report-title">Title</label>
-          <input id="report-title" type="text" placeholder="Short summary" required />
+        <div class="modal-body">
+          <div class="report-account-note">
+            You'll need a GitHub account to submit this — your default browser will open the
+            pre-filled issue page on
+            <a
+              href="https://github.com/galaxyproject/loom"
+              target="_blank"
+              rel="noopener noreferrer"
+              >github.com/galaxyproject/loom</a
+            >, and you click <em>Submit</em> there. No GitHub account?
+            <a href="https://github.com/signup" target="_blank" rel="noopener noreferrer"
+              >Create one</a
+            >
+            — if you're serious about data analysis, you'll want one anyway (code, notebooks,
+            collaboration all live there).
+          </div>
+          <div class="prefs-row">
+            <label for="report-title">Title</label>
+            <input id="report-title" type="text" placeholder="Short summary" required />
+          </div>
+          <div class="prefs-row">
+            <label for="report-body">What happened?</label>
+            <textarea
+              id="report-body"
+              rows="6"
+              placeholder="Steps to reproduce, expected vs actual, screenshots if relevant..."
+            ></textarea>
+          </div>
+          <div class="report-options">
+            <label><input type="checkbox" id="report-include-sysinfo" /> Include system info</label>
+            <label><input type="checkbox" id="report-include-logs" /> Include logs</label>
+          </div>
+          <details class="report-disclosure">
+            <summary>What's in this report?</summary>
+            <p>
+              <b>System info:</b> Orbit version, OS, Electron/Node versions, LLM model + provider
+              name (no API key), Galaxy connection state (no credentials).
+            </p>
+            <p>
+              <b>Logs:</b> last 30 lines of <code>activity.jsonl</code> (if present in the cwd) and
+              last ~150 lines of the in-app shell stream. These can include filenames, tool
+              arguments, and command output -- review the issue body on GitHub before you click
+              Submit there.
+            </p>
+            <p>
+              Both are off by default. Opt in only when you've decided you're OK sharing them on a
+              public issue.
+            </p>
+          </details>
         </div>
-        <div class="prefs-row">
-          <label for="report-body">What happened?</label>
-          <textarea id="report-body" rows="6" placeholder="Steps to reproduce, expected vs actual, screenshots if relevant..."></textarea>
-        </div>
-        <div class="report-options">
-          <label><input type="checkbox" id="report-include-sysinfo" /> Include system info</label>
-          <label><input type="checkbox" id="report-include-logs" /> Include logs</label>
-        </div>
-        <details class="report-disclosure">
-          <summary>What's in this report?</summary>
-          <p><b>System info:</b> Orbit version, OS, Electron/Node versions, LLM model + provider name (no API key), Galaxy connection state (no credentials).</p>
-          <p><b>Logs:</b> last 30 lines of <code>activity.jsonl</code> (if present in the cwd) and last ~150 lines of the in-app shell stream. These can include filenames, tool arguments, and command output -- review the issue body on GitHub before you click Submit there.</p>
-          <p>Both are off by default. Opt in only when you've decided you're OK sharing them on a public issue.</p>
-        </details>
-      </div>
-      <div class="modal-footer">
-        <div class="modal-actions">
-          <button id="report-cancel" class="plan-btn">Cancel</button>
-          <button id="report-submit" class="plan-btn primary">Open as GitHub issue</button>
+        <div class="modal-footer">
+          <div class="modal-actions">
+            <button id="report-cancel" class="plan-btn">Cancel</button>
+            <button id="report-submit" class="plan-btn primary">Open as GitHub issue</button>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <script type="module" src="./app.ts"></script>
-</body>
+    <script type="module" src="./app.ts"></script>
+  </body>
 </html>

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -45,7 +45,9 @@
   --bg-stripe: rgba(255, 255, 255, 0.02);
   --radius: 6px;
   --font: "JetBrains Mono", Monaco, Menlo, Consolas, "Courier New", monospace;
-  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-sans:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial,
+    sans-serif;
 
   /* Footer control tokens — single source of truth for the unified footer
      pill style. Every footer item (status, model, Galaxy dot, exec-mode
@@ -62,7 +64,8 @@
   box-sizing: border-box;
 }
 
-html, body {
+html,
+body {
   height: 100%;
   overflow: hidden;
   background: var(--bg);
@@ -89,7 +92,9 @@ a {
   text-decoration: underline;
   text-decoration-color: rgba(255, 215, 0, 0.4);
   text-underline-offset: 2px;
-  transition: color 0.15s, text-decoration-color 0.15s;
+  transition:
+    color 0.15s,
+    text-decoration-color 0.15s;
 }
 a:hover {
   color: var(--accent-hover);
@@ -213,7 +218,11 @@ body.files-collapsed #files-divider {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: opacity 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
+  transition:
+    opacity 0.15s,
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
 }
 .files-header-btn:hover {
   opacity: 1;
@@ -236,7 +245,9 @@ body.files-collapsed #files-divider {
   color: var(--text);
 }
 
-#files-tree::-webkit-scrollbar { width: 6px; }
+#files-tree::-webkit-scrollbar {
+  width: 6px;
+}
 #files-tree::-webkit-scrollbar-thumb {
   background: var(--border-strong);
   border-radius: 3px;
@@ -311,7 +322,11 @@ body.files-collapsed #files-divider {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  transition: opacity 0.15s, color 0.15s, border-color 0.15s, background 0.15s;
+  transition:
+    opacity 0.15s,
+    color 0.15s,
+    border-color 0.15s,
+    background 0.15s;
 }
 .pane-title-btn:hover {
   opacity: 1;
@@ -365,7 +380,10 @@ body:not(.artifact-collapsed) #artifact-toggle {
   font-size: 11px;
   cursor: pointer;
   font-family: var(--font-sans);
-  transition: color 0.15s, border-color 0.15s, background 0.15s;
+  transition:
+    color 0.15s,
+    border-color 0.15s,
+    background 0.15s;
 }
 .file-viewer-btn:hover:not(:disabled) {
   color: var(--accent);
@@ -589,7 +607,10 @@ body:not(.artifact-collapsed) #artifact-toggle {
   font-weight: 500;
   white-space: nowrap;
   appearance: none;
-  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
 }
 .footer-control.is-interactive {
   cursor: pointer;
@@ -639,8 +660,16 @@ body:not(.artifact-collapsed) #artifact-toggle {
   animation: heartbeat-pulse 0.8s ease-out;
 }
 @keyframes heartbeat-pulse {
-  0%   { background: var(--accent); transform: scale(1.6); box-shadow: 0 0 4px var(--accent); }
-  100% { background: var(--text-dim); transform: scale(1); box-shadow: 0 0 0 transparent; }
+  0% {
+    background: var(--accent);
+    transform: scale(1.6);
+    box-shadow: 0 0 4px var(--accent);
+  }
+  100% {
+    background: var(--text-dim);
+    transform: scale(1);
+    box-shadow: 0 0 0 transparent;
+  }
 }
 
 #model-indicator {
@@ -662,14 +691,18 @@ body:not(.artifact-collapsed) #artifact-toggle {
 #agent-status {
   margin-right: auto;
 }
-#usage-tokens { white-space: nowrap; }
+#usage-tokens {
+  white-space: nowrap;
+}
 #usage-cost {
   padding-left: 6px;
   border-left: 1px solid rgba(255, 255, 255, 0.15);
   color: var(--accent);
   white-space: nowrap;
 }
-#usage-cost.hidden { display: none; }
+#usage-cost.hidden {
+  display: none;
+}
 
 /* Segmented Local|Cloud control — single rounded-rect container with two
    inner buttons, the active one filled with var(--accent). */
@@ -687,7 +720,9 @@ body:not(.artifact-collapsed) #artifact-toggle {
   height: 100%;
   padding: 0 10px;
   cursor: pointer;
-  transition: background 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
 .footer-control-segmented .exec-mode-btn:hover:not(.active) {
   color: var(--text);
@@ -856,10 +891,19 @@ body:not(.artifact-collapsed) #artifact-toggle {
   font-weight: 600;
   line-height: 1.3;
 }
-.message.assistant:not(.system-info) h1 { font-size: 18px; }
-.message.assistant:not(.system-info) h2 { font-size: 16px; }
-.message.assistant:not(.system-info) h3 { font-size: 14px; }
-.message.assistant:not(.system-info) h4 { font-size: 13px; color: var(--text); }
+.message.assistant:not(.system-info) h1 {
+  font-size: 18px;
+}
+.message.assistant:not(.system-info) h2 {
+  font-size: 16px;
+}
+.message.assistant:not(.system-info) h3 {
+  font-size: 14px;
+}
+.message.assistant:not(.system-info) h4 {
+  font-size: 13px;
+  color: var(--text);
+}
 
 .message.assistant:not(.system-info) ul,
 .message.assistant:not(.system-info) ol {
@@ -997,12 +1041,24 @@ body:not(.artifact-collapsed) #artifact-toggle {
   line-height: 1;
 }
 
-.thinking-dots span:nth-child(2) { animation-delay: 0.2s; }
-.thinking-dots span:nth-child(3) { animation-delay: 0.4s; }
+.thinking-dots span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.thinking-dots span:nth-child(3) {
+  animation-delay: 0.4s;
+}
 
 @keyframes thinking-bounce {
-  0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
-  30% { transform: translateY(-4px); opacity: 1; }
+  0%,
+  60%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.4;
+  }
+  30% {
+    transform: translateY(-4px);
+    opacity: 1;
+  }
 }
 
 .cursor-blink {
@@ -1101,7 +1157,9 @@ body:not(.artifact-collapsed) #artifact-toggle {
   animation: pulse 1.5s ease-in-out infinite;
   pointer-events: none;
 }
-#input-area { position: relative; }
+#input-area {
+  position: relative;
+}
 
 /* Slash-command autocomplete popup. Positioned above the textarea. */
 #slash-popup {
@@ -1119,7 +1177,9 @@ body:not(.artifact-collapsed) #artifact-toggle {
   z-index: 50;
 }
 
-#slash-popup.hidden { display: none; }
+#slash-popup.hidden {
+  display: none;
+}
 
 .slash-popup-item {
   display: flex;
@@ -1131,7 +1191,9 @@ body:not(.artifact-collapsed) #artifact-toggle {
   border-bottom: 1px solid rgba(255, 255, 255, 0.04);
 }
 
-.slash-popup-item:last-child { border-bottom: 0; }
+.slash-popup-item:last-child {
+  border-bottom: 0;
+}
 
 .slash-popup-item:hover,
 .slash-popup-item.active {
@@ -1161,8 +1223,13 @@ body:not(.artifact-collapsed) #artifact-toggle {
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
 }
 
 #input-hint {
@@ -1321,7 +1388,9 @@ body:not(.artifact-collapsed) #artifact-toggle {
   letter-spacing: 0.5px;
   flex-shrink: 0;
 }
-.activity-section-header > span { flex: 1; }
+.activity-section-header > span {
+  flex: 1;
+}
 .activity-section-header button {
   background: none;
   border: 1px solid rgba(255, 255, 255, 0.15);
@@ -1389,7 +1458,10 @@ body:not(.artifact-collapsed) #artifact-toggle {
   text-overflow: ellipsis;
   width: 100%;
 }
-#proc-monitor-table .col-num { text-align: right; color: var(--text-dim); }
+#proc-monitor-table .col-num {
+  text-align: right;
+  color: var(--text-dim);
+}
 .empty-procs {
   padding: 12px;
   color: var(--text-dim);
@@ -1425,11 +1497,23 @@ body:not(.artifact-collapsed) #artifact-toggle {
   padding: 1px 0;
 }
 
-.shell-line.shell-tool-start { color: #80c3ea; }
-.shell-line.shell-tool-end { color: var(--success); padding-left: 16px; }
-.shell-line.shell-tool-error { color: #ff817b; padding-left: 16px; }
-.shell-line.shell-status { color: var(--galaxy-gold-dark); }
-.shell-line.shell-info { color: rgba(255, 255, 255, 0.5); }
+.shell-line.shell-tool-start {
+  color: #80c3ea;
+}
+.shell-line.shell-tool-end {
+  color: var(--success);
+  padding-left: 16px;
+}
+.shell-line.shell-tool-error {
+  color: #ff817b;
+  padding-left: 16px;
+}
+.shell-line.shell-status {
+  color: var(--galaxy-gold-dark);
+}
+.shell-line.shell-info {
+  color: rgba(255, 255, 255, 0.5);
+}
 .shell-line.shell-stdout {
   color: rgba(255, 255, 255, 0.7);
   padding-left: 16px;
@@ -1571,7 +1655,7 @@ body:not(.artifact-collapsed) #artifact-toggle {
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 8px;
-  box-shadow: 0 10px 40px rgba(0,0,0,0.3);
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
   width: 560px;
   max-width: 90vw;
   max-height: 85vh;
@@ -1605,7 +1689,9 @@ body:not(.artifact-collapsed) #artifact-toggle {
   cursor: pointer;
   padding: 0 6px;
   opacity: 0.7;
-  transition: opacity 0.15s, color 0.15s;
+  transition:
+    opacity 0.15s,
+    color 0.15s;
 }
 
 .modal-close:hover {
@@ -1667,7 +1753,9 @@ body:not(.artifact-collapsed) #artifact-toggle {
   font-family: var(--font-sans);
   font-size: 13px;
   outline: none;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 }
 
 .prefs-row textarea {
@@ -1792,11 +1880,23 @@ body:not(.artifact-collapsed) #artifact-toggle {
   border-color: var(--accent-light);
 }
 
-.prefs-table .prefs-skills-name { width: 18%; }
-.prefs-table .prefs-skills-url { width: 50%; }
-.prefs-table .prefs-skills-branch { width: 12%; }
-.prefs-table .prefs-skills-enabled { width: 8%; text-align: center; }
-.prefs-table .prefs-skills-actions { width: 12%; text-align: right; }
+.prefs-table .prefs-skills-name {
+  width: 18%;
+}
+.prefs-table .prefs-skills-url {
+  width: 50%;
+}
+.prefs-table .prefs-skills-branch {
+  width: 12%;
+}
+.prefs-table .prefs-skills-enabled {
+  width: 8%;
+  text-align: center;
+}
+.prefs-table .prefs-skills-actions {
+  width: 12%;
+  text-align: right;
+}
 
 .prefs-skills-actions .plan-btn {
   padding: 4px 10px;
@@ -1829,9 +1929,15 @@ body:not(.artifact-collapsed) #artifact-toggle {
   padding: 4px 0;
   color: var(--text-dim);
 }
-.api-key-status.checking { color: var(--text-dim); }
-.api-key-status.valid   { color: #2ea043; }
-.api-key-status.invalid { color: #f85149; }
+.api-key-status.checking {
+  color: var(--text-dim);
+}
+.api-key-status.valid {
+  color: #2ea043;
+}
+.api-key-status.invalid {
+  color: #f85149;
+}
 
 .modal-footer {
   display: flex;
@@ -1882,7 +1988,10 @@ body:not(.artifact-collapsed) #artifact-toggle {
   font: inherit;
   font-size: 12px;
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
   white-space: nowrap;
 }
 .plan-btn:hover:not(:disabled) {
@@ -2012,7 +2121,9 @@ body:not(.artifact-collapsed) #artifact-toggle {
   font-weight: 400;
   color: rgba(255, 255, 255, 0.6);
   cursor: pointer;
-  transition: background 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
 
 .pane-tab-close:hover {
@@ -2140,8 +2251,12 @@ body:not(.artifact-collapsed) #artifact-toggle {
   display: none;
   vertical-align: -2px;
 }
-.notify-marker-warning { color: var(--warning); }
-.notify-marker-error { color: var(--error); }
+.notify-marker-warning {
+  color: var(--warning);
+}
+.notify-marker-error {
+  color: var(--error);
+}
 /* Linux without colored emoji: prefer the SVG. The font-family check
    below targets browsers that fall back to system-monospace for emoji
    codepoints (a tell-tale on Ubuntu without Noto Color Emoji). */
@@ -2150,8 +2265,12 @@ body:not(.artifact-collapsed) #artifact-toggle {
 }
 /* Force-SVG for users who set --no-emoji-prefix; toggleable from
    Preferences later if needed. */
-.no-emoji .notify-marker-emoji { display: none; }
-.no-emoji .notify-marker-svg { display: inline-block; }
+.no-emoji .notify-marker-emoji {
+  display: none;
+}
+.no-emoji .notify-marker-svg {
+  display: inline-block;
+}
 
 /* ── Extension request modal ───────────────────────────────────────────── */
 
@@ -2198,16 +2317,23 @@ body:not(.artifact-collapsed) #artifact-toggle {
   border-color: var(--accent);
 }
 
-
 /* ── Animations ────────────────────────────────────────────────────────────── */
 
 @keyframes fade-up {
-  from { opacity: 0; transform: translateY(8px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes blink {
-  50% { opacity: 0; }
+  50% {
+    opacity: 0;
+  }
 }
 
 /* ── Results ───────────────────────────────────────────────────────────────── */
@@ -2228,11 +2354,24 @@ body:not(.artifact-collapsed) #artifact-toggle {
   color: var(--text);
 }
 
-.result-markdown p { margin: 6px 0; }
-.result-markdown h1, .result-markdown h2, .result-markdown h3 { margin: 12px 0 6px; color: var(--text-bright); }
-.result-markdown h1 { font-size: 16px; }
-.result-markdown h2 { font-size: 14px; }
-.result-markdown h3 { font-size: 13px; }
+.result-markdown p {
+  margin: 6px 0;
+}
+.result-markdown h1,
+.result-markdown h2,
+.result-markdown h3 {
+  margin: 12px 0 6px;
+  color: var(--text-bright);
+}
+.result-markdown h1 {
+  font-size: 16px;
+}
+.result-markdown h2 {
+  font-size: 14px;
+}
+.result-markdown h3 {
+  font-size: 13px;
+}
 
 .result-markdown code {
   font-family: var(--font);
@@ -2251,7 +2390,10 @@ body:not(.artifact-collapsed) #artifact-toggle {
   margin: 8px 0;
 }
 
-.result-markdown pre code { background: transparent; padding: 0; }
+.result-markdown pre code {
+  background: transparent;
+  padding: 0;
+}
 
 .result-markdown ul,
 .result-markdown ol {
@@ -2271,7 +2413,9 @@ body:not(.artifact-collapsed) #artifact-toggle {
   margin: 2px 0;
 }
 
-.result-markdown strong { color: var(--text-bright); }
+.result-markdown strong {
+  color: var(--text-bright);
+}
 
 .result-markdown table {
   width: 100%;
@@ -2316,13 +2460,42 @@ body:not(.artifact-collapsed) #artifact-toggle {
 }
 
 /* Team dispatch (multi-agent critic loop) tool card */
-.team-dispatch-card { margin: 6px 0; border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; }
-.team-dispatch-header { width: 100%; text-align: left; background: var(--bg-hover); border: none; color: var(--text); padding: 6px 10px; cursor: pointer; font: inherit; }
-.team-dispatch-body { padding: 6px 10px; background: var(--bg-surface); }
-.team-dispatch-body.hidden { display: none; }
-.team-turn { margin: 6px 0; }
-.team-turn-meta { font-size: 11px; color: var(--text-dim); font-family: var(--font); }
-.team-turn-content { white-space: pre-wrap; font: inherit; margin: 2px 0 8px; }
+.team-dispatch-card {
+  margin: 6px 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.team-dispatch-header {
+  width: 100%;
+  text-align: left;
+  background: var(--bg-hover);
+  border: none;
+  color: var(--text);
+  padding: 6px 10px;
+  cursor: pointer;
+  font: inherit;
+}
+.team-dispatch-body {
+  padding: 6px 10px;
+  background: var(--bg-surface);
+}
+.team-dispatch-body.hidden {
+  display: none;
+}
+.team-turn {
+  margin: 6px 0;
+}
+.team-turn-meta {
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: var(--font);
+}
+.team-turn-content {
+  white-space: pre-wrap;
+  font: inherit;
+  margin: 2px 0 8px;
+}
 
 /* Plan draft card — rendered from ```plan``` fences in assistant messages */
 .plan-draft-card {
@@ -2345,14 +2518,20 @@ body:not(.artifact-collapsed) #artifact-toggle {
 .plan-draft-card-body {
   padding: 8px 12px;
 }
-.plan-draft-card-body > :first-child { margin-top: 0; }
-.plan-draft-card-body > :last-child { margin-bottom: 0; }
+.plan-draft-card-body > :first-child {
+  margin-top: 0;
+}
+.plan-draft-card-body > :last-child {
+  margin-bottom: 0;
+}
 .plan-draft-card-body h1 {
   font-size: 15px;
   margin: 0 0 6px;
   color: var(--text);
 }
-.plan-draft-card-body ul { padding-left: 18px; }
+.plan-draft-card-body ul {
+  padding-left: 18px;
+}
 .plan-draft-card-actions {
   display: flex;
   gap: 6px;
@@ -2366,7 +2545,9 @@ body:not(.artifact-collapsed) #artifact-toggle {
   letter-spacing: 0;
   font-weight: 400;
 }
-.plan-draft-card.rejected { opacity: 0.6; }
+.plan-draft-card.rejected {
+  opacity: 0.6;
+}
 .plan-draft-card.rejected .plan-draft-card-header::after {
   content: " · rejected";
   color: var(--text-dim);

--- a/bin/loom.js
+++ b/bin/loom.js
@@ -32,18 +32,13 @@ const piModelRegistryModulePath = join(piPackageDir, "dist/core/model-registry.j
 const userArgs = process.argv.slice(2);
 
 function hasArg(flag) {
-  return userArgs.includes(flag) || userArgs.some(arg => arg.startsWith(`${flag}=`));
+  return userArgs.includes(flag) || userArgs.some((arg) => arg.startsWith(`${flag}=`));
 }
 
-const isInformationalCommand = [
-  "--help",
-  "-h",
-  "--version",
-  "--list-models",
-].some(hasArg);
+const isInformationalCommand = ["--help", "-h", "--version", "--list-models"].some(hasArg);
 
 function getListModelsSearchPattern() {
-  const index = userArgs.findIndex(arg => arg === "--list-models");
+  const index = userArgs.findIndex((arg) => arg === "--list-models");
   if (index === -1) return undefined;
   const candidate = userArgs[index + 1];
   if (!candidate || candidate.startsWith("-") || candidate.startsWith("@")) {
@@ -87,8 +82,7 @@ async function handleInformationalCommand() {
 // each shell's own dir.
 // ─────────────────────────────────────────────────────────────────────────────
 
-const agentDir = process.env.PI_CODING_AGENT_DIR
-  || join(homedir(), ".pi", "agent");
+const agentDir = process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Apply consolidated config
@@ -188,7 +182,11 @@ if (!isInformationalCommand) {
   // mode option on writeFileSync sets perms only when the file is *created*;
   // a follow-up chmod ensures we tighten existing files too.
   writeFileSync(mcpConfigPath, JSON.stringify(mcpConfig, null, 2), { mode: 0o600 });
-  try { chmodSync(mcpConfigPath, 0o600); } catch { /* best-effort */ }
+  try {
+    chmodSync(mcpConfigPath, 0o600);
+  } catch {
+    /* best-effort */
+  }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -197,21 +195,33 @@ if (!isInformationalCommand) {
 
 function checkLLMProvider() {
   const skipFlags = ["--version", "--help", "-h", "--api-key", "--list-models"];
-  if (userArgs.some(a => skipFlags.some(f => a.startsWith(f)))) return;
+  if (userArgs.some((a) => skipFlags.some((f) => a.startsWith(f)))) return;
   if (hasArg("--provider")) return;
 
   // Consolidated config has an API key
   if (loomConfig.llm?.apiKey) return;
 
   const providerEnvVars = [
-    "ANTHROPIC_API_KEY", "ANTHROPIC_OAUTH_TOKEN",
-    "OPENAI_API_KEY", "GEMINI_API_KEY", "GROQ_API_KEY",
-    "MISTRAL_API_KEY", "XAI_API_KEY", "OPENROUTER_API_KEY",
-    "CEREBRAS_API_KEY", "AI_GATEWAY_API_KEY", "HF_TOKEN",
-    "AWS_PROFILE", "AWS_ACCESS_KEY_ID", "GOOGLE_CLOUD_PROJECT",
-    "AZURE_OPENAI_API_KEY", "COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_OAUTH_TOKEN",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GROQ_API_KEY",
+    "MISTRAL_API_KEY",
+    "XAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "CEREBRAS_API_KEY",
+    "AI_GATEWAY_API_KEY",
+    "HF_TOKEN",
+    "AWS_PROFILE",
+    "AWS_ACCESS_KEY_ID",
+    "GOOGLE_CLOUD_PROJECT",
+    "AZURE_OPENAI_API_KEY",
+    "COPILOT_GITHUB_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
   ];
-  if (providerEnvVars.some(v => process.env[v])) return;
+  if (providerEnvVars.some((v) => process.env[v])) return;
 
   // Config has an encrypted key but this CLI can't decrypt it — Electron's
   // safeStorage lives in the Orbit main process. Point the user at the two
@@ -245,7 +255,7 @@ Do one of the following:
     try {
       const models = JSON.parse(readFileSync(modelsPath, "utf-8"));
       const providers = models.providers || {};
-      if (Object.values(providers).some(p => p.apiKey)) return;
+      if (Object.values(providers).some((p) => p.apiKey)) return;
     } catch {}
   }
 
@@ -286,7 +296,11 @@ if (!hasArg("--provider")) {
   // Prefer consolidated config
   if (loomConfig.llm?.provider) {
     providerArgs.push("--provider", loomConfig.llm.provider);
-    if (loomConfig.llm.model && !userArgs.includes("--model") && !userArgs.some(a => a.startsWith("--model="))) {
+    if (
+      loomConfig.llm.model &&
+      !userArgs.includes("--model") &&
+      !userArgs.some((a) => a.startsWith("--model="))
+    ) {
       providerArgs.push("--model", loomConfig.llm.model);
     }
   } else {
@@ -299,7 +313,7 @@ if (!hasArg("--provider")) {
         const [providerName, providerConfig] = Object.entries(providers)[0] || [];
         if (providerName && providerConfig?.models?.length) {
           providerArgs.push("--provider", providerName);
-          if (!userArgs.includes("--model") && !userArgs.some(a => a.startsWith("--model="))) {
+          if (!userArgs.includes("--model") && !userArgs.some((a) => a.startsWith("--model="))) {
             providerArgs.push("--model", providerConfig.models[0].id);
           }
         }
@@ -309,7 +323,16 @@ if (!hasArg("--provider")) {
 }
 
 // Build args: inject extensions, pass through everything else
-const args = ["-e", mcpAdapterPath, "-e", webAccessPath, "-e", extensionPath, ...providerArgs, ...userArgs];
+const args = [
+  "-e",
+  mcpAdapterPath,
+  "-e",
+  webAccessPath,
+  "-e",
+  extensionPath,
+  ...providerArgs,
+  ...userArgs,
+];
 
 if (await handleInformationalCommand()) {
   process.exit(0);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,7 +138,7 @@ Edit/Write tool rewrites notebook.md
 → if loom.managed: commitFile(notebookPath, "Notebook updated")
 ```
 
-There is no separate plan/state mutation path -- the markdown file *is* the state.
+There is no separate plan/state mutation path -- the markdown file _is_ the state.
 
 ### Galaxy invocation tracking
 

--- a/docs/recipes/literature-review.md
+++ b/docs/recipes/literature-review.md
@@ -29,15 +29,15 @@ Flag **gaps**. If a query returns zero meaningful hits ("no genomic foundation m
 
 For each hit that survives a title-and-abstract skim, capture:
 
-| Field | Required | Notes |
-|---|---|---|
-| title | yes | Full title, not abbreviated |
-| first author + year | yes | e.g., "Zhou et al. 2018" |
-| venue | yes | Journal or preprint server |
-| PMID | if available | Required for PubMed-indexed work |
-| DOI | if available | Preferred for preprints and non-PubMed venues |
-| role | yes | One of: precedent, comparator, limitation, replication, novel-connection |
-| relevance | yes | 1-2 sentences, concrete. Not "is related to X" -- say what it supports, refutes, or caveats |
+| Field               | Required     | Notes                                                                                       |
+| ------------------- | ------------ | ------------------------------------------------------------------------------------------- |
+| title               | yes          | Full title, not abbreviated                                                                 |
+| first author + year | yes          | e.g., "Zhou et al. 2018"                                                                    |
+| venue               | yes          | Journal or preprint server                                                                  |
+| PMID                | if available | Required for PubMed-indexed work                                                            |
+| DOI                 | if available | Preferred for preprints and non-PubMed venues                                               |
+| role                | yes          | One of: precedent, comparator, limitation, replication, novel-connection                    |
+| relevance           | yes          | 1-2 sentences, concrete. Not "is related to X" -- say what it supports, refutes, or caveats |
 
 Fifteen to twenty-five candidates is a healthy pre-validation pool for a single research question. Fewer suggests the search was too narrow; many more suggests queries were too generic.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,87 @@
+import js from "@eslint/js";
+import globals from "globals";
+import reactHooks from "eslint-plugin-react-hooks";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  {
+    ignores: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/.vite/**",
+      "app/out/**",
+      "coverage/**",
+      ".worktrees/**",
+      ".claude/**",
+      "package-lock.json",
+      "app/package-lock.json",
+      "web/package-lock.json",
+      "*.jsonl",
+      "*-notebook.md",
+    ],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["**/*.{js,mjs,cjs,ts,tsx}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: {
+        ...globals.es2026,
+      },
+    },
+    rules: {
+      "no-empty": ["error", { allowEmptyCatch: true }],
+      "no-control-regex": "off",
+    },
+  },
+  {
+    files: ["**/*.{js,mjs,cjs}"],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+  {
+    files: ["**/*.{ts,tsx}"],
+    rules: {
+      "no-undef": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+          varsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+  {
+    files: ["tests/**/*.ts"],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.vitest,
+      },
+    },
+  },
+  {
+    files: ["app/src/preload/**/*.{ts,tsx}", "app/src/renderer/**/*.{ts,tsx}", "web/**/*.{ts,tsx}"],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+    plugins: {
+      "react-hooks": reactHooks,
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+    },
+  },
+);

--- a/extensions/loom/activity-hooks.ts
+++ b/extensions/loom/activity-hooks.ts
@@ -14,25 +14,17 @@ import { appendActivityEvent } from "./activity";
 
 // Read-only / filesystem-traversal tools clutter the log without telling the
 // user anything they'd want to re-read later. Omit them.
-const NOISY_TOOLS = new Set([
-  "read",
-  "grep",
-  "glob",
-  "ls",
-  "find",
-]);
+const NOISY_TOOLS = new Set(["read", "grep", "glob", "ls", "find"]);
 
 // Tools whose argument shape is known to carry credentials. activity.jsonl
 // lives in the project cwd and users may share the dir (commit it, send it
 // over for help) — never persist secrets there.
-const CREDENTIAL_TOOLS = new Set([
-  "galaxy_connect",
-  "galaxy_set_profile",
-]);
+const CREDENTIAL_TOOLS = new Set(["galaxy_connect", "galaxy_set_profile"]);
 
 // Argument keys that universally indicate secrets, redacted on every tool.
 const CREDENTIAL_KEYS = new Set([
-  "apikey", "api_key",
+  "apikey",
+  "api_key",
   "authorization",
   "token",
   "password",
@@ -77,7 +69,9 @@ function summarizeResult(result: unknown): string {
   if (result == null) return "";
   const str = typeof result === "string" ? result : JSON.stringify(result);
   if (str.length <= RESULT_SUMMARY_MAX) return str;
-  return str.slice(0, RESULT_SUMMARY_MAX) + `… [truncated ${str.length - RESULT_SUMMARY_MAX} chars]`;
+  return (
+    str.slice(0, RESULT_SUMMARY_MAX) + `… [truncated ${str.length - RESULT_SUMMARY_MAX} chars]`
+  );
 }
 
 export function registerActivityHooks(pi: ExtensionAPI): void {

--- a/extensions/loom/activity.ts
+++ b/extensions/loom/activity.ts
@@ -93,10 +93,7 @@ export function loadActivityLog(sessionDir: string): void {
  * on failure. Also updates the in-memory mirror and notifies listeners so
  * the UI can refresh incrementally.
  */
-export function appendActivityEvent(
-  sessionDir: string,
-  event: ActivityEvent,
-): string | null {
+export function appendActivityEvent(sessionDir: string, event: ActivityEvent): string | null {
   const filePath = path.join(sessionDir, "activity.jsonl");
   try {
     mkdirSync(sessionDir, { recursive: true });

--- a/extensions/loom/config.ts
+++ b/extensions/loom/config.ts
@@ -1,8 +1,3 @@
-export {
-  getConfigDir,
-  getConfigPath,
-  loadConfig,
-  saveConfig,
-} from "../../shared/loom-config.js";
+export { getConfigDir, getConfigPath, loadConfig, saveConfig } from "../../shared/loom-config.js";
 
 export type { LoomConfig } from "../../shared/loom-config.js";

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -544,9 +544,9 @@ function buildSkillsContext(): string {
   sections.push("");
   sections.push(
     `Use the \`skills_fetch({ repo, path })\` tool to load a skill on demand. ` +
-    `**Don't guess operational patterns from training data — fetch the ` +
-    `relevant skill first.** Each fetch is cached locally for 24h. ` +
-    `When \`repo\` is omitted, the first enabled repo is used.`,
+      `**Don't guess operational patterns from training data — fetch the ` +
+      `relevant skill first.** Each fetch is cached locally for 24h. ` +
+      `When \`repo\` is omitted, the first enabled repo is used.`,
   );
   sections.push("");
 
@@ -563,9 +563,7 @@ function buildSkillsContext(): string {
   if (repos.some((r) => r.name === "galaxy-skills")) {
     sections.push(`### When to fetch which galaxy-skills skill`);
     sections.push("");
-    sections.push(
-      `Always pass \`repo: "galaxy-skills"\` (or omit if it's the default).`,
-    );
+    sections.push(`Always pass \`repo: "galaxy-skills"\` (or omit if it's the default).`);
     sections.push("");
     sections.push(`- **Manipulating dataset collections** (filter, sort, relabel, restructure,
   flatten, nest, merge; building paired collections from PE FASTQ; mapping
@@ -632,13 +630,11 @@ fully before acting on what it teaches.`);
     sections.push("");
     sections.push(
       `For repos other than galaxy-skills, fetch \`AGENTS.md\` (or \`README.md\` ` +
-      `if AGENTS.md is missing) first to discover the available skill paths:`,
+        `if AGENTS.md is missing) first to discover the available skill paths:`,
     );
     sections.push("");
     for (const r of otherRepos) {
-      sections.push(
-        `- \`skills_fetch({ repo: "${r.name}", path: "AGENTS.md" })\``,
-      );
+      sections.push(`- \`skills_fetch({ repo: "${r.name}", path: "AGENTS.md" })\``);
     }
     sections.push("");
   }
@@ -706,7 +702,6 @@ asks what was said.
 }
 
 export function setupContextInjection(pi: ExtensionAPI): void {
-
   pi.on("before_agent_start", async (_event, ctx) => {
     const systemPrompt = [
       buildOperatingDisciplineBlock(),

--- a/extensions/loom/execution-commands.ts
+++ b/extensions/loom/execution-commands.ts
@@ -16,15 +16,15 @@ export function registerExecutionCommands(pi: ExtensionAPI): void {
 
     pi.sendUserMessage(
       `The user typed /execute (or /run). Read \`${nbPath}\`, locate the most ` +
-      `recent plan section that has unchecked steps (\`- [ ]\`), and execute ` +
-      `the next pending step. For each step:\n` +
-      `1. Decide local vs Galaxy per the plan's routing tag (see [local|hybrid|remote] in the section header).\n` +
-      `2. For Galaxy steps: invoke via Galaxy MCP, then call galaxy_invocation_record(...).\n` +
-      `3. For local steps: run via bash; capture results into the notebook.\n` +
-      `4. After completion, edit the markdown checkbox to \`- [x]\` (or \`- [!]\` on failure).\n` +
-      `5. Periodically call galaxy_invocation_check_all to advance in-flight Galaxy work.\n` +
-      `Do NOT narrate progress in chat — the Notebook tab shows it. ` +
-      `Stop on failure; do not auto-advance past errors.`
+        `recent plan section that has unchecked steps (\`- [ ]\`), and execute ` +
+        `the next pending step. For each step:\n` +
+        `1. Decide local vs Galaxy per the plan's routing tag (see [local|hybrid|remote] in the section header).\n` +
+        `2. For Galaxy steps: invoke via Galaxy MCP, then call galaxy_invocation_record(...).\n` +
+        `3. For local steps: run via bash; capture results into the notebook.\n` +
+        `4. After completion, edit the markdown checkbox to \`- [x]\` (or \`- [!]\` on failure).\n` +
+        `5. Periodically call galaxy_invocation_check_all to advance in-flight Galaxy work.\n` +
+        `Do NOT narrate progress in chat — the Notebook tab shows it. ` +
+        `Stop on failure; do not auto-advance past errors.`,
     );
   };
 

--- a/extensions/loom/galaxy-api.ts
+++ b/extensions/loom/galaxy-api.ts
@@ -55,7 +55,7 @@ export function getGalaxyConfig(): GalaxyConfig | null {
   const url = process.env.GALAXY_URL;
   const apiKey = process.env.GALAXY_API_KEY;
   if (!url || !apiKey) return null;
-  return { url: url.replace(/\/+$/, ''), apiKey };
+  return { url: url.replace(/\/+$/, ""), apiKey };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -68,12 +68,12 @@ export async function galaxyGet<T = unknown>(path: string, signal?: AbortSignal)
 
   const url = `${config.url}/api${path}`;
   const resp = await fetch(url, {
-    headers: { 'x-api-key': config.apiKey },
+    headers: { "x-api-key": config.apiKey },
     signal,
   });
 
   if (!resp.ok) {
-    const body = await resp.text().catch(() => '');
+    const body = await resp.text().catch(() => "");
     throw new Error(`Galaxy API ${resp.status}: ${body || resp.statusText}`);
   }
 

--- a/extensions/loom/git.ts
+++ b/extensions/loom/git.ts
@@ -148,10 +148,7 @@ export function commitNotebook(notebookPath: string, message: string): void {
 /**
  * Build a human-readable commit message from a change type and its data.
  */
-export function buildCommitMessage(
-  changeType: string,
-  data: Record<string, unknown>,
-): string {
+export function buildCommitMessage(changeType: string, data: Record<string, unknown>): string {
   switch (changeType) {
     case "step_added":
       return `Add step: ${(data.step as { name?: string })?.name ?? "unknown"}`;

--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -19,10 +19,7 @@ import { isTeamDispatchEnabled } from "./teams/is-enabled";
 import { registerSessionIndexTools } from "./session-index/tools";
 import { isSessionIndexEnabled } from "./session-index/is-enabled";
 import * as fs from "fs";
-import {
-  getState,
-  getNotebookPath,
-} from "./state";
+import { getState, getNotebookPath } from "./state";
 import {
   loadProfiles,
   saveProfile,
@@ -33,7 +30,6 @@ import {
 import { LoomWidgetKey, encodeMarkdownWidget } from "../../shared/loom-shell-contract.js";
 
 export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
-
   warnOnUnusableActiveProfile();
 
   setupUIBridge(pi);
@@ -55,17 +51,18 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
   // /connect — Galaxy connection with profile support
   // ─────────────────────────────────────────────────────────────────────────────
   pi.registerCommand("connect", {
-    description: "Connect to Galaxy server. Use /connect to pick a profile or add a new one, /connect <name> to switch.",
+    description:
+      "Connect to Galaxy server. Use /connect to pick a profile or add a new one, /connect <name> to switch.",
     handler: async (args, ctx) => {
       const { profiles, active } = loadProfiles();
       const profileNames = Object.keys(profiles);
 
       async function reloadOrMessage(url: string) {
-        if (typeof ctx.reload === 'function') {
+        if (typeof ctx.reload === "function") {
           await ctx.reload();
         } else {
           pi.sendUserMessage(
-            `Please connect to Galaxy at ${url} using the API key from environment variables.`
+            `Please connect to Galaxy at ${url} using the API key from environment variables.`,
           );
         }
       }
@@ -76,13 +73,16 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
           ctx.ui.notify(`Switched to ${requestedName} (${profiles[requestedName].url})`, "info");
           await reloadOrMessage(profiles[requestedName].url);
         } else {
-          ctx.ui.notify(`Unknown profile "${requestedName}". Use /profiles to see available profiles.`, "warning");
+          ctx.ui.notify(
+            `Unknown profile "${requestedName}". Use /profiles to see available profiles.`,
+            "warning",
+          );
         }
         return;
       }
 
       if (profileNames.length > 1) {
-        const choices = profileNames.map(name => {
+        const choices = profileNames.map((name) => {
           const marker = name === active ? "* " : "  ";
           return `${marker}${name} (${profiles[name].url})`;
         });
@@ -94,7 +94,8 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
           return;
         }
 
-        const selectedIndex = typeof selection === 'number' ? selection : choices.indexOf(selection);
+        const selectedIndex =
+          typeof selection === "number" ? selection : choices.indexOf(selection);
 
         if (selectedIndex >= 0 && selectedIndex < profileNames.length) {
           const name = profileNames[selectedIndex];
@@ -103,16 +104,18 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
           await reloadOrMessage(profiles[name].url);
           return;
         }
-      } else if (profileNames.length === 1 && active && process.env.GALAXY_URL && process.env.GALAXY_API_KEY) {
+      } else if (
+        profileNames.length === 1 &&
+        active &&
+        process.env.GALAXY_URL &&
+        process.env.GALAXY_API_KEY
+      ) {
         ctx.ui.notify(`Connecting to ${profiles[active].url}...`, "info");
         await reloadOrMessage(profiles[active].url);
         return;
       }
 
-      const galaxyUrl = await ctx.ui.input(
-        "Galaxy Server URL",
-        "https://usegalaxy.org"
-      );
+      const galaxyUrl = await ctx.ui.input("Galaxy Server URL", "https://usegalaxy.org");
       if (!galaxyUrl) {
         ctx.ui.notify("Connection cancelled", "warning");
         return;
@@ -120,7 +123,7 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
 
       ctx.ui.notify(
         "To get your API key: Log into Galaxy → User → Preferences → Manage API Key",
-        "info"
+        "info",
       );
       const apiKey = await ctx.ui.input("Galaxy API Key");
       if (!apiKey) {
@@ -207,7 +210,10 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
         }
         return;
       }
-      ctx.ui.notify("No notebook in cwd. A new notebook.md is created automatically on session start.", "info");
+      ctx.ui.notify(
+        "No notebook in cwd. A new notebook.md is created automatically on session start.",
+        "info",
+      );
     },
   });
 
@@ -240,27 +246,29 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
 
     if (event.toolName === "galaxy_connect" && !event.isError) {
       try {
-        const resultText = typeof event.result === 'string'
-          ? event.result
-          : JSON.stringify(event.result);
-        if (resultText.includes('"success": true') || resultText.includes('success')) {
+        const resultText =
+          typeof event.result === "string" ? event.result : JSON.stringify(event.result);
+        if (resultText.includes('"success": true') || resultText.includes("success")) {
           const state = getState();
           state.galaxyConnected = true;
         }
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
     }
 
     if (event.toolName === "galaxy_create_history" && !event.isError) {
       try {
-        const resultText = typeof event.result === 'string'
-          ? event.result
-          : JSON.stringify(event.result);
+        const resultText =
+          typeof event.result === "string" ? event.result : JSON.stringify(event.result);
         const match = resultText.match(/"id":\s*"([^"]+)"/);
         if (match) {
           const state = getState();
           state.currentHistoryId = match[1];
         }
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
     }
   });
 
@@ -268,18 +276,20 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
     if (event.toolName === "galaxy_connect") {
       try {
         const firstContent = event.content?.[0];
-        const resultText = firstContent && 'text' in firstContent ? firstContent.text : undefined;
+        const resultText = firstContent && "text" in firstContent ? firstContent.text : undefined;
         if (resultText && resultText.includes('"success": true')) {
           const state = getState();
           state.galaxyConnected = true;
         }
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
     }
 
     if (event.toolName === "galaxy_create_history") {
       try {
         const firstContent = event.content?.[0];
-        const resultText = firstContent && 'text' in firstContent ? firstContent.text : undefined;
+        const resultText = firstContent && "text" in firstContent ? firstContent.text : undefined;
         if (resultText) {
           const match = resultText.match(/"id":\s*"([^"]+)"/);
           if (match) {
@@ -287,7 +297,9 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
             state.currentHistoryId = match[1];
           }
         }
-      } catch { /* ignore */ }
+      } catch {
+        /* ignore */
+      }
     }
   });
 }

--- a/extensions/loom/notebook-writer.ts
+++ b/extensions/loom/notebook-writer.ts
@@ -36,7 +36,13 @@ export function withNotebookLock<T>(filePath: string, work: () => Promise<T>): P
   const next = prev.then(work, work);
   // Always clear so completed locks don't pin memory; the chain is preserved
   // through the Promise we just created.
-  writeLocks.set(filePath, next.then(() => undefined, () => undefined));
+  writeLocks.set(
+    filePath,
+    next.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
   return next;
 }
 
@@ -46,10 +52,7 @@ export function withNotebookLock<T>(filePath: string, work: () => Promise<T>): P
  * content — never partial. The file watcher in state.ts may still fire
  * on the rename, but it can no longer observe a half-written file.
  */
-export async function writeNotebook(
-  filePath: string,
-  content: string,
-): Promise<void> {
+export async function writeNotebook(filePath: string, content: string): Promise<void> {
   const tmp = `${filePath}.tmp`;
   // O_TRUNC | O_WRONLY | O_CREAT via fs.writeFile — but write to tmp first.
   await fs.writeFile(tmp, content, "utf-8");

--- a/extensions/loom/profiles.ts
+++ b/extensions/loom/profiles.ts
@@ -34,7 +34,7 @@ export class EncryptedProfileUnavailableError extends Error {
   constructor(public profileName: string) {
     super(
       `Profile "${profileName}" has only an encrypted API key; this process can't decrypt it. ` +
-      `Run from Orbit (auto-injects the key) or export GALAXY_API_KEY explicitly.`,
+        `Run from Orbit (auto-injects the key) or export GALAXY_API_KEY explicitly.`,
     );
     this.name = "EncryptedProfileUnavailableError";
   }
@@ -83,7 +83,10 @@ export function profileNameFromUrl(url: string): string {
     return host.replace(/\./g, "-").replace(/-+$/, "");
   } catch {
     // Fallback: slugify the whole string
-    return url.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-|-$/g, "").toLowerCase();
+    return url
+      .replace(/[^a-zA-Z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")
+      .toLowerCase();
   }
 }
 
@@ -100,7 +103,9 @@ export function profileNameFromUrl(url: string): string {
  */
 export function validateGalaxyUrl(url: string): { ok: true } | { ok: false; reason: string } {
   let parsed: URL;
-  try { parsed = new URL(url.trim()); } catch {
+  try {
+    parsed = new URL(url.trim());
+  } catch {
     return { ok: false, reason: "Not a valid URL." };
   }
   if (parsed.protocol === "http:") {
@@ -182,8 +187,8 @@ export function warnOnUnusableActiveProfile(): void {
   if (!profile.apiKeyEncrypted) return;
   console.error(
     `[galaxy] Active profile "${active}" has only an encrypted API key and ` +
-    `GALAXY_API_KEY is not set in the environment. Galaxy calls will fail. ` +
-    `Run from Orbit (auto-injects the decrypted key) or export GALAXY_API_KEY explicitly.`,
+      `GALAXY_API_KEY is not set in the environment. Galaxy calls will fail. ` +
+      `Run from Orbit (auto-injects the decrypted key) or export GALAXY_API_KEY explicitly.`,
   );
 }
 
@@ -217,8 +222,8 @@ export function switchProfile(name: string): boolean {
     delete process.env.GALAXY_API_KEY;
     console.warn(
       `[galaxy] Profile "${name}" has only an encrypted API key. Cleared ` +
-      `GALAXY_API_KEY in this session; restart the shell so Orbit can ` +
-      `re-inject the decrypted key for this profile.`,
+        `GALAXY_API_KEY in this session; restart the shell so Orbit can ` +
+        `re-inject the decrypted key for this profile.`,
     );
   }
   // mcp.json holds a literal "${GALAXY_API_KEY}" reference; pi-mcp-adapter
@@ -268,7 +273,11 @@ export function syncMcpConfig(url: string): void {
       // 0600 first so a concurrent reader can't catch the file with a
       // wider mode between writeFile and chmod.
       fs.writeFileSync(mcpPath, JSON.stringify(config, null, 2), { mode: 0o600 });
-      try { fs.chmodSync(mcpPath, 0o600); } catch { /* perm-tightening best-effort */ }
+      try {
+        fs.chmodSync(mcpPath, 0o600);
+      } catch {
+        /* perm-tightening best-effort */
+      }
     }
   } catch {
     // Non-fatal

--- a/extensions/loom/session-bootstrap.ts
+++ b/extensions/loom/session-bootstrap.ts
@@ -91,22 +91,22 @@ function sendStartupGreeting(pi: ExtensionAPI): void {
   if (hasCredentials) {
     pi.sendUserMessage(
       `Session started in this project directory. Read \`notebook.md\` to see prior work. ` +
-      (isOrbit
-        ? `Reply with one short sentence: "What do you want to work on next?" ` +
-          `No greeting, no emojis, no product branding.`
-        : `Give a brief welcome, then ask what to work on next, referencing the notebook contents if there is prior work. ` +
-          `Keep it to 2-3 sentences.`) +
-      connectInstr
+        (isOrbit
+          ? `Reply with one short sentence: "What do you want to work on next?" ` +
+            `No greeting, no emojis, no product branding.`
+          : `Give a brief welcome, then ask what to work on next, referencing the notebook contents if there is prior work. ` +
+            `Keep it to 2-3 sentences.`) +
+        connectInstr,
     );
     return;
   }
 
   pi.sendUserMessage(
     `Session started in this project directory. No Galaxy server configured. ` +
-    (isOrbit
-      ? `Reply with two short sentences: mention /connect for Galaxy, then ask "What do you want to work on?". ` +
-        `No greeting, no emojis, no product branding.`
-      : `Give a brief welcome, mention /connect to set up a Galaxy server, and ask what to work on. ` +
-        `Keep it to 2-3 sentences.`)
+      (isOrbit
+        ? `Reply with two short sentences: mention /connect for Galaxy, then ask "What do you want to work on?". ` +
+          `No greeting, no emojis, no product branding.`
+        : `Give a brief welcome, mention /connect to set up a Galaxy server, and ask what to work on. ` +
+          `Keep it to 2-3 sentences.`),
   );
 }

--- a/extensions/loom/session-index/db.ts
+++ b/extensions/loom/session-index/db.ts
@@ -41,9 +41,9 @@ export function openIndexDb(filePath: string): Db {
 
 function isSchemaCurrent(db: Db): boolean {
   try {
-    const row = db
-      .prepare("SELECT value FROM meta WHERE key='schema_version'")
-      .get() as { value: string } | undefined;
+    const row = db.prepare("SELECT value FROM meta WHERE key='schema_version'").get() as
+      | { value: string }
+      | undefined;
     return row?.value === String(SCHEMA_VERSION);
   } catch {
     // meta table doesn't exist yet

--- a/extensions/loom/session-index/parse.ts
+++ b/extensions/loom/session-index/parse.ts
@@ -56,10 +56,7 @@ export interface ParseOptions {
  * the caller's endOffset still advances past them (so incremental scans
  * don't loop on a corrupt line).
  */
-export function parseSessionFile(
-  filePath: string,
-  opts: ParseOptions = {},
-): ParseResult {
+export function parseSessionFile(filePath: string, opts: ParseOptions = {}): ParseResult {
   const startOffset = opts.startOffset ?? 0;
   const buf = fs.readFileSync(filePath);
   const slice = buf.subarray(startOffset);
@@ -167,13 +164,15 @@ function entryRowFromObj(obj: Record<string, unknown>): EntryRow | null {
     if (r === "user" || r === "assistant") role = r;
     text = flattenTextBlocks(msg?.content);
   } else if (type === "compaction") {
-    text = typeof (obj as { summary?: string }).summary === "string"
-      ? (obj as { summary: string }).summary
-      : null;
+    text =
+      typeof (obj as { summary?: string }).summary === "string"
+        ? (obj as { summary: string }).summary
+        : null;
   } else if (type === "branch_summary") {
-    text = typeof (obj as { summary?: string }).summary === "string"
-      ? (obj as { summary: string }).summary
-      : null;
+    text =
+      typeof (obj as { summary?: string }).summary === "string"
+        ? (obj as { summary: string }).summary
+        : null;
   } else if (type === "custom") {
     text = JSON.stringify((obj as { data?: unknown }).data ?? null);
   }
@@ -220,9 +219,8 @@ function extractToolUses(
     if (!block || typeof block !== "object") continue;
     const b = block as { type?: string; name?: string; input?: unknown; id?: string };
     if (b.type !== "tool_use" || typeof b.name !== "string") continue;
-    const tool_use_id = typeof b.id === "string" && b.id.length > 0
-      ? b.id
-      : `synth-${b.name}-${out.length}`;
+    const tool_use_id =
+      typeof b.id === "string" && b.id.length > 0 ? b.id : `synth-${b.name}-${out.length}`;
     out.push({
       tool_use_id,
       tool_name: b.name,

--- a/extensions/loom/session-index/query.ts
+++ b/extensions/loom/session-index/query.ts
@@ -108,7 +108,12 @@ export function getSessionContext(db: Db, params: ContextParams): ContextRow[] {
       LIMIT @n
       `,
     )
-    .all({ sid: anchor.session_id, ts: anchor.timestamp, eid: params.entry_id, n: before }) as ContextRow[];
+    .all({
+      sid: anchor.session_id,
+      ts: anchor.timestamp,
+      eid: params.entry_id,
+      n: before,
+    }) as ContextRow[];
 
   const anchorRow = db
     .prepare(
@@ -129,7 +134,12 @@ export function getSessionContext(db: Db, params: ContextParams): ContextRow[] {
       LIMIT @n
       `,
     )
-    .all({ sid: anchor.session_id, ts: anchor.timestamp, eid: params.entry_id, n: after }) as ContextRow[];
+    .all({
+      sid: anchor.session_id,
+      ts: anchor.timestamp,
+      eid: params.entry_id,
+      n: after,
+    }) as ContextRow[];
 
   return [...beforeRows.reverse(), anchorRow, ...afterRows];
 }
@@ -138,9 +148,7 @@ export function findToolCalls(db: Db, params: ToolCallParams): ToolCallHit[] {
   const limit = clampLimit(params.limit);
   const scopeCwd = params.scope === "cwd" && params.cwd;
   const scopeClause = scopeCwd ? "AND s.cwd = @cwd" : "";
-  const argsClause = params.args_contains
-    ? "AND tc.arguments_json LIKE @args ESCAPE '\\'"
-    : "";
+  const argsClause = params.args_contains ? "AND tc.arguments_json LIKE @args ESCAPE '\\'" : "";
 
   const bindParams: Record<string, unknown> = { tool: params.tool_name, limit };
   if (params.args_contains) bindParams.args = `%${escapeLike(params.args_contains)}%`;
@@ -168,16 +176,16 @@ export function findToolCalls(db: Db, params: ToolCallParams): ToolCallHit[] {
       `,
     )
     .all(bindParams) as Array<{
-      entry_id: string;
-      session_id: string;
-      cwd: string;
-      notebook_path: string | null;
-      timestamp: string;
-      arguments_json: string;
-      result_text: string | null;
-    }>;
+    entry_id: string;
+    session_id: string;
+    cwd: string;
+    notebook_path: string | null;
+    timestamp: string;
+    arguments_json: string;
+    result_text: string | null;
+  }>;
 
-  return rows.map(r => ({
+  return rows.map((r) => ({
     entry_id: r.entry_id,
     session_id: r.session_id,
     cwd: r.cwd,

--- a/extensions/loom/session-index/tools.ts
+++ b/extensions/loom/session-index/tools.ts
@@ -3,11 +3,7 @@ import { Text } from "@mariozechner/pi-tui";
 import { Type } from "@sinclair/typebox";
 import { openIndexDb, defaultDbPath } from "./db";
 import { scanSessions } from "./indexer";
-import {
-  searchChat,
-  getSessionContext,
-  findToolCalls,
-} from "./query";
+import { searchChat, getSessionContext, findToolCalls } from "./query";
 
 export function registerSessionIndexTools(pi: ExtensionAPI): void {
   // Long-lived DB handle for the lifetime of the extension. The session-index
@@ -67,10 +63,16 @@ export function registerSessionIndexTools(pi: ExtensionAPI): void {
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         return {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify({ error: msg, hint: "Check FTS5 query syntax (e.g. quoting)." }, null, 2),
-          }],
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                { error: msg, hint: "Check FTS5 query syntax (e.g. quoting)." },
+                null,
+                2,
+              ),
+            },
+          ],
           details: { count: 0, error: msg as string | undefined },
         };
       }

--- a/extensions/loom/skills.ts
+++ b/extensions/loom/skills.ts
@@ -48,14 +48,14 @@ export function listEnabledSkillRepos(): ConfiguredSkillRepo[] {
     if (!isSafeSkillName(r.name)) {
       console.warn(
         `[skills] Dropping repo with unsafe name "${r.name}" — ` +
-        `must match /^[A-Za-z0-9._-]+$/ (used as filesystem path)`,
+          `must match /^[A-Za-z0-9._-]+$/ (used as filesystem path)`,
       );
       continue;
     }
     if (!isAllowedSkillUrl(r.url)) {
       console.warn(
         `[skills] Dropping disallowed repo "${r.name}" (${r.url}) — ` +
-        `not under github.com/galaxyproject/*`,
+          `not under github.com/galaxyproject/*`,
       );
       continue;
     }

--- a/extensions/loom/state.ts
+++ b/extensions/loom/state.ts
@@ -102,7 +102,11 @@ function startWatchingNotebook(filePath: string, autoCommit = false): void {
 
 function stopWatchingNotebook(): void {
   if (currentWatcher) {
-    try { currentWatcher.close(); } catch { /* ignore */ }
+    try {
+      currentWatcher.close();
+    } catch {
+      /* ignore */
+    }
     currentWatcher = null;
   }
   watcherPath = null;
@@ -180,7 +184,11 @@ export function initSessionArtifacts(cwd: string): void {
 // Galaxy connection state
 // ─────────────────────────────────────────────────────────────────────────────
 
-export function setGalaxyConnection(connected: boolean, historyId?: string, _serverUrl?: string): void {
+export function setGalaxyConnection(
+  connected: boolean,
+  historyId?: string,
+  _serverUrl?: string,
+): void {
   state.galaxyConnected = connected;
   if (historyId) {
     state.currentHistoryId = historyId;

--- a/extensions/loom/teams/critic-parser.ts
+++ b/extensions/loom/teams/critic-parser.ts
@@ -43,9 +43,15 @@ function findJsonObjects(text: string): string[] {
   const out: string[] = [];
   let i = 0;
   while (i < text.length) {
-    if (text[i] !== "{") { i++; continue; }
+    if (text[i] !== "{") {
+      i++;
+      continue;
+    }
     const end = scanBalancedBrace(text, i);
-    if (end < 0) { i++; continue; }
+    if (end < 0) {
+      i++;
+      continue;
+    }
     out.push(text.slice(i, end + 1));
     i = end + 1;
   }
@@ -58,13 +64,25 @@ function scanBalancedBrace(text: string, start: number): number {
   let escaped = false;
   for (let i = start; i < text.length; i++) {
     const c = text[i];
-    if (escaped) { escaped = false; continue; }
-    if (inString) {
-      if (c === "\\") { escaped = true; continue; }
-      if (c === '"')  { inString = false; continue; }
+    if (escaped) {
+      escaped = false;
       continue;
     }
-    if (c === '"') { inString = true; continue; }
+    if (inString) {
+      if (c === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (c === '"') {
+        inString = false;
+        continue;
+      }
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      continue;
+    }
     if (c === "{") depth++;
     else if (c === "}") {
       depth--;

--- a/extensions/loom/teams/dispatcher.ts
+++ b/extensions/loom/teams/dispatcher.ts
@@ -1,14 +1,9 @@
 import { validateTeamSpec } from "./validate";
 import { parseCriticResponse } from "./critic-parser";
-import type {
-  DispatchDeps,
-  TeamResult,
-  TeamSpec,
-  TeamTurn,
-} from "./types";
+import type { DispatchDeps, TeamResult, TeamSpec, TeamTurn } from "./types";
 
 export interface DispatchOptions {
-  tokenCeiling?: number;   // default 300_000
+  tokenCeiling?: number; // default 300_000
 }
 
 export type OnTurnUpdate = (snapshot: {
@@ -50,11 +45,16 @@ export async function runTeamDispatch(
       const proposerInput = renderProposerInput(spec.description, currentCritique);
       const proposerPreamble = buildPreamble(spec, proposer, "proposer");
       const proposerResult = await deps.runRoleTurn(
-        proposer, proposerPreamble, proposerInput, signal,
+        proposer,
+        proposerPreamble,
+        proposerInput,
+        signal,
       );
       currentProposal = proposerResult.content;
       transcript.push({
-        round, role: proposer.name, content: currentProposal,
+        round,
+        role: proposer.name,
+        content: currentProposal,
       });
       totalUsage = add(totalUsage, proposerResult.usage);
       onTurn?.({ round, max_rounds: maxRounds, current_role: proposer.name, turns: transcript });
@@ -67,12 +67,12 @@ export async function runTeamDispatch(
       if (signal.aborted) return aborted(transcript, round, currentProposal, totalUsage);
       const criticInput = renderCriticInput(spec.description, currentProposal);
       const criticPreamble = buildPreamble(spec, critic, "critic");
-      const criticResult = await deps.runRoleTurn(
-        critic, criticPreamble, criticInput, signal,
-      );
+      const criticResult = await deps.runRoleTurn(critic, criticPreamble, criticInput, signal);
       const verdict = parseCriticResponse(criticResult.content);
       transcript.push({
-        round, role: critic.name, content: criticResult.content,
+        round,
+        role: critic.name,
+        content: criticResult.content,
         approved: verdict.approved,
       });
       totalUsage = add(totalUsage, criticResult.usage);
@@ -137,33 +137,74 @@ function renderCriticInput(description: string, proposal: string): string {
   );
 }
 
-function buildPreamble(spec: TeamSpec, role: { system_prompt: string }, kind: "proposer" | "critic"): string {
+function buildPreamble(
+  spec: TeamSpec,
+  role: { system_prompt: string },
+  kind: "proposer" | "critic",
+): string {
   const teamContext =
     `You are one role in a two-agent team collaborating on the task: "${spec.description}". ` +
     `Respond only from your role's perspective.`;
-  const criticContract = kind === "critic"
-    ? ` When you have finished critiquing, finish your response with a JSON line: ` +
-      `{"approved": boolean, "critique": "one paragraph"}.`
-    : "";
+  const criticContract =
+    kind === "critic"
+      ? ` When you have finished critiquing, finish your response with a JSON line: ` +
+        `{"approved": boolean, "critique": "one paragraph"}.`
+      : "";
   return `${teamContext}${criticContract}\n\n${role.system_prompt}`;
 }
 
-function add(a: { input_tokens: number; output_tokens: number }, b: { input_tokens: number; output_tokens: number }) {
-  return { input_tokens: a.input_tokens + b.input_tokens, output_tokens: a.output_tokens + b.output_tokens };
+function add(
+  a: { input_tokens: number; output_tokens: number },
+  b: { input_tokens: number; output_tokens: number },
+) {
+  return {
+    input_tokens: a.input_tokens + b.input_tokens,
+    output_tokens: a.output_tokens + b.output_tokens,
+  };
 }
 
-function exceedsCeiling(u: { input_tokens: number; output_tokens: number }, ceiling: number): boolean {
+function exceedsCeiling(
+  u: { input_tokens: number; output_tokens: number },
+  ceiling: number,
+): boolean {
   return u.input_tokens + u.output_tokens > ceiling;
 }
 
-function aborted(transcript: TeamTurn[], round: number, finalOutput: string, usage: { input_tokens: number; output_tokens: number }): TeamResult {
-  return { converged: false, aborted: true, rounds: round, final_output: finalOutput, transcript, usage };
+function aborted(
+  transcript: TeamTurn[],
+  round: number,
+  finalOutput: string,
+  usage: { input_tokens: number; output_tokens: number },
+): TeamResult {
+  return {
+    converged: false,
+    aborted: true,
+    rounds: round,
+    final_output: finalOutput,
+    transcript,
+    usage,
+  };
 }
 
-function budgetExhausted(transcript: TeamTurn[], round: number, finalOutput: string, usage: { input_tokens: number; output_tokens: number }): TeamResult {
-  return { converged: false, budget_exhausted: true, rounds: round, final_output: finalOutput, transcript, usage };
+function budgetExhausted(
+  transcript: TeamTurn[],
+  round: number,
+  finalOutput: string,
+  usage: { input_tokens: number; output_tokens: number },
+): TeamResult {
+  return {
+    converged: false,
+    budget_exhausted: true,
+    rounds: round,
+    final_output: finalOutput,
+    transcript,
+    usage,
+  };
 }
 
 function isAbortError(err: unknown): boolean {
-  return err instanceof Error && (err.name === "AbortError" || err.message.toLowerCase().includes("abort"));
+  return (
+    err instanceof Error &&
+    (err.name === "AbortError" || err.message.toLowerCase().includes("abort"))
+  );
 }

--- a/extensions/loom/teams/tool.ts
+++ b/extensions/loom/teams/tool.ts
@@ -1,19 +1,11 @@
-import type {
-  ExtensionAPI,
-  ExtensionContext,
-} from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { Text } from "@mariozechner/pi-tui";
 import { completeSimple } from "@mariozechner/pi-ai";
 import type { Model } from "@mariozechner/pi-ai";
 import { runTeamDispatch } from "./dispatcher";
 import { validateTeamSpec } from "./validate";
-import type {
-  DispatchDeps,
-  RoleTurnResult,
-  TeamSpec,
-  RoleSpec,
-} from "./types";
+import type { DispatchDeps, RoleTurnResult, TeamSpec, RoleSpec } from "./types";
 import { TEAM_DISPATCH_KIND } from "../../../shared/team-dispatch-contract.js";
 import type { TeamDispatchDetails } from "../../../shared/team-dispatch-contract.js";
 
@@ -70,9 +62,7 @@ export function registerTeamTools(pi: ExtensionAPI): void {
             model,
             {
               systemPrompt: preamble,
-              messages: [
-                { role: "user", content: userMessage, timestamp: Date.now() },
-              ],
+              messages: [{ role: "user", content: userMessage, timestamp: Date.now() }],
             },
             { signal: runSignal },
           );
@@ -147,7 +137,10 @@ export function registerTeamTools(pi: ExtensionAPI): void {
  * Resolve a Model<any> from a "provider:modelId" string, a bare Anthropic
  * model id, or by falling back to the session model.
  */
-function resolveModel(ctx: ExtensionContext, modelSpec: string | undefined): Model<any> | undefined {
+function resolveModel(
+  ctx: ExtensionContext,
+  modelSpec: string | undefined,
+): Model<any> | undefined {
   if (modelSpec && modelSpec.trim().length > 0) {
     const colon = modelSpec.indexOf(":");
     const provider = colon >= 0 ? modelSpec.slice(0, colon) : "anthropic";
@@ -156,7 +149,7 @@ function resolveModel(ctx: ExtensionContext, modelSpec: string | undefined): Mod
     if (!found) {
       throw new Error(
         `Unknown model "${modelSpec}" (provider="${provider}", modelId="${modelId}"). ` +
-        `Check ctx.modelRegistry, or omit the model field to use the session default.`,
+          `Check ctx.modelRegistry, or omit the model field to use the session default.`,
       );
     }
     return found;
@@ -180,7 +173,9 @@ function errorResult(err: unknown) {
     summary: `team_dispatch failed: ${message}`,
   };
   return {
-    content: [{ type: "text" as const, text: JSON.stringify({ ok: false, error: message }, null, 2) }],
+    content: [
+      { type: "text" as const, text: JSON.stringify({ ok: false, error: message }, null, 2) },
+    ],
     details,
   };
 }

--- a/extensions/loom/tools.ts
+++ b/extensions/loom/tools.ts
@@ -21,16 +21,8 @@ import {
   upsertInvocationBlock,
   type InvocationYaml,
 } from "./notebook-writer";
-import {
-  getGalaxyConfig,
-  galaxyGet,
-  type GalaxyInvocationResponse,
-} from "./galaxy-api";
-import {
-  type ConfiguredSkillRepo,
-  listEnabledSkillRepos,
-  findSkillRepo,
-} from "./skills";
+import { getGalaxyConfig, galaxyGet, type GalaxyInvocationResponse } from "./galaxy-api";
+import { type ConfiguredSkillRepo, listEnabledSkillRepos, findSkillRepo } from "./skills";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -78,7 +70,10 @@ function stripGtnHtml(html: string): string {
     .replace(/&#39;/g, "'")
     .replace(/&nbsp;/g, " ")
     .replace(/&#(\d+);/g, (_m, code) => String.fromCharCode(Number(code)));
-  text = text.replace(/[ \t]+/g, " ").replace(/\n{3,}/g, "\n\n").trim();
+  text = text
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
   return text;
 }
 
@@ -107,7 +102,6 @@ function githubRawBase(repoUrl: string, branch: string): string | null {
 }
 
 export function registerPlanTools(pi: ExtensionAPI): void {
-
   // ─────────────────────────────────────────────────────────────────────────────
   // Tool: Search/browse GTN topics and tutorials
   // ─────────────────────────────────────────────────────────────────────────────
@@ -118,12 +112,16 @@ export function registerPlanTools(pi: ExtensionAPI): void {
 topics. Provide a topic ID to list its tutorials. Use query to filter tutorials by keyword
 in their title or objectives. Use this to find tutorial URLs before fetching with gtn_fetch.`,
     parameters: Type.Object({
-      topic: Type.Optional(Type.String({
-        description: "Topic ID to list tutorials for (e.g., 'transcriptomics', 'introduction')"
-      })),
-      query: Type.Optional(Type.String({
-        description: "Keyword to filter tutorials by title or objectives (case-insensitive)"
-      })),
+      topic: Type.Optional(
+        Type.String({
+          description: "Topic ID to list tutorials for (e.g., 'transcriptomics', 'introduction')",
+        }),
+      ),
+      query: Type.Optional(
+        Type.String({
+          description: "Keyword to filter tutorials by title or objectives (case-insensitive)",
+        }),
+      ),
     }),
     async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
       const GTN_API = "https://training.galaxyproject.org/training-material/api";
@@ -138,7 +136,10 @@ in their title or objectives. Use this to find tutorial URLs before fetching wit
             };
           }
 
-          const data = await resp.json() as Record<string, { name: string; title: string; summary: string }>;
+          const data = (await resp.json()) as Record<
+            string,
+            { name: string; title: string; summary: string }
+          >;
           const topics = Object.values(data).map((t) => ({
             name: t.name,
             title: t.title,
@@ -146,14 +147,20 @@ in their title or objectives. Use this to find tutorial URLs before fetching wit
           }));
 
           return {
-            content: [{
-              type: "text",
-              text: JSON.stringify({
-                count: topics.length,
-                topics,
-                hint: "Use gtn_search with a topic name to list its tutorials.",
-              }, null, 2),
-            }],
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(
+                  {
+                    count: topics.length,
+                    topics,
+                    hint: "Use gtn_search with a topic name to list its tutorials.",
+                  },
+                  null,
+                  2,
+                ),
+              },
+            ],
             details: { count: topics.length },
           };
         }
@@ -161,15 +168,17 @@ in their title or objectives. Use this to find tutorial URLs before fetching wit
         const resp = await fetch(`${GTN_API}/topics/${params.topic}.json`, { signal });
         if (!resp.ok) {
           return {
-            content: [{
-              type: "text",
-              text: `Error: Topic "${params.topic}" not found (HTTP ${resp.status}). Use gtn_search with no arguments to list available topics.`,
-            }],
+            content: [
+              {
+                type: "text",
+                text: `Error: Topic "${params.topic}" not found (HTTP ${resp.status}). Use gtn_search with no arguments to list available topics.`,
+              },
+            ],
             details: { error: true },
           };
         }
 
-        const topicData = await resp.json() as {
+        const topicData = (await resp.json()) as {
           name: string;
           title: string;
           materials: Array<{
@@ -196,23 +205,30 @@ in their title or objectives. Use this to find tutorial URLs before fetching wit
 
         if (params.query) {
           const q = params.query.toLowerCase();
-          tutorials = tutorials.filter((t) =>
-            t.title.toLowerCase().includes(q) ||
-            t.objectives.some((o) => o.toLowerCase().includes(q))
+          tutorials = tutorials.filter(
+            (t) =>
+              t.title.toLowerCase().includes(q) ||
+              t.objectives.some((o) => o.toLowerCase().includes(q)),
           );
         }
 
         return {
-          content: [{
-            type: "text",
-            text: JSON.stringify({
-              topic: topicData.title,
-              count: tutorials.length,
-              ...(params.query ? { query: params.query } : {}),
-              tutorials,
-              hint: "Use gtn_fetch with a tutorial URL to read its full content.",
-            }, null, 2),
-          }],
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  topic: topicData.title,
+                  count: tutorials.length,
+                  ...(params.query ? { query: params.query } : {}),
+                  tutorials,
+                  hint: "Use gtn_fetch with a tutorial URL to read its full content.",
+                },
+                null,
+                2,
+              ),
+            },
+          ],
           details: { topic: params.topic, count: tutorials.length },
         };
       } catch (error) {
@@ -248,7 +264,7 @@ instructions, tool names, parameters, and workflow steps so you can follow along
 analyses in Galaxy.`,
     parameters: Type.Object({
       url: Type.String({
-        description: "URL of the GTN tutorial page (must be on training.galaxyproject.org)"
+        description: "URL of the GTN tutorial page (must be on training.galaxyproject.org)",
       }),
     }),
     async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
@@ -266,10 +282,12 @@ analyses in Galaxy.`,
 
       if (parsed.hostname !== GTN_HOST) {
         return {
-          content: [{
-            type: "text",
-            text: `Error: Only URLs on ${GTN_HOST} are allowed. Got: ${parsed.hostname}`,
-          }],
+          content: [
+            {
+              type: "text",
+              text: `Error: Only URLs on ${GTN_HOST} are allowed. Got: ${parsed.hostname}`,
+            },
+          ],
           details: { error: true },
         };
       }
@@ -279,10 +297,12 @@ analyses in Galaxy.`,
 
         if (!response.ok) {
           return {
-            content: [{
-              type: "text",
-              text: `Error: Failed to fetch tutorial (HTTP ${response.status})`,
-            }],
+            content: [
+              {
+                type: "text",
+                text: `Error: Failed to fetch tutorial (HTTP ${response.status})`,
+              },
+            ],
             details: { error: true },
           };
         }
@@ -291,10 +311,12 @@ analyses in Galaxy.`,
         const text = stripGtnHtml(html);
 
         return {
-          content: [{
-            type: "text",
-            text,
-          }],
+          content: [
+            {
+              type: "text",
+              text,
+            },
+          ],
           details: { url: params.url, length: text.length },
         };
       } catch (error) {
@@ -325,11 +347,13 @@ system prompt's "Skills repositories" section lists the available repos and the
 canonical paths inside each. Results are cached locally for 24h. If \`repo\` is
 omitted, the first enabled repo is used (typically \`galaxy-skills\`).`,
     parameters: Type.Object({
-      repo: Type.Optional(Type.String({
-        description:
-          "Name of the skills repo to fetch from (e.g. 'galaxy-skills'). " +
-          "Omit to use the default (first enabled repo).",
-      })),
+      repo: Type.Optional(
+        Type.String({
+          description:
+            "Name of the skills repo to fetch from (e.g. 'galaxy-skills'). " +
+            "Omit to use the default (first enabled repo).",
+        }),
+      ),
       path: Type.String({
         description:
           "Relative path inside the repo, e.g. 'collection-manipulation/SKILL.md', " +
@@ -339,14 +363,19 @@ omitted, the first enabled repo is used (typically \`galaxy-skills\`).`,
     async execute(_toolCallId, params, signal, _onUpdate, _ctx) {
       const repo = findSkillRepo(params.repo);
       if (!repo) {
-        const enabled = listEnabledSkillRepos().map((r) => r.name).join(", ") || "(none)";
+        const enabled =
+          listEnabledSkillRepos()
+            .map((r) => r.name)
+            .join(", ") || "(none)";
         return {
-          content: [{
-            type: "text",
-            text: params.repo
-              ? `Error: Skills repo "${params.repo}" is not configured or is disabled. Enabled: ${enabled}.`
-              : `Error: No skills repos are enabled. Configure one in Preferences → Skills.`,
-          }],
+          content: [
+            {
+              type: "text",
+              text: params.repo
+                ? `Error: Skills repo "${params.repo}" is not configured or is disabled. Enabled: ${enabled}.`
+                : `Error: No skills repos are enabled. Configure one in Preferences → Skills.`,
+            },
+          ],
           details: { error: true },
         };
       }
@@ -362,10 +391,12 @@ omitted, the first enabled repo is used (typically \`galaxy-skills\`).`,
       const rawBase = githubRawBase(repo.url, repo.branch);
       if (!rawBase) {
         return {
-          content: [{
-            type: "text",
-            text: `Error: Repo URL "${repo.url}" must be a GitHub repo (https://github.com/<owner>/<repo>).`,
-          }],
+          content: [
+            {
+              type: "text",
+              text: `Error: Repo URL "${repo.url}" must be a GitHub repo (https://github.com/<owner>/<repo>).`,
+            },
+          ],
           details: { error: true },
         };
       }
@@ -375,7 +406,13 @@ omitted, the first enabled repo is used (typically \`galaxy-skills\`).`,
       // whose branch was switched) keeps serving 24h of stale content from
       // the old upstream because cache lookup keyed only on repo.name.
       const cacheTag = createSkillsCacheTag(repo.url, repo.branch);
-      const cacheDir = path.join(os.homedir(), ".loom", "cache", "skills", `${repo.name}@${cacheTag}`);
+      const cacheDir = path.join(
+        os.homedir(),
+        ".loom",
+        "cache",
+        "skills",
+        `${repo.name}@${cacheTag}`,
+      );
       const cachePath = path.join(cacheDir, cleanPath);
       const ttlMs = 24 * 60 * 60 * 1000;
       try {
@@ -396,11 +433,14 @@ omitted, the first enabled repo is used (typically \`galaxy-skills\`).`,
         const response = await fetch(url, { signal });
         if (!response.ok) {
           return {
-            content: [{
-              type: "text",
-              text: `Error: Failed to fetch "${cleanPath}" from ${repo.name} (HTTP ${response.status}). ` +
-                `Check the path against the skills router in the system prompt.`,
-            }],
+            content: [
+              {
+                type: "text",
+                text:
+                  `Error: Failed to fetch "${cleanPath}" from ${repo.name} (HTTP ${response.status}). ` +
+                  `Check the path against the skills router in the system prompt.`,
+              },
+            ],
             details: { error: true, repo: repo.name, path: cleanPath },
           };
         }
@@ -426,7 +466,9 @@ omitted, the first enabled repo is used (typically \`galaxy-skills\`).`,
       }
     },
     renderResult: (result) => {
-      const d = result.details as { repo?: string; path?: string; length?: number; cached?: boolean; error?: boolean } | undefined;
+      const d = result.details as
+        | { repo?: string; path?: string; length?: number; cached?: boolean; error?: boolean }
+        | undefined;
       if (d?.error) return new Text("❌ Skill fetch failed");
       const tag = d?.cached ? "(cached)" : "(fetched)";
       return new Text(`📘 ${d?.repo}/${d?.path} ${tag} (${d?.length || 0} chars)`);
@@ -458,7 +500,9 @@ Writes a fenced \`loom-invocation\` YAML block at the end of the notebook. Polli
       const notebookPath = getNotebookPath();
       if (!notebookPath) {
         return {
-          content: [{ type: "text", text: JSON.stringify({ success: false, error: "No notebook open." }) }],
+          content: [
+            { type: "text", text: JSON.stringify({ success: false, error: "No notebook open." }) },
+          ],
           details: { error: true } as Record<string, unknown>,
         };
       }
@@ -482,18 +526,27 @@ Writes a fenced \`loom-invocation\` YAML block at the end of the notebook. Polli
         });
 
         return {
-          content: [{
-            type: "text",
-            text: JSON.stringify({
-              success: true,
-              invocationId: inv.invocationId,
-              notebookAnchor: inv.notebookAnchor,
-              label: inv.label,
-              status: inv.status,
-              message: `Recorded invocation ${inv.invocationId} (${inv.label}) at ${inv.notebookAnchor}.`,
-            }, null, 2),
-          }],
-          details: { invocationId: inv.invocationId, notebookAnchor: inv.notebookAnchor } as Record<string, unknown>,
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  success: true,
+                  invocationId: inv.invocationId,
+                  notebookAnchor: inv.notebookAnchor,
+                  label: inv.label,
+                  status: inv.status,
+                  message: `Recorded invocation ${inv.invocationId} (${inv.label}) at ${inv.notebookAnchor}.`,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          details: { invocationId: inv.invocationId, notebookAnchor: inv.notebookAnchor } as Record<
+            string,
+            unknown
+          >,
         };
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
@@ -504,7 +557,9 @@ Writes a fenced \`loom-invocation\` YAML block at the end of the notebook. Polli
       }
     },
     renderResult: (result) => {
-      const d = result.details as { invocationId?: string; notebookAnchor?: string; error?: boolean } | undefined;
+      const d = result.details as
+        | { invocationId?: string; notebookAnchor?: string; error?: boolean }
+        | undefined;
       if (d?.error) return new Text("❌ Failed to record invocation");
       return new Text(`🔗 Invocation ${d?.invocationId} → ${d?.notebookAnchor}`);
     },
@@ -570,18 +625,31 @@ interface CheckInvocationsResult {
   details: Record<string, unknown>;
 }
 
-export async function checkInvocations(specificId: string | undefined, signal?: AbortSignal): Promise<CheckInvocationsResult> {
+export async function checkInvocations(
+  specificId: string | undefined,
+  signal?: AbortSignal,
+): Promise<CheckInvocationsResult> {
   const notebookPath = getNotebookPath();
   if (!notebookPath) {
     return {
-      content: [{ type: "text" as const, text: JSON.stringify({ success: false, error: "No notebook open." }) }],
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({ success: false, error: "No notebook open." }),
+        },
+      ],
       details: { error: true } as Record<string, unknown>,
     };
   }
 
   if (!getGalaxyConfig()) {
     return {
-      content: [{ type: "text" as const, text: JSON.stringify({ success: false, error: "Galaxy credentials not configured." }) }],
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({ success: false, error: "Galaxy credentials not configured." }),
+        },
+      ],
       details: { error: true } as Record<string, unknown>,
     };
   }
@@ -604,7 +672,15 @@ export async function checkInvocations(specificId: string | undefined, signal?: 
         return {
           kind: "early",
           result: {
-            content: [{ type: "text" as const, text: JSON.stringify({ success: false, error: `Invocation ${specificId} not found in notebook.` }) }],
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify({
+                  success: false,
+                  error: `Invocation ${specificId} not found in notebook.`,
+                }),
+              },
+            ],
             details: { error: true } as Record<string, unknown>,
           },
         };
@@ -618,10 +694,16 @@ export async function checkInvocations(specificId: string | undefined, signal?: 
       return {
         kind: "early",
         result: {
-          content: [{
-            type: "text" as const,
-            text: JSON.stringify({ success: true, results: [], message: "No in-progress invocations." }),
-          }],
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                success: true,
+                results: [],
+                message: "No in-progress invocations.",
+              }),
+            },
+          ],
           details: { checked: 0 } as Record<string, unknown>,
         },
       };
@@ -645,9 +727,12 @@ export async function checkInvocations(specificId: string | undefined, signal?: 
           for (const job of invStep.jobs) {
             stepJobs++;
             totalJobs++;
-            if (job.state === "ok") { summary.ok++; stepOk++; }
-            else if (job.state === "running") summary.running++;
-            else if (job.state === "queued" || job.state === "new" || job.state === "waiting") summary.queued++;
+            if (job.state === "ok") {
+              summary.ok++;
+              stepOk++;
+            } else if (job.state === "running") summary.running++;
+            else if (job.state === "queued" || job.state === "new" || job.state === "waiting")
+              summary.queued++;
             else if (job.state === "error" || job.state === "deleted") summary.error++;
             else summary.other++;
           }
@@ -658,7 +743,12 @@ export async function checkInvocations(specificId: string | undefined, signal?: 
         let nextStatus: InvocationYaml["status"] = block.status;
         let nextSummary = block.summary;
 
-        if (summary.error === 0 && summary.running === 0 && summary.queued === 0 && summary.ok > 0) {
+        if (
+          summary.error === 0 &&
+          summary.running === 0 &&
+          summary.queued === 0 &&
+          summary.ok > 0
+        ) {
           nextStatus = "completed";
           nextSummary = `Workflow completed: ${summary.ok} jobs succeeded`;
           autoAction = "completed";
@@ -714,10 +804,12 @@ export async function checkInvocations(specificId: string | undefined, signal?: 
   const results = lockResult.results;
 
   return {
-    content: [{
-      type: "text" as const,
-      text: JSON.stringify({ success: true, checked: results.length, results }, null, 2),
-    }],
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ success: true, checked: results.length, results }, null, 2),
+      },
+    ],
     details: { checked: results.length } as Record<string, unknown>,
   };
 }

--- a/extensions/loom/ui-bridge.ts
+++ b/extensions/loom/ui-bridge.ts
@@ -9,10 +9,7 @@
 
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { onNotebookChange, getNotebookPath } from "./state.js";
-import {
-  LoomWidgetKey,
-  encodeMarkdownWidget,
-} from "../../shared/loom-shell-contract.js";
+import { LoomWidgetKey, encodeMarkdownWidget } from "../../shared/loom-shell-contract.js";
 
 export function setupUIBridge(pi: ExtensionAPI): void {
   let latestCtx: ExtensionContext | null = null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "loom",
+  "name": "@galaxyproject/loom",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "loom",
+      "name": "@galaxyproject/loom",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -23,11 +23,22 @@
         "loom": "bin/loom.js"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@mariozechner/pi-ai": "^0.70.0",
         "@types/better-sqlite3": "^7.6.13",
         "@types/uuid": "^11.0.0",
+        "eslint": "^10.2.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "globals": "^17.5.0",
+        "husky": "^9.1.7",
+        "lint-staged": "^16.4.0",
+        "prettier": "^3.8.3",
         "typescript": "^6.0.2",
+        "typescript-eslint": "^8.59.1",
         "vitest": "^4.1.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -802,11 +813,281 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -855,6 +1136,134 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@google/genai": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.40.0.tgz",
@@ -887,6 +1296,72 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -985,12 +1460,55 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@mariozechner/clipboard": {
       "version": "0.3.3",
@@ -2515,10 +3033,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2556,6 +3088,226 @@
       "optional": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
+      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/type-utils": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.2",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.2",
+        "@typescript-eslint/types": "^8.59.2",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
+      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.2",
+        "@typescript-eslint/tsconfig-utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
+      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.2",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2684,6 +3436,29 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2724,6 +3499,22 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-regex": {
@@ -2803,6 +3594,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.28",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.28.tgz",
+      "integrity": "sha512-Ic44hnOtFIgravCunj1ifSoQPSUrkNiJuH9Mf6jr2jjoA74icqV8wU0KuadXeOR8zuIJMOoTv0GuQjZ9ZYNMeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/basic-ftp": {
       "version": "5.1.0",
@@ -2901,6 +3705,40 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -2993,6 +3831,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001792",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
+      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -3036,6 +3895,22 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-highlight": {
       "version": "2.1.11",
       "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
@@ -3073,6 +3948,69 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -3101,6 +4039,23 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -3263,6 +4218,13 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
@@ -3435,6 +4397,13 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.352",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
+      "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3469,6 +4438,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-define-property": {
@@ -3523,6 +4505,19 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/escodegen": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
@@ -3544,6 +4539,166 @@
         "source-map": "~0.6.1"
       }
     },
+    "node_modules/eslint": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
+      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -3555,6 +4710,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estraverse": {
@@ -3593,6 +4774,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
@@ -3736,6 +4924,20 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -3838,6 +5040,19 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/file-type": {
       "version": "21.3.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
@@ -3882,6 +5097,44 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -3998,6 +5251,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -4119,6 +5382,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/google-auth-library": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
@@ -4217,6 +5506,23 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/highlight.js": {
@@ -4320,6 +5626,22 @@
         "node": ">= 14"
       }
     },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -4363,6 +5685,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/inherits": {
@@ -4410,6 +5742,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4417,6 +5759,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-inside-container": {
@@ -4488,6 +5843,26 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -4496,6 +5871,13 @@
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
@@ -4522,6 +5904,26 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -4543,6 +5945,16 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/koffi": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.1.tgz",
@@ -4552,6 +5964,20 @@
       "optional": true,
       "funding": {
         "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -4828,6 +6254,287 @@
         "uhyphen": "^0.2.0"
       }
     },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
@@ -4918,6 +6625,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -5034,6 +6754,13 @@
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -5112,6 +6839,13 @@
         "he": "1.2.0"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -5177,6 +6911,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/open": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
@@ -5216,6 +6966,24 @@
         }
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.2.0.tgz",
@@ -5226,6 +6994,51 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5304,6 +7117,16 @@
       "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
       "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
       "license": "MIT"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-expression-matcher": {
       "version": "1.5.0",
@@ -5491,6 +7314,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
@@ -5581,6 +7430,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -5682,6 +7541,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -5690,6 +7579,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "5.0.10",
@@ -6066,6 +7962,52 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -6153,6 +8095,16 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-width": {
@@ -6315,9 +8267,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6384,6 +8336,19 @@
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6413,6 +8378,19 @@
       "engines": {
         "node": ">=18",
         "npm": ">=9"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-is": {
@@ -6447,6 +8425,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
+      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.2",
+        "@typescript-eslint/parser": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uhyphen": {
@@ -6503,6 +8505,47 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -6749,6 +8792,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -6834,6 +8887,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.2",
@@ -6927,6 +8987,19 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25 || ^4"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -45,17 +45,38 @@
     "yaml": "^2.8.2"
   },
   "scripts": {
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "precommit": "lint-staged",
+    "prepare": "husky",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "smoke:pack": "node scripts/smoke-pack.mjs",
     "prepublishOnly": "npm run typecheck && npm test && npm run smoke:pack"
   },
+  "lint-staged": {
+    "*.{json,md,css,html,yml,yaml}": "prettier --write",
+    "*.{js,jsx,ts,tsx}": [
+      "prettier --write",
+      "eslint --fix"
+    ]
+  },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@mariozechner/pi-ai": "^0.70.0",
     "@types/better-sqlite3": "^7.6.13",
     "@types/uuid": "^11.0.0",
+    "eslint": "^10.2.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "globals": "^17.5.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
+    "prettier": "^3.8.3",
     "typescript": "^6.0.2",
+    "typescript-eslint": "^8.59.1",
     "vitest": "^4.1.4"
   }
 }

--- a/scripts/smoke-pack.mjs
+++ b/scripts/smoke-pack.mjs
@@ -32,9 +32,7 @@ try {
   // 2. Extract.
   const extractDir = join(tmp, "extracted");
   execSync(`mkdir -p ${JSON.stringify(extractDir)}`);
-  execSync(
-    `tar -xzf ${JSON.stringify(tarballPath)} -C ${JSON.stringify(extractDir)}`,
-  );
+  execSync(`tar -xzf ${JSON.stringify(tarballPath)} -C ${JSON.stringify(extractDir)}`);
   const pkgDir = join(extractDir, "package");
   console.log(`[smoke] extracted to ${pkgDir}`);
 

--- a/shared/loom-config.js
+++ b/shared/loom-config.js
@@ -24,7 +24,11 @@ export const ALLOWED_SKILLS_PREFIX = "https://github.com/galaxyproject/";
 export function isAllowedSkillUrl(url) {
   if (typeof url !== "string") return false;
   let parsed;
-  try { parsed = new URL(url.trim()); } catch { return false; }
+  try {
+    parsed = new URL(url.trim());
+  } catch {
+    return false;
+  }
   if (parsed.protocol !== "https:") return false;
   if (parsed.hostname.toLowerCase() !== "github.com") return false;
   const cleaned = parsed.pathname

--- a/tests/activity-redaction.test.ts
+++ b/tests/activity-redaction.test.ts
@@ -3,10 +3,12 @@ import { redactArgs } from "../extensions/loom/activity-hooks";
 
 describe("redactArgs", () => {
   it("whole-object redacts credential tools", () => {
-    expect(redactArgs("galaxy_connect", { url: "x", apiKey: "secret" }))
-      .toEqual({ _redacted: true });
-    expect(redactArgs("galaxy_set_profile", { name: "default", apiKey: "k" }))
-      .toEqual({ _redacted: true });
+    expect(redactArgs("galaxy_connect", { url: "x", apiKey: "secret" })).toEqual({
+      _redacted: true,
+    });
+    expect(redactArgs("galaxy_set_profile", { name: "default", apiKey: "k" })).toEqual({
+      _redacted: true,
+    });
   });
 
   it("redacts known credential keys on any tool", () => {

--- a/tests/agent-manager.test.ts
+++ b/tests/agent-manager.test.ts
@@ -48,7 +48,9 @@ function makeProcess(pid: number) {
   const proc = new EventEmitter() as EventEmitter & Record<string, unknown>;
   proc.pid = pid;
   proc.stdin = { writable: true, write: vi.fn() };
-  proc.stdout = new EventEmitter() as EventEmitter & { removeAllListeners: ReturnType<typeof vi.fn> };
+  proc.stdout = new EventEmitter() as EventEmitter & {
+    removeAllListeners: ReturnType<typeof vi.fn>;
+  };
   proc.stdout.removeAllListeners = vi.fn();
   proc.stderr = new EventEmitter() as EventEmitter & {
     removeAllListeners: ReturnType<typeof vi.fn>;
@@ -90,9 +92,9 @@ describe("AgentManager", () => {
       1,
       "node",
       expect.arrayContaining(["--mode", "rpc"]),
-      expect.objectContaining({ cwd: "/analysis/old" })
+      expect.objectContaining({ cwd: "/analysis/old" }),
     );
-    expect((spawnMock.mock.calls[0][1] as string[])).not.toContain("--continue");
+    expect(spawnMock.mock.calls[0][1] as string[]).not.toContain("--continue");
 
     expect(manager.switchCwd("/analysis/new")).toBe(true);
 
@@ -101,9 +103,9 @@ describe("AgentManager", () => {
       2,
       "node",
       expect.arrayContaining(["--mode", "rpc"]),
-      expect.objectContaining({ cwd: "/analysis/new" })
+      expect.objectContaining({ cwd: "/analysis/new" }),
     );
-    expect((spawnMock.mock.calls[1][1] as string[])).not.toContain("--continue");
+    expect(spawnMock.mock.calls[1][1] as string[]).not.toContain("--continue");
   });
 
   it("does not restart when the cwd is unchanged", async () => {

--- a/tests/invocation.test.ts
+++ b/tests/invocation.test.ts
@@ -127,10 +127,11 @@ describe("upsertInvocationBlock", () => {
   it("replaces in place when invocation_id already exists", () => {
     const original = makeInvocation();
     const initial = "# Plan A\n\n" + renderInvocationYaml(original) + "\nMore prose after.\n";
-    const updated = upsertInvocationBlock(
-      initial,
-      { ...original, status: "completed", summary: "ok" },
-    );
+    const updated = upsertInvocationBlock(initial, {
+      ...original,
+      status: "completed",
+      summary: "ok",
+    });
     const blocks = findInvocationBlocks(updated);
     expect(blocks).toHaveLength(1);
     expect(blocks[0].status).toBe("completed");

--- a/tests/profiles.test.ts
+++ b/tests/profiles.test.ts
@@ -34,7 +34,9 @@ afterEach(() => {
   else process.env.HOME = prevHome;
   if (prevUserProfile === undefined) delete process.env.USERPROFILE;
   else process.env.USERPROFILE = prevUserProfile;
-  try { fs.rmSync(sandboxHome, { recursive: true, force: true }); } catch {}
+  try {
+    fs.rmSync(sandboxHome, { recursive: true, force: true });
+  } catch {}
 });
 
 describe("EncryptedProfileUnavailableError", () => {
@@ -49,7 +51,10 @@ describe("EncryptedProfileUnavailableError", () => {
 
 describe("resolveProfileApiKey", () => {
   it("returns plaintext when apiKey is set", () => {
-    const got = resolveProfileApiKey("p", { url: "https://x.galaxyproject.org", apiKey: "plain-key" });
+    const got = resolveProfileApiKey("p", {
+      url: "https://x.galaxyproject.org",
+      apiKey: "plain-key",
+    });
     expect(got).toBe("plain-key");
   });
 
@@ -60,12 +65,12 @@ describe("resolveProfileApiKey", () => {
   });
 
   it("throws a plain Error when no key field is set", () => {
-    expect(() =>
-      resolveProfileApiKey("empty", { url: "https://usegalaxy.org" }),
-    ).toThrow(/no API key/i);
-    expect(() =>
-      resolveProfileApiKey("empty", { url: "https://usegalaxy.org" }),
-    ).not.toThrow(EncryptedProfileUnavailableError);
+    expect(() => resolveProfileApiKey("empty", { url: "https://usegalaxy.org" })).toThrow(
+      /no API key/i,
+    );
+    expect(() => resolveProfileApiKey("empty", { url: "https://usegalaxy.org" })).not.toThrow(
+      EncryptedProfileUnavailableError,
+    );
   });
 });
 
@@ -137,7 +142,11 @@ describe("warnOnUnusableActiveProfile", () => {
     const errors: string[] = [];
     const orig = console.error;
     console.error = (msg: string) => errors.push(msg);
-    try { fn(); } finally { console.error = orig; }
+    try {
+      fn();
+    } finally {
+      console.error = orig;
+    }
     return errors;
   }
 
@@ -150,7 +159,7 @@ describe("warnOnUnusableActiveProfile", () => {
     delete process.env.GALAXY_API_KEY;
     const errors = captureErrors(() => warnOnUnusableActiveProfile());
     expect(errors.length).toBe(1);
-    expect(errors[0]).toContain("Active profile \"a\"");
+    expect(errors[0]).toContain('Active profile "a"');
     expect(errors[0]).toMatch(/GALAXY_API_KEY/);
   });
 

--- a/tests/session-index/db.test.ts
+++ b/tests/session-index/db.test.ts
@@ -20,9 +20,7 @@ describe("session-index db", () => {
       .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
       .all()
       .map((r: { name: string }) => r.name);
-    expect(tables).toEqual(
-      expect.arrayContaining(["sessions", "entries", "tool_calls", "meta"]),
-    );
+    expect(tables).toEqual(expect.arrayContaining(["sessions", "entries", "tool_calls", "meta"]));
     // FTS5 virtual table's shadow tables exist too
     expect(tables).toEqual(expect.arrayContaining(["entries_fts"]));
     db.close();
@@ -40,7 +38,10 @@ describe("session-index db", () => {
   it("rebuilds cleanly if schema_version mismatches", () => {
     const p = path.join(dir, "idx.db");
     const db1 = openIndexDb(p);
-    db1.prepare("INSERT INTO sessions(session_id, file_path, cwd, created_at, last_indexed_at, last_indexed_offset) VALUES (?, ?, ?, ?, ?, ?)")
+    db1
+      .prepare(
+        "INSERT INTO sessions(session_id, file_path, cwd, created_at, last_indexed_at, last_indexed_offset) VALUES (?, ?, ?, ?, ?, ?)",
+      )
       .run("s1", "/tmp/f.jsonl", "/tmp", "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", 0);
     db1.prepare("UPDATE meta SET value='0' WHERE key='schema_version'").run();
     db1.close();

--- a/tests/session-index/indexer.test.ts
+++ b/tests/session-index/indexer.test.ts
@@ -43,12 +43,14 @@ describe("scanSessions", () => {
     expect(report.sessionsSeen).toBe(1);
     expect(report.entriesInserted).toBe(2);
 
-    const entries = db.prepare("SELECT entry_id, role, text_content FROM entries ORDER BY timestamp").all() as Array<{
+    const entries = db
+      .prepare("SELECT entry_id, role, text_content FROM entries ORDER BY timestamp")
+      .all() as Array<{
       entry_id: string;
       role: string | null;
       text_content: string | null;
     }>;
-    expect(entries.map(e => e.entry_id)).toEqual(["e1", "e2"]);
+    expect(entries.map((e) => e.entry_id)).toEqual(["e1", "e2"]);
     db.close();
   });
 
@@ -82,12 +84,15 @@ describe("scanSessions", () => {
 
   it("populates notebook_path from galaxy_analyst_plan custom entries", () => {
     const fp = path.join(sessionsDir, encodeCwd("/tmp/proj"), "sess-basic.jsonl");
-    fs.appendFileSync(fp,
+    fs.appendFileSync(
+      fp,
       `{"type":"custom","id":"ec","parentId":"e2","timestamp":"2026-04-01T10:00:20Z","customType":"galaxy_analyst_plan","data":{"notebookPath":"/tmp/proj/notebook.md"}}\n`,
     );
     const db = openIndexDb(dbPath);
     scanSessions(db, sessionsDir);
-    const row = db.prepare("SELECT notebook_path FROM sessions WHERE session_id='sess-basic'").get() as { notebook_path: string | null };
+    const row = db
+      .prepare("SELECT notebook_path FROM sessions WHERE session_id='sess-basic'")
+      .get() as { notebook_path: string | null };
     expect(row.notebook_path).toBe("/tmp/proj/notebook.md");
     db.close();
   });
@@ -95,14 +100,17 @@ describe("scanSessions", () => {
   it("indexes parallel tool_use calls to the same tool without collapsing", () => {
     const fp = path.join(sessionsDir, encodeCwd("/tmp/proj"), "sess-basic.jsonl");
     // Append an assistant message with TWO tool_use blocks for the same tool name.
-    fs.appendFileSync(fp,
+    fs.appendFileSync(
+      fp,
       `{"type":"message","id":"par","parentId":"e2","timestamp":"2026-04-01T10:00:30Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tuA","name":"workflow_set_overrides","input":{"stepId":"ism","overrides":{"variant_ism_width":600}}},{"type":"tool_use","id":"tuB","name":"workflow_set_overrides","input":{"stepId":"ism","overrides":{"ism_scanner":{"max_region_width":600}}}}]}}\n`,
     );
     const db = openIndexDb(dbPath);
     scanSessions(db, sessionsDir);
-    const rows = db.prepare("SELECT tool_use_id, arguments_json FROM tool_calls WHERE entry_id = 'par'").all() as Array<{ tool_use_id: string; arguments_json: string }>;
+    const rows = db
+      .prepare("SELECT tool_use_id, arguments_json FROM tool_calls WHERE entry_id = 'par'")
+      .all() as Array<{ tool_use_id: string; arguments_json: string }>;
     expect(rows).toHaveLength(2);
-    const useIds = rows.map(r => r.tool_use_id).sort();
+    const useIds = rows.map((r) => r.tool_use_id).sort();
     expect(useIds).toEqual(["tuA", "tuB"]);
     db.close();
   });
@@ -110,7 +118,10 @@ describe("scanSessions", () => {
   it("does not index a partial line written without a trailing newline", () => {
     const fp = path.join(sessionsDir, encodeCwd("/tmp/proj"), "sess-basic.jsonl");
     // Simulate Pi mid-write: append a partial message line with NO trailing newline
-    fs.appendFileSync(fp, '{"type":"message","id":"partial","parentId":"e2","timestamp":"2026-04-01T10:00:12Z","message":{"role":"assistant","content":[{"type":"text","text":"half-writ');
+    fs.appendFileSync(
+      fp,
+      '{"type":"message","id":"partial","parentId":"e2","timestamp":"2026-04-01T10:00:12Z","message":{"role":"assistant","content":[{"type":"text","text":"half-writ',
+    );
 
     const db = openIndexDb(dbPath);
     const r1 = scanSessions(db, sessionsDir);
@@ -124,7 +135,9 @@ describe("scanSessions", () => {
 
     const r2 = scanSessions(db, sessionsDir);
     expect(r2.entriesInserted).toBe(1);
-    const row = db.prepare("SELECT entry_id FROM entries WHERE entry_id = 'partial'").get() as { entry_id?: string } | undefined;
+    const row = db.prepare("SELECT entry_id FROM entries WHERE entry_id = 'partial'").get() as
+      | { entry_id?: string }
+      | undefined;
     expect(row?.entry_id).toBe("partial");
     db.close();
   });

--- a/tests/session-index/integration.test.ts
+++ b/tests/session-index/integration.test.ts
@@ -45,7 +45,7 @@ describe("session-index end-to-end", () => {
 
     // 2. Agent pulls context around the top hit
     const ctx = getSessionContext(db, { entry_id: best.entry_id, before: 1, after: 1 });
-    const rationale = ctx.find(r => r.text.includes("secondary-cluster gap"));
+    const rationale = ctx.find((r) => r.text.includes("secondary-cluster gap"));
     expect(rationale).toBeDefined();
 
     // 3. Agent also finds the structured tool call

--- a/tests/session-index/query.test.ts
+++ b/tests/session-index/query.test.ts
@@ -23,16 +23,26 @@ describe("session-index query API", () => {
 
   beforeEach(() => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-index-query-"));
-    seed(dir, "/tmp/malaria", "sess-1.jsonl", `\
+    seed(
+      dir,
+      "/tmp/malaria",
+      "sess-1.jsonl",
+      `\
 {"type":"session","version":3,"id":"sess-1","timestamp":"2026-04-01T10:00:00Z","cwd":"/tmp/malaria"}
 {"type":"message","id":"m1","parentId":null,"timestamp":"2026-04-01T10:00:05Z","message":{"role":"user","content":[{"type":"text","text":"Tune variant_ism_width for malaria chr6"}]}}
 {"type":"message","id":"m2","parentId":"m1","timestamp":"2026-04-01T10:00:10Z","message":{"role":"assistant","content":[{"type":"text","text":"Set variant_ism_width=600 to widen the scan."},{"type":"tool_use","id":"tu1","name":"workflow_set_overrides","input":{"stepId":"ism","overrides":{"variant_ism_width":600}}}]}}
 {"type":"message","id":"m3","parentId":"m2","timestamp":"2026-04-01T10:00:15Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu1","content":[{"type":"text","text":"overrides recorded"}]}]}}
-`);
-    seed(dir, "/tmp/hiv", "sess-2.jsonl", `\
+`,
+    );
+    seed(
+      dir,
+      "/tmp/hiv",
+      "sess-2.jsonl",
+      `\
 {"type":"session","version":3,"id":"sess-2","timestamp":"2026-04-02T09:00:00Z","cwd":"/tmp/hiv"}
 {"type":"message","id":"h1","parentId":null,"timestamp":"2026-04-02T09:00:05Z","message":{"role":"user","content":[{"type":"text","text":"Run HIV locus analysis"}]}}
-`);
+`,
+    );
     db = openIndexDb(path.join(dir, "idx.db"));
     scanSessions(db, dir);
   });
@@ -51,13 +61,13 @@ describe("session-index query API", () => {
 
   it("scope='cwd' filters to the given directory", () => {
     const hits = searchChat(db, { query: "analysis", scope: "cwd", cwd: "/tmp/hiv" });
-    expect(hits.every(h => h.cwd === "/tmp/hiv")).toBe(true);
-    expect(hits.some(h => h.cwd === "/tmp/malaria")).toBe(false);
+    expect(hits.every((h) => h.cwd === "/tmp/hiv")).toBe(true);
+    expect(hits.some((h) => h.cwd === "/tmp/malaria")).toBe(false);
   });
 
   it("returns a window of entries around an anchor", () => {
     const ctx = getSessionContext(db, { entry_id: "m2", before: 1, after: 1 });
-    expect(ctx.map(e => e.entry_id)).toEqual(["m1", "m2", "m3"]);
+    expect(ctx.map((e) => e.entry_id)).toEqual(["m1", "m2", "m3"]);
   });
 
   it("finds tool calls by name with args_contains filter", () => {
@@ -65,10 +75,16 @@ describe("session-index query API", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].arguments).toEqual({ stepId: "ism", overrides: { variant_ism_width: 600 } });
 
-    const empty = findToolCalls(db, { tool_name: "workflow_set_overrides", args_contains: "neuroblastoma" });
+    const empty = findToolCalls(db, {
+      tool_name: "workflow_set_overrides",
+      args_contains: "neuroblastoma",
+    });
     expect(empty).toHaveLength(0);
 
-    const match = findToolCalls(db, { tool_name: "workflow_set_overrides", args_contains: "variant_ism_width" });
+    const match = findToolCalls(db, {
+      tool_name: "workflow_set_overrides",
+      args_contains: "variant_ism_width",
+    });
     expect(match).toHaveLength(1);
   });
 
@@ -80,18 +96,23 @@ describe("session-index query API", () => {
   it("includes timestamp-tied entries in the context window", () => {
     // Create a fresh scenario with three entries sharing a timestamp.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "session-index-tie-"));
-    seed(tmp, "/tmp/tie", "sess-tie.jsonl", `\
+    seed(
+      tmp,
+      "/tmp/tie",
+      "sess-tie.jsonl",
+      `\
 {"type":"session","version":3,"id":"sess-tie","timestamp":"2026-04-05T10:00:00Z","cwd":"/tmp/tie"}
 {"type":"message","id":"a","parentId":null,"timestamp":"2026-04-05T10:00:05Z","message":{"role":"user","content":[{"type":"text","text":"a"}]}}
 {"type":"message","id":"b","parentId":"a","timestamp":"2026-04-05T10:00:10Z","message":{"role":"assistant","content":[{"type":"text","text":"b"}]}}
 {"type":"message","id":"c","parentId":"b","timestamp":"2026-04-05T10:00:10Z","message":{"role":"user","content":[{"type":"text","text":"c"}]}}
 {"type":"message","id":"d","parentId":"c","timestamp":"2026-04-05T10:00:10Z","message":{"role":"assistant","content":[{"type":"text","text":"d"}]}}
 {"type":"message","id":"e","parentId":"d","timestamp":"2026-04-05T10:00:15Z","message":{"role":"user","content":[{"type":"text","text":"e"}]}}
-`);
+`,
+    );
     const db2 = openIndexDb(path.join(tmp, "idx.db"));
     scanSessions(db2, tmp);
     const ctx = getSessionContext(db2, { entry_id: "c", before: 5, after: 5 });
-    expect(ctx.map(e => e.entry_id)).toEqual(["a", "b", "c", "d", "e"]);
+    expect(ctx.map((e) => e.entry_id)).toEqual(["a", "b", "c", "d", "e"]);
     db2.close();
     fs.rmSync(tmp, { recursive: true, force: true });
   });
@@ -100,10 +121,15 @@ describe("session-index query API", () => {
     // variant_ism_width should match literally -- NOT match variantxismxwidth.
     // Seed a second tool call whose args contain 'variantxismxwidth' (underscores replaced).
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "session-index-like-"));
-    seed(tmp, "/tmp/like", "sess-like.jsonl", `\
+    seed(
+      tmp,
+      "/tmp/like",
+      "sess-like.jsonl",
+      `\
 {"type":"session","version":3,"id":"sess-like","timestamp":"2026-04-05T10:00:00Z","cwd":"/tmp/like"}
 {"type":"message","id":"x1","parentId":null,"timestamp":"2026-04-05T10:00:05Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"tux","name":"workflow_set_overrides","input":{"key":"variantxismxwidth","value":600}}]}}
-`);
+`,
+    );
     const db2 = openIndexDb(path.join(tmp, "idx.db"));
     scanSessions(db2, tmp);
     const match = findToolCalls(db2, {

--- a/tests/team-critic-parser.test.ts
+++ b/tests/team-critic-parser.test.ts
@@ -8,8 +8,9 @@ describe("parseCriticResponse", () => {
   });
 
   it("parses JSON at end of a longer response", () => {
-    const text = "Here is my reasoning.\nThe proposal misses X.\n" +
-                 '{"approved": false, "critique": "misses X"}';
+    const text =
+      "Here is my reasoning.\nThe proposal misses X.\n" +
+      '{"approved": false, "critique": "misses X"}';
     const r = parseCriticResponse(text);
     expect(r).toEqual({ approved: false, critique: "misses X" });
   });

--- a/tests/team-dispatcher.test.ts
+++ b/tests/team-dispatcher.test.ts
@@ -1,16 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { runTeamDispatch } from "../extensions/loom/teams/dispatcher";
-import type {
-  TeamSpec,
-  RoleTurnResult,
-  DispatchDeps,
-} from "../extensions/loom/teams/types";
+import type { TeamSpec, RoleTurnResult, DispatchDeps } from "../extensions/loom/teams/types";
 
 function spec(overrides: Partial<TeamSpec> = {}): TeamSpec {
   return {
     description: "find relevant papers",
     roles: [
-      { name: "Finder",    system_prompt: "find" },
+      { name: "Finder", system_prompt: "find" },
       { name: "Validator", system_prompt: "validate" },
     ],
     max_rounds: 5,
@@ -31,10 +27,14 @@ function deps(script: Record<string, string[]>): DispatchDeps {
 
 describe("runTeamDispatch", () => {
   it("converges when the validator approves round 1", async () => {
-    const r = await runTeamDispatch(spec(), deps({
-      Finder:    ["initial proposal"],
-      Validator: ['{"approved": true, "critique": "great"}'],
-    }), new AbortController().signal);
+    const r = await runTeamDispatch(
+      spec(),
+      deps({
+        Finder: ["initial proposal"],
+        Validator: ['{"approved": true, "critique": "great"}'],
+      }),
+      new AbortController().signal,
+    );
     expect(r.converged).toBe(true);
     expect(r.rounds).toBe(1);
     expect(r.final_output).toBe("initial proposal");
@@ -42,14 +42,18 @@ describe("runTeamDispatch", () => {
   });
 
   it("converges on round 3 of 5", async () => {
-    const r = await runTeamDispatch(spec(), deps({
-      Finder:    ["p1", "p2", "p3"],
-      Validator: [
-        '{"approved": false, "critique": "needs X"}',
-        '{"approved": false, "critique": "still missing Y"}',
-        '{"approved": true,  "critique": "ok"}',
-      ],
-    }), new AbortController().signal);
+    const r = await runTeamDispatch(
+      spec(),
+      deps({
+        Finder: ["p1", "p2", "p3"],
+        Validator: [
+          '{"approved": false, "critique": "needs X"}',
+          '{"approved": false, "critique": "still missing Y"}',
+          '{"approved": true,  "critique": "ok"}',
+        ],
+      }),
+      new AbortController().signal,
+    );
     expect(r.converged).toBe(true);
     expect(r.rounds).toBe(3);
     expect(r.final_output).toBe("p3");
@@ -57,13 +61,17 @@ describe("runTeamDispatch", () => {
   });
 
   it("returns best-so-far when max_rounds is hit without approval", async () => {
-    const r = await runTeamDispatch(spec({ max_rounds: 2 }), deps({
-      Finder:    ["p1", "p2"],
-      Validator: [
-        '{"approved": false, "critique": "bad"}',
-        '{"approved": false, "critique": "still bad"}',
-      ],
-    }), new AbortController().signal);
+    const r = await runTeamDispatch(
+      spec({ max_rounds: 2 }),
+      deps({
+        Finder: ["p1", "p2"],
+        Validator: [
+          '{"approved": false, "critique": "bad"}',
+          '{"approved": false, "critique": "still bad"}',
+        ],
+      }),
+      new AbortController().signal,
+    );
     expect(r.converged).toBe(false);
     expect(r.rounds).toBe(2);
     expect(r.final_output).toBe("p2");
@@ -95,7 +103,7 @@ describe("runTeamDispatch", () => {
           err.name = "AbortError";
           throw err;
         }
-        ac.abort();  // abort after the first turn completes
+        ac.abort(); // abort after the first turn completes
         return { content: "p", usage: { input_tokens: 0, output_tokens: 0 } };
       },
     };

--- a/tests/team-validate.test.ts
+++ b/tests/team-validate.test.ts
@@ -5,7 +5,7 @@ import type { TeamSpec } from "../extensions/loom/teams/types";
 const ok = (): TeamSpec => ({
   description: "find relevant RNA-seq papers",
   roles: [
-    { name: "Finder",    system_prompt: "find papers" },
+    { name: "Finder", system_prompt: "find papers" },
     { name: "Validator", system_prompt: "score relevance" },
   ],
 });

--- a/web/orbit-shim.ts
+++ b/web/orbit-shim.ts
@@ -23,10 +23,11 @@ function emit(event: string, ...args: unknown[]): void {
   listeners[event]?.forEach((cb) => cb(...args));
 }
 
-function on(event: string, cb: Callback<unknown[]>): () => void {
+function on<T extends unknown[]>(event: string, cb: Callback<T>): () => void {
+  const listener = cb as Callback<unknown[]>;
   if (!listeners[event]) listeners[event] = new Set();
-  listeners[event].add(cb);
-  return () => listeners[event].delete(cb);
+  listeners[event].add(listener);
+  return () => listeners[event].delete(listener);
 }
 
 function send(msg: Record<string, unknown>): void {
@@ -88,7 +89,7 @@ function connect(): void {
 connect();
 
 // Expose the same OrbitAPI shape the renderer expects.
-(window as Record<string, unknown>).orbit = {
+(window as unknown as Record<string, unknown>).orbit = {
   prompt: (message: string) => invoke("agent:prompt", message),
   abort: () => invoke("agent:abort"),
   newSession: () => invoke("agent:new-session"),
@@ -102,7 +103,10 @@ connect();
   getConfig: () => invoke("config:get"),
   saveConfig: (config: unknown) => invoke("config:save", config),
   respondToUiRequest: (id: string, response: Record<string, unknown>) => {
-    send({ channel: "agent:ui-response", args: [{ type: "extension_ui_response", id, ...response }] });
+    send({
+      channel: "agent:ui-response",
+      args: [{ type: "extension_ui_response", id, ...response }],
+    });
   },
   restartAgent: () => invoke("agent:restart"),
   resetSession: () => invoke("agent:reset-session"),

--- a/web/server.ts
+++ b/web/server.ts
@@ -33,7 +33,11 @@ function log(...args: unknown[]): void {
 
 function loadConfig(): Record<string, unknown> {
   if (existsSync(LOOM_CONFIG_PATH)) {
-    try { return JSON.parse(readFileSync(LOOM_CONFIG_PATH, "utf-8")); } catch { /* */ }
+    try {
+      return JSON.parse(readFileSync(LOOM_CONFIG_PATH, "utf-8"));
+    } catch {
+      /* */
+    }
   }
   return {};
 }
@@ -72,7 +76,11 @@ function startLoom(): void {
 
   rl.on("line", (line) => {
     let data: Record<string, unknown>;
-    try { data = JSON.parse(line); } catch { return; }
+    try {
+      data = JSON.parse(line);
+    } catch {
+      return;
+    }
 
     const type = data.type as string;
 
@@ -123,10 +131,12 @@ function sendToLoom(obj: Record<string, unknown>): void {
 
 function sendEvent(event: string, ...payload: unknown[]): void {
   if (!activeSocket || activeSocket.readyState !== WebSocket.OPEN) return;
-  activeSocket.send(JSON.stringify({
-    _event: event,
-    _payload: payload.length === 1 ? payload[0] : payload,
-  }));
+  activeSocket.send(
+    JSON.stringify({
+      _event: event,
+      _payload: payload.length === 1 ? payload[0] : payload,
+    }),
+  );
 }
 
 // ── Express + WebSocket ──────────────────────────────────────────────────────
@@ -166,11 +176,13 @@ async function setupVite(): Promise<void> {
       let html = readFileSync(indexPath, "utf-8");
       html = html.replace(
         '<script type="module" src="./app.ts"></script>',
-        '<script type="module" src="/orbit-shim.ts"></script>\n  <script type="module" src="./app.ts"></script>'
+        '<script type="module" src="/orbit-shim.ts"></script>\n  <script type="module" src="./app.ts"></script>',
       );
       html = await vite.transformIndexHtml(req.originalUrl, html);
       res.status(200).set({ "Content-Type": "text/html" }).end(html);
-    } catch (e) { next(e); }
+    } catch (e) {
+      next(e);
+    }
   });
 }
 
@@ -183,7 +195,11 @@ wss.on("connection", (socket) => {
 
   socket.on("message", (raw) => {
     let msg: Record<string, unknown>;
-    try { msg = JSON.parse(raw.toString()); } catch { return; }
+    try {
+      msg = JSON.parse(raw.toString());
+    } catch {
+      return;
+    }
 
     const id = msg.id as string | undefined;
     const channel = msg.channel as string;


### PR DESCRIPTION
## Summary

- Add root ESLint flat config (typescript-eslint recommended + react-hooks for renderer/preload/web) and Prettier config (lf, 100col, semi, double-quote, trailing comma).
- Add `format`, `format:check`, `lint`, `lint:fix`, `precommit`, `prepare` npm scripts.
- Wire up Husky pre-commit hook running `lint-staged` so format + autofix runs only on changed files.
- Apply a one-time Prettier baseline across the repo against current main (commit 2 is the noisy one -- 57 files, mechanical).
- Fix a small pre-existing `web/orbit-shim.ts` type issue surfaced by the new lint, plus a single `no-useless-assignment` error in `app/src/renderer/galaxy-invocations.ts` (`let host = ""` -> `let host: string` -- both branches assign).

## Verification

- `npm run typecheck` clean (root + app)
- `npm test` 132/132
- `npm run lint` 0 errors, 8 warnings (pre-existing `_`-rename and `any` patterns, non-blocking)
- `npm run format:check` clean

## Test plan

- [ ] Make a no-op edit, `git commit` -- verify pre-commit hook runs prettier + eslint --fix on changed files only.
- [ ] Run `npm run lint` on a fresh clone after `npm install` -- should match the verification output.