### PR TITLE
Files panel: show entry count next to directory names (closes #77)

### DIFF
--- a/app/src/renderer/files/files-panel.ts
+++ b/app/src/renderer/files/files-panel.ts
@@ -108,7 +108,14 @@ export class FilesPanel {
     if (node.type === "directory") {
       const isExpanded = this.expanded.has(node.relPath);
       icon.textContent = isExpanded ? "\u{1F4C2}" : "\u{1F4C1}";
-      row.title = node.name;
+      const count = node.children?.length;
+      if (typeof count === "number") {
+        const countEl = document.createElement("span");
+        countEl.className = "files-tree-size";
+        countEl.textContent = String(count);
+        row.appendChild(countEl);
+      }
+      row.title = typeof count === "number" ? `${node.name} (${count} entries)` : node.name;
       row.addEventListener("click", (e) => {
         e.stopPropagation();
         if (this.expanded.has(node.relPath)) {


### PR DESCRIPTION
Closes #77. 8 lines.

Directories in the file tree now show a child count to the right of the name (\`<dirname> &nbsp; N\`), reusing the existing \`.files-tree-size\` style that file rows already use for byte sizes. Tooltip on hover: \`<dirname> (N entries)\`.

Reuses \`node.children.length\` which \`files-handler\`'s recursive \`listFiles\` walk already populates — no new IPC, no extra disk read, no new column.