### PR TITLE
fix tests/agent-manager.test.ts: mock electron (closes #79)

### DIFF
--- a/tests/agent-manager.test.ts
+++ b/tests/agent-manager.test.ts
@@ -27,6 +27,19 @@ vi.mock("node:os", () => ({
   },
 }));
 
+// app/src/main/agent.ts → secure-config.ts imports `electron` at module top.
+// Without this stub the test only resolves when `app/node_modules/electron`
+// is present, which means CI or a fresh clone has to install app/ deps
+// before the root `vitest` can even start. Stub the small surface area we
+// transitively use; safeStorageAvailable() reads isEncryptionAvailable().
+vi.mock("electron", () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: () => Buffer.from(""),
+    decryptString: () => "",
+  },
+}));
+
 function makeProcess(pid: number) {
   const proc = new EventEmitter() as EventEmitter & Record<string, unknown>;
   proc.pid = pid;


### PR DESCRIPTION
Closes #79.

13 lines. \`agent.ts\` → \`secure-config.ts\` has \`import { safeStorage } from \"electron\"\` at module top, which in vitest pulls in real \`electron\` from \`app/node_modules\`. Without a stub, the root test run only succeeds after \`cd app && npm ci\` — which is why CI broke on every PR until #78 reordered the workflow.

Stub just the surface \`secure-config.ts\` touches: \`safeStorage.isEncryptionAvailable()\` → false routes through the plaintext branch, matching the existing test expectations.

After this lands, #78's workflow reorder is still nice-to-have for parallel install, but no longer required for correctness.

\`npm test\` 132/132.