### PR TITLE
Preferences: Disconnect Galaxy button (closes #49)

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -2093,6 +2093,8 @@ wireApiKeyValidation(prefsProvider, prefsApiKey, prefsApiKeyStatus);
 const prefsGalaxyUrl = document.getElementById("prefs-galaxy-url") as HTMLInputElement;
 const prefsGalaxyKey = document.getElementById("prefs-galaxy-key") as HTMLInputElement;
 const prefsGalaxyError = document.getElementById("prefs-galaxy-error")!;
+const prefsGalaxyActionsRow = document.getElementById("prefs-galaxy-actions-row")!;
+const prefsGalaxyDisconnect = document.getElementById("prefs-galaxy-disconnect") as HTMLButtonElement;
 const prefsDefaultCwd = document.getElementById("prefs-default-cwd") as HTMLInputElement;
 const prefsCondaBin = document.getElementById("prefs-conda-bin") as HTMLSelectElement;
 const prefsSkillsRows = document.getElementById("prefs-skills-rows")!;
@@ -2226,6 +2228,9 @@ async function openPreferences(): Promise<void> {
   prefsGalaxyHadKey = Boolean(activeProfile?.hasApiKey);
   prefsGalaxyKey.value = "";
   prefsGalaxyKey.placeholder = prefsGalaxyHadKey ? "•••••••• (unchanged)" : "";
+  // Disconnect button only makes sense when a profile is currently
+  // configured. Hide entirely when nothing's stored.
+  prefsGalaxyActionsRow.classList.toggle("hidden", !(activeProfile?.url || prefsGalaxyHadKey));
   updatePrefsGalaxyValidity();
 
   prefsDefaultCwd.value = config.defaultCwd || "";
@@ -2355,6 +2360,38 @@ prefsOverlay.addEventListener("click", (e) => {
 prefsBrowseCwd.addEventListener("click", async () => {
   const dir = await window.orbit.browseDirectory();
   if (dir) prefsDefaultCwd.value = dir;
+});
+
+// Disconnect Galaxy: send an explicit clear delta. Main's reconciler
+// already treats apiKey: "" as "drop the stored field" (#49). We send
+// galaxy with no profiles so main writes back active: null + empty
+// profiles map, which the brain reads on next start as "Galaxy not
+// configured" — re-registers MCP only when a key reappears.
+prefsGalaxyDisconnect.addEventListener("click", async () => {
+  if (streaming) {
+    const ok = confirm(
+      "The agent is still working. Disconnecting Galaxy will restart it " +
+      "and your in-flight prompt will be lost.\n\nContinue?"
+    );
+    if (!ok) return;
+  } else {
+    if (!confirm("Disconnect Galaxy and clear stored credentials? Other Preferences are saved as well.")) return;
+  }
+  prefsGalaxyDisconnect.disabled = true;
+  try {
+    const current = (await window.orbit.getConfig()) as Record<string, unknown>;
+    current.galaxy = { active: null, profiles: {} };
+    const result = await window.orbit.saveConfig(current);
+    if (!result.success) {
+      alert(`Failed to disconnect: ${result.error}`);
+      return;
+    }
+    closePreferences();
+    chat.addInfoMessage("<i>Disconnected from Galaxy. Agent restarted.</i>");
+    void refreshGalaxyStatus();
+  } finally {
+    prefsGalaxyDisconnect.disabled = false;
+  }
 });
 
 document.addEventListener("keydown", (e) => {

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -240,6 +240,10 @@
             <input id="prefs-galaxy-key" type="password" placeholder="Galaxy API key" />
           </div>
           <div id="prefs-galaxy-error" class="prefs-galaxy-error"></div>
+          <div class="prefs-row prefs-galaxy-actions hidden" id="prefs-galaxy-actions-row">
+            <span></span>
+            <button id="prefs-galaxy-disconnect" class="plan-btn danger" type="button">Disconnect Galaxy</button>
+          </div>
         </section>
 
         <section class="prefs-section">

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -1486,6 +1486,13 @@ body:not(.artifact-collapsed) #artifact-toggle {
   font-size: 12px;
   min-height: 14px;
 }
+
+.prefs-galaxy-actions {
+  margin-top: 6px;
+}
+.prefs-galaxy-actions.hidden {
+  display: none;
+}
 .required {
   color: var(--error);
   font-size: 11px;


### PR DESCRIPTION
Closes #49.

## Problem

Stored Galaxy profile had no working clearance path:
- The key field is empty by design (placeholder \`•••••••• (unchanged)\`); user can't see/delete the stored value directly.
- Clearing the URL field left \`prefsGalaxyHadKey = true\`, so #38's validity check decided \"key state is filled\" and disabled Save — dead-end.

## Fix

Pick option 2 from the issue: explicit **Disconnect Galaxy** button at the bottom of the Galaxy section in Preferences. Visible only when a profile is currently configured.

Click → confirm → send \`{ active: null, profiles: {} }\` via the existing \`saveConfig\` IPC. Main's \`reconcileIncomingConfig\` rebuilds an empty profiles map; on the next brain start Galaxy MCP is not registered.

Confirm copy gets a stronger \"agent is busy\" variant when a turn is mid-flight (mirrors #62's prefs-save warning).

## Files

- \`app/src/renderer/index.html\` — button + actions row in Galaxy section
- \`app/src/renderer/app.ts\` — refs, visibility toggle on prefs open, click handler
- \`app/src/renderer/styles.css\` — small \`.prefs-galaxy-actions\` spacing rule

## Test

- \`npm run typecheck\` clean (root + app)
- \`npm test\` 132/132
- Smoke: store a profile → reopen Prefs → Disconnect appears → click → footer dot turns red, brain restarts, chat shows \"Disconnected from Galaxy\".

48 lines net.