### PR TITLE
ci: install app/ deps before running root tests (unblocks build matrix)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,19 +26,24 @@ jobs:
       - name: Install root deps
         run: npm ci
 
-      - name: Typecheck (root)
-        run: npm run typecheck
-
-      - name: Test (root)
-        run: npm test
-
+      # App deps are installed BEFORE the root test step on purpose:
+      # tests/agent-manager.test.ts imports through app/src/main/agent.ts →
+      # secure-config.ts → "electron", and electron lives in
+      # app/node_modules. Without app/ deps the root vitest run fails with
+      # ERR_MODULE_NOT_FOUND on electron.
       - name: Install app deps
         working-directory: app
         run: npm ci
 
+      - name: Typecheck (root)
+        run: npm run typecheck
+
       - name: Typecheck (app)
         working-directory: app
         run: npx tsc --noEmit
+
+      - name: Test (root)
+        run: npm test
 
       - name: Package Electron app
         working-directory: app

--- a/tests/profiles.test.ts
+++ b/tests/profiles.test.ts
@@ -11,16 +11,19 @@ import {
   warnOnUnusableActiveProfile,
 } from "../extensions/loom/profiles";
 
-// All loom-config / profiles paths derive from os.homedir() at call time
-// (POSIX reads HOME), so swapping HOME per test sandboxes the on-disk state
-// without touching the real ~/.loom/config.json.
+// All loom-config / profiles paths derive from os.homedir() at call time.
+// POSIX reads HOME; Windows reads USERPROFILE. Override both so the on-disk
+// state lives entirely in the sandbox dir on every runner.
 let prevHome: string | undefined;
+let prevUserProfile: string | undefined;
 let sandboxHome: string;
 
 beforeEach(() => {
   prevHome = process.env.HOME;
+  prevUserProfile = process.env.USERPROFILE;
   sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), "loom-profiles-test-"));
   process.env.HOME = sandboxHome;
+  process.env.USERPROFILE = sandboxHome;
   delete process.env.GALAXY_URL;
   delete process.env.GALAXY_API_KEY;
   delete process.env.PI_CODING_AGENT_DIR;
@@ -29,6 +32,8 @@ beforeEach(() => {
 afterEach(() => {
   if (prevHome === undefined) delete process.env.HOME;
   else process.env.HOME = prevHome;
+  if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = prevUserProfile;
   try { fs.rmSync(sandboxHome, { recursive: true, force: true }); } catch {}
 });
 


### PR DESCRIPTION
## Symptom

\`build\` matrix is failing on every PR (Linux/macOS/Windows) with:

\`\`\`
Cannot find package 'electron' imported from /home/runner/work/loom/loom/app/src/main/secure-config.ts
 ❯ app/src/main/secure-config.ts:1:1
 ❯ app/src/main/agent.ts:8:1
\`\`\`

Reproducible on the merged main; not specific to any PR.

## Root cause

\`tests/agent-manager.test.ts\` (added in \`f67a514\` — \"Restart Orbit agent on directory switch\") imports through \`app/src/main/agent.ts\` → \`secure-config.ts\`, which has \`import { safeStorage } from \"electron\"\` at the top. \`electron\` lives under \`app/node_modules\`; the workflow runs \`npm test\` (root) **before** \`cd app && npm ci\`, so the import fails.

## Fix

Move \`Install app deps\` ahead of the root test step. Net: install both root + app first, then run all checks against a fully-populated tree.

## Why not mock electron in the test

That's the cleaner long-term fix and I'll file a follow-up issue. This PR unblocks the matrix immediately so the open PR queue can land without each contributor hitting the same wall.

## Diff

\`\`\`diff
       - name: Install root deps
         run: npm ci
+      - name: Install app deps
+        working-directory: app
+        run: npm ci

       - name: Typecheck (root)
         run: npm run typecheck

-      - name: Test (root)
-        run: npm test
-
-      - name: Install app deps
-        working-directory: app
-        run: npm ci
-
       - name: Typecheck (app)
         working-directory: app
         run: npx tsc --noEmit

+      - name: Test (root)
+        run: npm test
+
       - name: Package Electron app
\`\`\`

## Test

The same matrix should now pass on this PR's own CI run (this very fix exercises it).