### PR TITLE
fix Galaxy footer dot stuck on red despite configured key

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -387,10 +387,14 @@ const galaxyStatus = document.getElementById("galaxy-status")!;
 
 async function refreshGalaxyStatus(): Promise<void> {
   const cfg = (await window.orbit.getConfig()) as Record<string, unknown>;
-  const galaxy = cfg.galaxy as { active?: string; profiles?: Record<string, { url?: string; apiKey?: string }> } | undefined;
+  // getConfig returns the *masked* config — Galaxy profiles carry
+  // `hasApiKey: boolean`, never the plaintext apiKey. Checking
+  // `profile.apiKey` here used to make the dot stay red even when a key
+  // was set, because the field is undefined in the masked shape.
+  const galaxy = cfg.galaxy as { active?: string; profiles?: Record<string, { url?: string; hasApiKey?: boolean }> } | undefined;
   const active = galaxy?.active;
   const profile = active ? galaxy?.profiles?.[active] : undefined;
-  const connected = !!(profile?.url && profile?.apiKey);
+  const connected = !!(profile?.url && profile?.hasApiKey);
 
   if (connected) {
     galaxyStatus.classList.add("status-dot-connected");


### PR DESCRIPTION
## Symptom

Agent says \"Galaxy is connected\" but the footer dot stays red. Reported during testing today.

## Root cause

\`refreshGalaxyStatus\` (\`app/src/renderer/app.ts:388\`) decides connected/disconnected from \`profile.apiKey\`:

\`\`\`ts
const connected = !!(profile?.url && profile?.apiKey);
\`\`\`

But \`getConfig()\` returns the **masked** \`MaskedLoomConfig\` shape (\`app/src/main/ipc-handlers.ts\`), where Galaxy profiles carry \`{ url, hasApiKey: boolean }\` — the plaintext key is intentionally not in the renderer-visible payload (see #26). So \`profile.apiKey\` is always undefined, \`connected\` is always false, dot stays red.

The brain side, however, has the actual credentials and connects fine — hence the visible disagreement.

## Fix

Switch the check to \`profile?.hasApiKey\` and update the type cast accordingly. 6 lines.

## Test

- \`npm run typecheck\` clean (root + app)
- \`npm test\` 117/117
- Smoke: configure a Galaxy profile in Preferences → save → footer dot turns green.

## Related

- #26 (the encrypted-secrets PR that introduced the masking) — the renderer just wasn't updated to use the new shape here.