### PR TITLE
Confirm model switch via chat info card (closes #57)

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -1327,12 +1327,13 @@ async function switchModelByAlias(originalText: string, alias: string): Promise<
   renderModelIndicator();
 
   if (switchingProvider) {
-    chat.addErrorMessage(
-      `Switched to ${chosen.provider} / ${chosen.model.id}. Agent restarting… ` +
-      `(if you don't have a ${chosen.provider} API key set in Preferences, the agent will fail to start)`
+    chat.addInfoMessage(
+      `<i>Changed model to <code>${chosen.model.id}</code> ` +
+      `(provider: ${chosen.provider}). Agent restarting…</i><br>` +
+      `<small>If you don't have a ${chosen.provider} API key set in Preferences, the agent will fail to start.</small>`
     );
   } else {
-    chat.addErrorMessage(`Model switched to ${chosen.model.id}. Agent restarting…`);
+    chat.addInfoMessage(`<i>Changed model to <code>${chosen.model.id}</code>. Agent restarting…</i>`);
   }
 }
 
@@ -2330,6 +2331,11 @@ async function savePreferences(): Promise<void> {
 
   config.skills = { repos: cleaned };
 
+  // Snapshot the model name BEFORE the save so we can mention it in the
+  // info card if it actually changed (vs. user toggling some other field
+  // and not touching the model — that case shouldn't claim a model swap).
+  const prevModel = currentModel;
+
   const result = await window.orbit.saveConfig(config as Record<string, unknown>);
   if (result.success) {
     closePreferences();
@@ -2339,7 +2345,14 @@ async function savePreferences(): Promise<void> {
     }
     // Info card, not a fake user prompt — was getting numbered as a real
     // user submission and inflating the prompt counter.
-    chat.addInfoMessage("<i>Preferences saved. Agent restarted.</i>");
+    const modelChanged = selectedModel && selectedModel !== prevModel;
+    if (modelChanged) {
+      chat.addInfoMessage(
+        `<i>Preferences saved. Changed model to <code>${selectedModel}</code>. Agent restarted.</i>`
+      );
+    } else {
+      chat.addInfoMessage("<i>Preferences saved. Agent restarted.</i>");
+    }
   } else {
     alert(`Failed to save preferences: ${result.error}`);
   }


### PR DESCRIPTION
Closes #57. Two paths announce a model switch; both had poor wording.

## /model command (\`switchModelByAlias\`)

Was using \`chat.addErrorMessage(...)\` — renders red, looks like a failure even though the switch succeeded. Wording was \"Model switched to X. Agent restarting…\".

Now uses \`addInfoMessage\` with: \`Changed model to <code>X</code>. Agent restarting…\`. Provider mention + API-key hint stays for cross-provider swaps.

## Preferences → Save

Was saying the generic \`Preferences saved. Agent restarted.\` regardless of what changed. User couldn't tell at a glance whether they actually swapped model or just toggled another field.

Now snapshots \`currentModel\` before the save, and if the new model differs, names it: \`Preferences saved. Changed model to <code>X</code>. Agent restarted.\` Otherwise keeps the original generic text.

## Test

- \`npm run typecheck\` clean
- \`npm test\` 132/132
- Smoke: \`/model haiku\` → info-style card; Preferences → change model → Save → \"Changed model to … Agent restarted.\"; Preferences → toggle a non-model field → Save → no spurious model claim.