### PR TITLE
liveness indicator: heartbeat dot + elapsed timer on status badge (closes #71)

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -1589,6 +1589,10 @@ window.orbit.onAgentEvent((event) => {
   const type = event.type as string;
   console.log("[orbit] event:", type, JSON.stringify(event).slice(0, 150));
 
+  // Liveness: any event from the brain pulses the heartbeat dot. Debounced
+  // inside tickHeartbeat — message_update fires very rapidly during streaming.
+  tickHeartbeat();
+
   // Capture usage from any event that carries a message with usage
   if (type === "message_start" || type === "message_update" || type === "message_end" || type === "turn_end") {
     captureUsage(event as Record<string, unknown>);
@@ -1602,6 +1606,7 @@ window.orbit.onAgentEvent((event) => {
       streaming = true;
       sendBtn.classList.add("hidden");
       abortBtn.classList.remove("hidden");
+      startTurnTimer();
       // Don't hide thinking yet — wait for actual text content
       break;
 
@@ -1702,6 +1707,7 @@ window.orbit.onAgentEvent((event) => {
     case "agent_end":
       chat.hideThinking();
       streaming = false;
+      stopTurnTimer();
       setStatusBadge("");
       sendBtn.classList.remove("hidden");
       abortBtn.classList.add("hidden");
@@ -1717,6 +1723,7 @@ window.orbit.onAgentEvent((event) => {
       chat.hideThinking();
       chat.addErrorMessage(msg);
       streaming = false;
+      stopTurnTimer();
       setStatusBadge("error");
       sendBtn.classList.remove("hidden");
       abortBtn.classList.add("hidden");
@@ -1946,12 +1953,66 @@ statusBadge.addEventListener("click", () => {
  * "connecting", or "" for the default ready state). `msg` overrides
  * the badge label when present; otherwise the status word is shown.
  */
+// Liveness state. While a turn is in flight we re-render the badge
+// every second so the (M:SS) elapsed counter keeps moving — gives the
+// user a visible signal the brain is alive even when no tool name is
+// changing (#71). turnStartedAt is set on agent_start, cleared on
+// agent_end / status:stopped.
+let lastBadgeBaseText = "";
+let turnStartedAt: number | null = null;
+let elapsedTimer: ReturnType<typeof setInterval> | null = null;
+
+function formatElapsed(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return m > 0 ? `${m}:${String(s).padStart(2, "0")}` : `${s}s`;
+}
+
+function renderBadgeText(): void {
+  if (turnStartedAt) {
+    const elapsed = formatElapsed(Date.now() - turnStartedAt);
+    statusBadge.textContent = `${lastBadgeBaseText} (${elapsed})`;
+  } else {
+    statusBadge.textContent = lastBadgeBaseText;
+  }
+}
+
+function startTurnTimer(): void {
+  turnStartedAt = Date.now();
+  if (elapsedTimer) clearInterval(elapsedTimer);
+  elapsedTimer = setInterval(renderBadgeText, 1000);
+}
+
+function stopTurnTimer(): void {
+  turnStartedAt = null;
+  if (elapsedTimer) { clearInterval(elapsedTimer); elapsedTimer = null; }
+  renderBadgeText();
+}
+
 function setStatusBadge(status: string, msg?: string): void {
-  statusBadge.textContent = msg || status || "Ready";
+  lastBadgeBaseText = msg || status || "Ready";
   statusBadge.className = ("footer-control status-badge " + (status || "")).trim();
   statusBadgeIsStuck = STUCK_STATUS.has(status);
   statusBadge.style.cursor = statusBadgeIsStuck ? "pointer" : "default";
   statusBadge.title = statusBadgeIsStuck ? "Click to open Preferences" : "";
+  renderBadgeText();
+}
+
+// Heartbeat dot next to the badge — pulses each time an agent event
+// arrives (debounced to ~1Hz so it doesn't strobe during streaming).
+// If it goes still while the badge still says running, the brain is
+// genuinely hung.
+const heartbeatEl = document.getElementById("agent-heartbeat")!;
+let lastHeartbeat = 0;
+function tickHeartbeat(): void {
+  const now = performance.now();
+  if (now - lastHeartbeat < 900) return;
+  lastHeartbeat = now;
+  heartbeatEl.classList.remove("pulse");
+  // Force reflow so removing+adding the class restarts the animation.
+  void (heartbeatEl as HTMLElement).offsetWidth;
+  heartbeatEl.classList.add("pulse");
 }
 
 window.orbit.onAgentStatus((status, msg) => {

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -157,6 +157,7 @@
     <!-- Footer bar — status indicators (pane toggles live in chat-title) -->
     <div id="app-footer">
       <span id="agent-status" class="footer-control status-badge">connecting...</span>
+      <span id="agent-heartbeat" class="agent-heartbeat" aria-hidden="true" title="Brain liveness — pulses on every event from the brain"></span>
       <button id="galaxy-status" class="footer-control is-interactive status-dot status-dot-disconnected" title="Galaxy: not configured" aria-label="Galaxy connection: not configured. Click to open Preferences.">
         <span class="status-dot-label">Galaxy</span>
       </button>

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -595,6 +595,31 @@ body:not(.artifact-collapsed) #artifact-toggle {
   animation: blink 1.5s step-end infinite;
 }
 
+/* Heartbeat dot next to the agent status badge. CSS class is added/
+   removed on each agent event (debounced to ~1Hz in JS) — restarts the
+   pulse animation. If the heartbeat stops while the badge still says
+   running/thinking, the brain is genuinely hung. */
+.agent-heartbeat {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-dim);
+  margin-left: -4px;
+  margin-right: 4px;
+  align-self: center;
+  flex-shrink: 0;
+  transition: background 0.4s;
+}
+.agent-heartbeat.pulse {
+  background: var(--accent);
+  animation: heartbeat-pulse 0.8s ease-out;
+}
+@keyframes heartbeat-pulse {
+  0%   { background: var(--accent); transform: scale(1.6); box-shadow: 0 0 4px var(--accent); }
+  100% { background: var(--text-dim); transform: scale(1); box-shadow: 0 0 0 transparent; }
+}
+
 #model-indicator {
   font-family: var(--font);
 }


### PR DESCRIPTION
Closes #71.

Long turns (Galaxy waits, slow bash, big LLM streams) leave the status badge static for minutes. Testers thought Orbit was hung when it wasn't. Two complementary signals:

## 1. Heartbeat dot

A small dot next to the agent-status badge that pulses every time *any* event arrives from the brain. Debounced to ~1Hz so it doesn't strobe during streaming. CSS animation restarts on each pulse.

If the heartbeat goes still while the badge still says \`running:\` / \`thinking…\`, the brain is genuinely hung — that's now visible.

## 2. Elapsed-time counter

Badge text gains a \`(M:SS)\` suffix while a turn is in flight: \`running: bash (3:42)\`. Updates every second. Starts on \`agent_start\`, clears on \`agent_end\` / \`error\`.

\`setStatusBadge\` now keeps the base text in a closure variable and re-renders against the elapsed counter; no other call sites need to change.

## Files

- \`app/src/renderer/index.html\` — heartbeat dot DOM next to \`#agent-status\`
- \`app/src/renderer/styles.css\` — \`.agent-heartbeat\` + \`@keyframes heartbeat-pulse\`
- \`app/src/renderer/app.ts\` — turn-timer state, heartbeat tick on \`onAgentEvent\`, start/stop calls in the agent_start/agent_end/error branches

## Test

- \`npm run typecheck\` clean (root + app)
- \`npm test\` 132/132
- Manual: send a slow prompt → badge updates each second with elapsed (\`running: bash (12s)\` → \`(13s)\` → …) and the dot pulses on each tool/message event.

88 lines net.