### PR TITLE
Brain-lifecycle UI hardening: reset on stop, warn before prefs-save restart (closes #62, #63)

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -1957,6 +1957,17 @@ function setStatusBadge(status: string, msg?: string): void {
 window.orbit.onAgentStatus((status, msg) => {
   setStatusBadge(status, msg);
 
+  // Brain transitioned to stopped/error: clear the "we're streaming" UI
+  // so the user has a clean Send button + no stuck "thinking…" card.
+  // Without this, /resume / agent:restart / a brain crash leaves the
+  // renderer believing a turn is still mid-flight (#63).
+  if (status === "stopped" || status === "error") {
+    streaming = false;
+    sendBtn.classList.remove("hidden");
+    abortBtn.classList.add("hidden");
+    chat.hideThinking();
+  }
+
   // Show cwd welcome once, after the first successful agent start.
   if (status === "running" && !hasShownStartupWelcome) {
     hasShownStartupWelcome = true;
@@ -2251,6 +2262,19 @@ function closePreferences(): void {
 }
 
 async function savePreferences(): Promise<void> {
+  // Saving config restarts the brain (so MCP env / model changes take
+  // effect). If a prompt is currently in flight, the restart silently
+  // drops it — the user's message is lost without warning (#62). Make
+  // them confirm explicitly.
+  if (streaming) {
+    const ok = confirm(
+      "The agent is still working on your previous prompt. " +
+      "Saving Preferences will restart it and your in-flight prompt will be lost.\n\n" +
+      "Continue?"
+    );
+    if (!ok) return;
+  }
+
   // Build a delta — only fields the user can edit. Main reconciles secrets
   // against what's on disk; the sentinel preserves a stored key when the
   // user left the input blank.


### PR DESCRIPTION
Closes #62 and #63 — sister bugs surfaced in the same testing session, same root cause: brain-restart paths don't unwind renderer state cleanly.

## #63 — Renderer doesn't reset on stop/error

\`/resume\`, \`agent:restart\`, prefs save, or a brain crash all stop the brain abruptly. The renderer waits for \`agent_end\` to flip \`streaming\` back off; that event never comes, so the badge stays \"thinking…\", Stop button stays visible, and Send stays hidden. User had to Ctrl+R or kill \`npm start\` to escape.

**Fix**: in \`onAgentStatus\`, when status transitions to \`stopped\` or \`error\`, flip \`streaming = false\`, restore the Send button, hide the abort button, and clear the thinking card.

## #62 — Prefs save kills in-flight prompt silently

Saving Preferences restarts the brain (so MCP env / model / etc. take effect). If a prompt is mid-flight, the restart silently drops it — the user's message is just gone, and the renderer keeps showing \"thinking…\" forever (until the #63 fix above kicks in).

**Fix**: in \`savePreferences\`, if \`streaming\` is true, \`confirm()\` first. Default cancel.

## Test

- \`npm test\` 132/132
- \`npm run typecheck\` clean (root + app)
- Manual: send a slow prompt → \`/resume\` → badge flips off thinking, Send button returns. Then send another, open Prefs mid-stream, click Save → confirm dialog appears.

24 lines, one file.