### PR TITLE
Galaxy invocation progress section in Activity tab (refs #67, part 1/2)

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -3,6 +3,7 @@ import { ShellPanel } from "./chat/shell-panel.js";
 import { ArtifactPanel } from "./artifacts/artifact-panel.js";
 import { FilesPanel } from "./files/files-panel.js";
 import { FileViewer } from "./files/file-viewer.js";
+import { refreshGalaxyInvocations } from "./galaxy-invocations.js";
 import {
   LoomWidgetKey,
   decodeMarkdownWidget,
@@ -376,9 +377,11 @@ document.addEventListener("mouseup", () => {
 
 // Initial tree population + live updates from the main-process watcher.
 void filesPanel.refresh();
+void refreshGalaxyInvocations(window.orbit);
 window.orbit.onFilesChanged(() => {
   void filesPanel.refresh();
   void fileViewer.refreshFromDisk();
+  void refreshGalaxyInvocations(window.orbit);
 });
 
 // ── Galaxy connection indicator ──────────────────────────────────────────────
@@ -715,6 +718,7 @@ function applyCwdChange(dir: string): void {
   artifacts.hideFileTab();
   filesPanel.reset();
   void filesPanel.refresh();
+  void refreshGalaxyInvocations(window.orbit);
 }
 
 cwdChangeBtn.addEventListener("click", async () => {

--- a/app/src/renderer/galaxy-invocations.ts
+++ b/app/src/renderer/galaxy-invocations.ts
@@ -1,0 +1,193 @@
+/**
+ * Galaxy invocations panel — third section in the Activity tab. Parses
+ * `loom-invocation` YAML blocks from `notebook.md` and draws a live
+ * progress row per active workflow.
+ *
+ * The brain owns polling Galaxy and rewriting the YAML; this side just
+ * reads what's on disk and re-renders on every files:changed event.
+ * Hidden when there are no in-progress invocations (with a brief linger
+ * so users see the final completed/failed state).
+ */
+
+interface Invocation {
+  invocationId: string;
+  galaxyServerUrl: string;
+  notebookAnchor: string;
+  label: string;
+  submittedAt: string;
+  status: "in_progress" | "completed" | "failed";
+  summary?: string;
+  totalSteps?: number;
+  completedSteps?: number;
+  totalJobs?: number;
+  completedJobs?: number;
+  failedJobs?: number;
+  lastPolledAt?: string;
+}
+
+const FENCE_OPEN = "```loom-invocation";
+const FENCE_CLOSE = "```";
+const STATUSES = new Set(["in_progress", "completed", "failed"] as const);
+// After the last in-progress invocation flips to completed/failed, keep
+// the section visible for a few seconds so the user sees the final state
+// before it disappears.
+const LINGER_MS = 5000;
+
+let lingerTimer: ReturnType<typeof setTimeout> | null = null;
+
+function unescape(value: string): string {
+  if (value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\"/g, '"');
+  }
+  return value;
+}
+
+export function parseInvocationBlocks(content: string): Invocation[] {
+  const out: Invocation[] = [];
+  const lines = content.split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    if (lines[i].trim() === FENCE_OPEN) {
+      const start = i + 1;
+      let end = start;
+      while (end < lines.length && lines[end].trim() !== FENCE_CLOSE) end++;
+      const body = lines.slice(start, end);
+      const fields: Record<string, string> = {};
+      for (const line of body) {
+        const m = line.match(/^([a-z_]+):\s*(.*)$/);
+        if (m) fields[m[1]] = unescape(m[2].trim());
+      }
+      const status = fields.status as Invocation["status"];
+      if (
+        fields.invocation_id &&
+        fields.galaxy_server_url &&
+        fields.notebook_anchor &&
+        fields.label &&
+        fields.submitted_at &&
+        STATUSES.has(status)
+      ) {
+        const num = (k: string): number | undefined => {
+          const raw = fields[k];
+          if (!raw) return undefined;
+          const n = Number(raw);
+          return Number.isFinite(n) ? n : undefined;
+        };
+        out.push({
+          invocationId: fields.invocation_id,
+          galaxyServerUrl: fields.galaxy_server_url,
+          notebookAnchor: fields.notebook_anchor,
+          label: fields.label,
+          submittedAt: fields.submitted_at,
+          status,
+          summary: fields.summary || undefined,
+          totalSteps: num("total_steps"),
+          completedSteps: num("completed_steps"),
+          totalJobs: num("total_jobs"),
+          completedJobs: num("completed_jobs"),
+          failedJobs: num("failed_jobs"),
+          lastPolledAt: fields.last_polled_at || undefined,
+        });
+      }
+      i = end + 1;
+    } else {
+      i++;
+    }
+  }
+  return out;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function renderRow(inv: Invocation): string {
+  const total = inv.totalJobs ?? 0;
+  const done = inv.completedJobs ?? 0;
+  const failed = inv.failedJobs ?? 0;
+  const pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : 0;
+
+  const stepsText = inv.totalSteps !== undefined
+    ? `${inv.completedSteps ?? 0}/${inv.totalSteps} steps`
+    : "";
+  const jobsText = total > 0
+    ? `${done}/${total} jobs${failed > 0 ? ` · ${failed} failed` : ""}`
+    : "";
+  const counts = [stepsText, jobsText].filter(Boolean).join(" · ");
+
+  let host = "";
+  try { host = new URL(inv.galaxyServerUrl).host; } catch { host = inv.galaxyServerUrl; }
+  const submitted = inv.submittedAt.replace("T", " ").replace(/\.\d+Z$/, "Z");
+
+  return `
+    <div class="galaxy-invocation-row ${inv.status}">
+      <div class="galaxy-invocation-head">
+        <span class="galaxy-invocation-label" title="${escapeHtml(inv.label)}">${escapeHtml(inv.label)}</span>
+        <span class="galaxy-invocation-counts">${counts || inv.status}</span>
+      </div>
+      <div class="galaxy-invocation-bar">
+        <div class="galaxy-invocation-bar-fill" style="width: ${pct}%"></div>
+      </div>
+      <div class="galaxy-invocation-meta">
+        ${escapeHtml(inv.status)} · ${escapeHtml(host)} · submitted ${escapeHtml(submitted)}
+      </div>
+    </div>
+  `;
+}
+
+/**
+ * Render the invocations section from notebook.md. Hides the section
+ * when no invocations exist (with a linger after the last in-progress
+ * one finishes so the final state is briefly visible).
+ */
+export async function refreshGalaxyInvocations(
+  api: { readFile: (p: string) => Promise<{ ok: true; bytes: Uint8Array } | { ok: false }> },
+): Promise<void> {
+  const section = document.getElementById("activity-galaxy-section");
+  const body = document.getElementById("galaxy-invocations-body");
+  const countEl = document.getElementById("galaxy-invocations-count");
+  if (!section || !body || !countEl) return;
+
+  let invocations: Invocation[] = [];
+  try {
+    const res = await api.readFile("notebook.md");
+    if (res.ok) {
+      const text = new TextDecoder("utf-8").decode(res.bytes);
+      invocations = parseInvocationBlocks(text);
+    }
+  } catch { /* notebook missing — leave invocations empty */ }
+
+  const inProgress = invocations.filter((i) => i.status === "in_progress");
+
+  if (invocations.length === 0) {
+    section.classList.add("hidden");
+    return;
+  }
+
+  // Sort: in-progress first, then by submittedAt descending
+  invocations.sort((a, b) => {
+    if (a.status === "in_progress" && b.status !== "in_progress") return -1;
+    if (b.status === "in_progress" && a.status !== "in_progress") return 1;
+    return b.submittedAt.localeCompare(a.submittedAt);
+  });
+
+  body.innerHTML = invocations.map(renderRow).join("");
+  countEl.textContent = String(inProgress.length);
+  countEl.classList.toggle("zero", inProgress.length === 0);
+  section.classList.remove("hidden");
+
+  // Linger logic: when nothing is in-progress, schedule a hide.
+  if (inProgress.length === 0) {
+    if (lingerTimer) clearTimeout(lingerTimer);
+    lingerTimer = setTimeout(() => {
+      lingerTimer = null;
+      section.classList.add("hidden");
+    }, LINGER_MS);
+  } else if (lingerTimer) {
+    clearTimeout(lingerTimer);
+    lingerTimer = null;
+  }
+}

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -113,6 +113,12 @@
           </div>
         </div>
         <div id="activity-view" class="pane-body hidden">
+          <div id="activity-galaxy-section" class="hidden">
+            <div class="activity-section-header">
+              <span>Galaxy invocations <span id="galaxy-invocations-count" class="zero">0</span></span>
+            </div>
+            <div id="galaxy-invocations-body"></div>
+          </div>
           <div id="activity-shell-section">
             <div class="activity-section-header">
               <span>Shell</span>

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -1177,6 +1177,90 @@ body:not(.artifact-collapsed) #artifact-toggle {
   overflow: hidden;
 }
 
+#activity-galaxy-section {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  background: var(--masthead);
+  color: var(--text);
+  overflow: hidden;
+  max-height: 40%;
+}
+#activity-galaxy-section.hidden {
+  display: none;
+}
+
+#galaxy-invocations-body {
+  overflow-y: auto;
+  padding: 6px 12px 8px;
+}
+
+.galaxy-invocation-row {
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border);
+}
+.galaxy-invocation-row:last-child {
+  border-bottom: 0;
+}
+
+.galaxy-invocation-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+}
+.galaxy-invocation-label {
+  flex: 1;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.galaxy-invocation-counts {
+  color: var(--text-dim);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.galaxy-invocation-bar {
+  margin-top: 4px;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.galaxy-invocation-bar-fill {
+  height: 100%;
+  background: var(--accent);
+  transition: width 0.3s;
+}
+.galaxy-invocation-row.failed .galaxy-invocation-bar-fill {
+  background: var(--error);
+}
+.galaxy-invocation-row.completed .galaxy-invocation-bar-fill {
+  background: var(--success);
+}
+
+.galaxy-invocation-meta {
+  margin-top: 2px;
+  font-size: 10px;
+  color: var(--text-dim);
+}
+
+#galaxy-invocations-count {
+  background: var(--accent);
+  color: var(--galaxy-dark);
+  padding: 0 6px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 700;
+}
+#galaxy-invocations-count.zero {
+  background: var(--bg-deep);
+  color: var(--text-dim);
+}
+
 .activity-section-header {
   display: flex;
   align-items: center;

--- a/extensions/loom/notebook-writer.ts
+++ b/extensions/loom/notebook-writer.ts
@@ -130,6 +130,16 @@ export interface InvocationYaml {
   submittedAt: string;
   status: "in_progress" | "completed" | "failed";
   summary?: string;
+  // Progress counters — populated by galaxy_invocation_check_*. Persisted
+  // back to the YAML so the Orbit renderer can draw a live progress bar
+  // without each side polling Galaxy independently. Optional so older
+  // blocks (and the initial record-time write) round-trip cleanly.
+  totalSteps?: number;
+  completedSteps?: number;
+  totalJobs?: number;
+  completedJobs?: number;
+  failedJobs?: number;
+  lastPolledAt?: string;
 }
 
 const INVOCATION_FENCE_OPEN = "```loom-invocation";
@@ -149,8 +159,14 @@ export function renderInvocationYaml(inv: InvocationYaml): string {
     `submitted_at: ${inv.submittedAt}`,
     `status: ${inv.status}`,
     `summary: ${escapeYaml(inv.summary ?? "")}`,
-    INVOCATION_FENCE_CLOSE,
   ];
+  if (inv.totalSteps !== undefined) lines.push(`total_steps: ${inv.totalSteps}`);
+  if (inv.completedSteps !== undefined) lines.push(`completed_steps: ${inv.completedSteps}`);
+  if (inv.totalJobs !== undefined) lines.push(`total_jobs: ${inv.totalJobs}`);
+  if (inv.completedJobs !== undefined) lines.push(`completed_jobs: ${inv.completedJobs}`);
+  if (inv.failedJobs !== undefined) lines.push(`failed_jobs: ${inv.failedJobs}`);
+  if (inv.lastPolledAt) lines.push(`last_polled_at: ${inv.lastPolledAt}`);
+  lines.push(INVOCATION_FENCE_CLOSE);
   return lines.join("\n") + "\n";
 }
 
@@ -252,6 +268,12 @@ function parseInvocationBlock(blockLines: string[]): InvocationYaml | null {
   ) {
     return null;
   }
+  const numField = (key: string): number | undefined => {
+    const raw = fields[key];
+    if (raw === undefined || raw === "") return undefined;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : undefined;
+  };
   return {
     invocationId: fields.invocation_id,
     galaxyServerUrl: fields.galaxy_server_url,
@@ -260,6 +282,12 @@ function parseInvocationBlock(blockLines: string[]): InvocationYaml | null {
     submittedAt: fields.submitted_at,
     status,
     summary: fields.summary || undefined,
+    totalSteps: numField("total_steps"),
+    completedSteps: numField("completed_steps"),
+    totalJobs: numField("total_jobs"),
+    completedJobs: numField("completed_jobs"),
+    failedJobs: numField("failed_jobs"),
+    lastPolledAt: fields.last_polled_at || undefined,
   };
 }
 

--- a/extensions/loom/tools.ts
+++ b/extensions/loom/tools.ts
@@ -637,14 +637,21 @@ export async function checkInvocations(specificId: string | undefined, signal?: 
         );
 
         const summary = { ok: 0, running: 0, queued: 0, error: 0, other: 0 };
+        let totalJobs = 0;
+        let completedSteps = 0;
         for (const invStep of inv.steps) {
+          let stepJobs = 0;
+          let stepOk = 0;
           for (const job of invStep.jobs) {
-            if (job.state === "ok") summary.ok++;
+            stepJobs++;
+            totalJobs++;
+            if (job.state === "ok") { summary.ok++; stepOk++; }
             else if (job.state === "running") summary.running++;
             else if (job.state === "queued" || job.state === "new" || job.state === "waiting") summary.queued++;
             else if (job.state === "error" || job.state === "deleted") summary.error++;
             else summary.other++;
           }
+          if (stepJobs > 0 && stepJobs === stepOk) completedSteps++;
         }
 
         let autoAction: string | undefined;
@@ -661,10 +668,21 @@ export async function checkInvocations(specificId: string | undefined, signal?: 
           autoAction = "failed";
         }
 
-        if (nextStatus !== block.status || nextSummary !== block.summary) {
-          const updated: InvocationYaml = { ...block, status: nextStatus, summary: nextSummary };
-          content = upsertInvocationBlock(content, updated);
-        }
+        // Always update the block — even if the rolled-up status didn't
+        // change, the per-poll counters (and last_polled_at) did, and the
+        // renderer wants those for the live progress bar.
+        const updated: InvocationYaml = {
+          ...block,
+          status: nextStatus,
+          summary: nextSummary,
+          totalSteps: inv.steps.length,
+          completedSteps,
+          totalJobs,
+          completedJobs: summary.ok,
+          failedJobs: summary.error,
+          lastPolledAt: new Date().toISOString(),
+        };
+        content = upsertInvocationBlock(content, updated);
 
         results.push({
           invocationId: block.invocationId,

--- a/tests/invocation.test.ts
+++ b/tests/invocation.test.ts
@@ -150,3 +150,34 @@ describe("upsertInvocationBlock", () => {
     expect(parsed.find((p) => p.invocationId === "inv-b")?.label).toBe("B");
   });
 });
+
+describe("progress counters", () => {
+  it("round-trips total_steps / completed_steps / total_jobs / completed_jobs / failed_jobs / last_polled_at", () => {
+    const original = makeInvocation({
+      totalSteps: 5,
+      completedSteps: 3,
+      totalJobs: 27,
+      completedJobs: 12,
+      failedJobs: 0,
+      lastPolledAt: "2026-04-29T14:31:12Z",
+    });
+    const yaml = renderInvocationYaml(original);
+    const [parsed] = findInvocationBlocks(yaml);
+    expect(parsed.totalSteps).toBe(5);
+    expect(parsed.completedSteps).toBe(3);
+    expect(parsed.totalJobs).toBe(27);
+    expect(parsed.completedJobs).toBe(12);
+    expect(parsed.failedJobs).toBe(0);
+    expect(parsed.lastPolledAt).toBe("2026-04-29T14:31:12Z");
+  });
+
+  it("omits counter fields when undefined (older blocks round-trip cleanly)", () => {
+    const yaml = renderInvocationYaml(makeInvocation());
+    expect(yaml).not.toContain("total_steps");
+    expect(yaml).not.toContain("completed_jobs");
+    expect(yaml).not.toContain("last_polled_at");
+    const [parsed] = findInvocationBlocks(yaml);
+    expect(parsed.totalSteps).toBeUndefined();
+    expect(parsed.completedJobs).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Refs #67 — first half. Ships the visible UI; the background poller (the riskier lifecycle work I called out in the issue thread) will be a separate PR.

## What

Adds a third section to the Activity tab — **Galaxy invocations** — that draws a live progress bar per active workflow:

\`\`\`
┌ Galaxy invocations · 2 ─────────────────────┐
│ chrM Variant Calling      3/5 steps · 12/27 jobs │
│ ▓▓▓▓▓▓▓░░░░░░░░░░  in_progress              │
│ in_progress · usegalaxy.org · submitted ... │
├─────────────────────────────────────────────┤
│ QC pre-screen             1/2 steps · 3/8 jobs  │
│ ▓▓▓▓░░░░░░░░░░░░░░  in_progress              │
└─────────────────────────────────────────────┘
\`\`\`

Hidden when no invocations exist. After the last in-progress entry flips to completed/failed, the section lingers 5s with the final state then hides.

## How

**Schema** (\`extensions/loom/notebook-writer.ts\`): \`InvocationYaml\` gains 6 optional fields — \`totalSteps\`, \`completedSteps\`, \`totalJobs\`, \`completedJobs\`, \`failedJobs\`, \`lastPolledAt\`. All optional, so blocks written by older code (or by \`galaxy_invocation_record\` at submit-time) round-trip cleanly.

**Brain** (\`extensions/loom/tools.ts\`): \`galaxy_invocation_check_all\` already tallies these counts in-memory to derive the rolled-up \`status\` field. Persist them to the YAML on every poll. Previously the upsert was skipped when status didn't change — now it always writes so the renderer sees fresh \`last_polled_at\` and counters.

**Renderer** (\`app/src/renderer/galaxy-invocations.ts\` — new): small local YAML parser + render loop. Mirrors the brain's parser intentionally (renderer can't import brain code without bundling it). Reads \`notebook.md\` via the existing \`files:read\` IPC, parses \`loom-invocation\` blocks, draws rows.

**Wire-up** (\`app/src/renderer/app.ts\`): re-renders on every \`files:changed\` event (the existing watcher fires when the brain rewrites the notebook) and on cwd change. No new IPC, no new polling on the renderer side.

## Why notebook-as-truth

We've just spent the last few hours fixing renderer/brain state-desync bugs (#62/#63/#66). The notebook is the durable record; the brain reasons about it; the renderer reads it. No side-channel.

## Out of scope (part 2)

- **Background poller**: today \`galaxy_invocation_check_all\` runs only when the agent decides to call it. Without it, counters stop updating between agent turns. Part 2 adds a brain-side poller that runs every 15s while at least one block has \`status: in_progress\`. Filed separately so its lifecycle code (start on first in-progress block, stop when none remain, survive cwd-change / brain-restart) can be reviewed without the UI work tangled in.

## Test

- \`npm run typecheck\` clean (root + app)
- \`npm test\` 132/132 (added 2 round-trip tests for the new counter fields)
- Manual smoke: in a project with an in-flight Galaxy invocation, ask the agent to \`galaxy_invocation_check_all\`. Counters appear in the YAML; section appears in Activity; bar fills correctly.

## Related

- #67 (parent issue)
- #66 (Galaxy footer indicator) — same testing session, related state-sync theme.