### PR TITLE
Stop button: kill brain's tool subprocesses on abort (closes #64)

### DIFF
--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -7,6 +7,7 @@ import { app, type BrowserWindow } from "electron";
 import { loadConfig } from "./config.js";
 import { resolveLlmApiKey, resolveGalaxyApiKey } from "./secure-config.js";
 import { loadSessionHistory } from "./session-replay.js";
+import { collectDescendantsOf } from "./proc-monitor.js";
 
 const PROVIDER_ENV_MAP: Record<string, string> = {
   anthropic: "ANTHROPIC_API_KEY",
@@ -418,6 +419,39 @@ export class AgentManager {
     const json = JSON.stringify(obj);
     log("→ stdin:", json.slice(0, 200));
     this.process.stdin.write(json + "\n");
+  }
+
+  /**
+   * Stop button handler — signals the brain AND kills its tool subprocess
+   * descendants. pi-coding-agent's abort flag only fires at the next agent
+   * loop tick, which means a long bash → fastp keeps running until natural
+   * exit (#64). Walk the brain's process tree and SIGTERM everything,
+   * with a 3s grace before SIGKILL.
+   */
+  async abort(): Promise<void> {
+    this.send({ type: "abort" });
+    const brainPid = this.process?.pid;
+    if (!brainPid) return;
+    try {
+      const descendants = await collectDescendantsOf(brainPid);
+      if (descendants.length === 0) return;
+      log(`abort: SIGTERM ${descendants.length} descendant(s)`);
+      for (const p of descendants) {
+        try { process.kill(p.pid, "SIGTERM"); } catch { /* already gone */ }
+      }
+      // After 3s, SIGKILL anything still alive.
+      setTimeout(() => {
+        for (const p of descendants) {
+          try {
+            process.kill(p.pid, 0); // probe
+            log(`abort: SIGKILL stuck pid ${p.pid}`);
+            try { process.kill(p.pid, "SIGKILL"); } catch { /* gone now */ }
+          } catch { /* already exited */ }
+        }
+      }, 3000);
+    } catch (err) {
+      log("abort: failed to walk descendants:", err);
+    }
   }
 
   sendCommand(obj: Record<string, unknown>): Promise<unknown> {

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -141,7 +141,7 @@ export function registerIpcHandlers(agent: AgentManager): void {
 
   ipcMain.handle("agent:abort", async () => {
     log("abort");
-    agent.send({ type: "abort" });
+    await agent.abort();
   });
 
   ipcMain.handle("agent:new-session", async () => {

--- a/app/src/main/proc-monitor.ts
+++ b/app/src/main/proc-monitor.ts
@@ -80,6 +80,15 @@ export class ProcMonitor {
    * Excludes the agent itself.
    */
   private async collectDescendants(agentPid: number): Promise<ProcInfo[]> {
+    return collectDescendantsOf(agentPid);
+  }
+}
+
+/**
+ * Standalone descendant walker — also used by AgentManager.abort() to
+ * SIGTERM the brain's tool subprocesses on Stop.
+ */
+export async function collectDescendantsOf(agentPid: number): Promise<ProcInfo[]> {
     // Get all processes with their PID and PPID so we can walk the tree.
     // Note: macOS ps doesn't support `nlwp` (thread count) — don't request it.
     const { stdout: psOut } = await execFileP("ps", [
@@ -128,5 +137,4 @@ export class ProcMonitor {
       }
     }
     return descendants;
-  }
 }


### PR DESCRIPTION
Closes #64.

## Problem

pi-coding-agent's abort flag only fires at the next agent-loop tick. A long-running \`bash → fastp\` keeps running until natural exit, so the Stop button looked like a no-op for the bulk of testers' real waits.

## Fix

\`AgentManager.abort()\` now does both:

1. Send the abort message to the brain (existing behavior).
2. Walk the brain's process tree (\`collectDescendantsOf\`, factored out of \`ProcMonitor\` for reuse) and \`SIGTERM\` every descendant.
3. After a 3s grace, \`SIGKILL\` any that survived.

\`agent:abort\` IPC now calls \`agent.abort()\` (was: \`agent.send({type:\"abort\"})\` only). Renderer surface unchanged.

## Side-effect

Tools mid-write may leave a corrupt output file when SIGKILL'd. That's acceptable — user explicitly chose to stop.

## Files

- \`app/src/main/proc-monitor.ts\` — \`collectDescendants\` extracted to module-level \`collectDescendantsOf\` so AgentManager can reuse the same ps walk.
- \`app/src/main/agent.ts\` — new \`abort()\` method.
- \`app/src/main/ipc-handlers.ts\` — \`agent:abort\` calls \`agent.abort()\`.

## Test

- \`npm run typecheck\` clean (root + app)
- \`npm test\` 132/132
- Manual: run \`fastp\` on a large gzipped FASTQ → click Stop → fastp pid disappears from the Activity → Processes pane within 3s.

44 lines net.