### PR TITLE
brain prompt: prefer UDTs to local glue + drop galaxy-mcp 1.4.0 hedge

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ Loom registers a small set of extension tools. Plans, decisions, results, and in
 | **Skills** | `skills_fetch` (fetch SKILL.md / reference docs from configured repos) |
 | **Multi-agent (experimental)** | `team_dispatch` (gated by `LOOM_TEAM_DISPATCH=1`) |
 
-Galaxy MCP (registered separately when credentials are present) provides `galaxy_connect`, `galaxy_search_tools_by_name`, `galaxy_run_tool`, `galaxy_invoke_workflow`, `galaxy_search_iwc`, `get_iwc_workflows`, `import_workflow_from_iwc`, history/dataset operations, and more.
+Galaxy MCP (registered separately when credentials are present) provides `galaxy_connect`, `galaxy_search_tools_by_name`, `galaxy_run_tool`, `galaxy_invoke_workflow`, `galaxy_search_iwc`, `get_iwc_workflows`, `import_workflow_from_iwc`, user-defined tool lifecycle (`galaxy_create_user_tool`, `galaxy_list_user_tools`, `galaxy_run_user_tool`, `galaxy_delete_user_tool`), history/dataset operations, and more.
 
 ## Tech stack
 

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -150,22 +150,32 @@ resources before deciding what runs where:
    - Heavy compute (alignment, large variant calling, big assemblies,
      long-running BLAST, etc.) → check Galaxy tool availability
      (\`galaxy_search_tools_by_name\`); if installed, mark step Galaxy.
-   - Light/exploratory (parsing, summarization, awk/sed/jq/small
-     scripts) → mark step local.
+   - **Gap-filling glue** between Galaxy steps (a small filter,
+     reformatter, joiner, column-trimmer, etc. that isn't in the
+     public tool panel) → **prefer a user-defined tool** over a local
+     script. Create it once with \`galaxy_create_user_tool\` and run it
+     with \`galaxy_run_user_tool\`. Keeps the analysis on Galaxy,
+     preserves provenance, stays reusable across histories. Default to
+     this whenever the glue is something a future user might want to
+     run again.
+   - Light/exploratory (parsing, summarization, awk/sed/jq one-offs,
+     truly throwaway probes) → mark step local. Reserve for work that
+     doesn't belong in the durable record.
 3. Document routing in the plan section header and inline per-step:
    \`## Plan A: chrM Variant Calling [hybrid]\`
    \`Step 3: BWA alignment (Galaxy: bwa-mem2/2.2.1)\`
-   \`Step 4: VCF filter (local awk)\`
+   \`Step 4: VCF filter (Galaxy UDT: vcf_min_depth)\`
+   \`Step 5: quick stat probe (local awk)\`
 
 ### Galaxy terminology
 
 - **User-defined tool** ("UDT"): a server-side custom tool the user
-  registers in their Galaxy account. Created/managed via Galaxy API
-  (and the Galaxy MCP if/when the version installed exposes UDT
-  endpoints). **Do not generate old-style XML tool wrappers locally
-  when the user asks for a UDT** — that's a different concept (legacy
-  ToolShed tools). If the connected Galaxy MCP doesn't expose UDT
-  tools, say so and point the user to the Galaxy UI rather than
+  registers in their Galaxy account, runs unprivileged. The connected
+  Galaxy MCP exposes the full lifecycle: \`galaxy_create_user_tool\`,
+  \`galaxy_list_user_tools\`, \`galaxy_run_user_tool\`,
+  \`galaxy_delete_user_tool\`. **Do not generate old-style XML tool
+  wrappers locally when the user asks for a UDT** — that's a different
+  concept (legacy ToolShed tools). Reach for the MCP tools rather than
   inventing a local workaround.
 - **Workflow invocation**: a single run of a Galaxy workflow on a
   history. Tracked in the notebook via \`loom-invocation\` blocks.


### PR DESCRIPTION
## Summary

Two small prompt nudges to the connected-Galaxy brain prompt, same theme:

- galaxy-mcp 1.4.0 (UDT-aware) shipped 2026-04-27. The existing `galaxy-mcp>=1.4.0` pin in `bin/loom.js` was already future-dated for it. Drop the "if/when the version installed exposes UDT endpoints" hedge in the Galaxy glossary and name the four lifecycle MCP tools (`galaxy_create_user_tool`, `_list_`, `_run_`, `_delete_`) so the brain reaches for them.
- When a step is gap-filling glue between Galaxy tools (filter, reformatter, joiner, column-trimmer that isn't in the public tool panel), prefer creating a UDT over running a local script. Keeps the analysis on Galaxy, preserves provenance, stays reusable across histories. Local steps stay reserved for genuinely throwaway exploration that doesn't belong in the durable record.

README's Galaxy MCP tool list updated to match.

Closes #22.

## Test plan

- [x] `npm test` -- 130/130
- [x] `npm run typecheck` -- clean
- [ ] Live verification: ask the brain to fill a gap with a UDT against a real Galaxy account that supports UDT endpoints