### PR TITLE
add Reload + Force Reload to View menu (Ctrl+R / Ctrl+Shift+R)

### DIFF
--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -364,7 +364,10 @@ function buildMenu(): void {
     {
       label: "View",
       submenu: [
+        { role: "reload" },
+        { role: "forceReload" },
         { role: "toggleDevTools" },
+        { type: "separator" },
         { role: "resetZoom" },
         { role: "zoomIn" },
         { role: "zoomOut" },


### PR DESCRIPTION
The View menu was missing the standard \`reload\` and \`forceReload\` roles, so Ctrl+R fired nothing and a stuck renderer left the user with no in-app escape hatch — they had to kill \`npm start\` from a terminal. This came up live during testing today (companion bugs #62, #63, #64).

3 lines. Adds the two standard Electron menu roles, which auto-bind the platform keyboard shortcuts (Ctrl+R / Ctrl+Shift+R on Linux/Windows, Cmd+R / Cmd+Shift+R on macOS).

```diff
       label: \"View\",
       submenu: [
+        { role: \"reload\" },
+        { role: \"forceReload\" },
         { role: \"toggleDevTools\" },
+        { type: \"separator\" },
         { role: \"resetZoom\" },
         { role: \"zoomIn\" },
         { role: \"zoomOut\" },
```