### PR TITLE
Nudge to cheaper model before /execute on Opus tier (closes #73)

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -821,11 +821,55 @@ document.getElementById("queued-indicator")?.addEventListener("click", () => {
   clearPendingMessage();
 });
 
+// Cheaper-model nudge state. Suppress per-session if the user dismisses
+// the hint, or persistently if they click "Don't show again".
+const CHEAPER_NUDGE_SKIP_KEY = "loom.skipCheaperNudge";
+const EXEC_COMMAND_RE = /^\/(execute|run)\b/i;
+let cheaperNudgeShownThisSession = false;
+
+/**
+ * Plan execution is mostly mechanical (file edits, tool invocations, polling)
+ * — Sonnet/Haiku-class models usually do equally well at 5–20× lower cost
+ * than Opus. When the user kicks off /execute or /run on an Opus-tier model,
+ * surface a one-time chat hint inviting a model swap. (#73)
+ */
+function maybeShowCheaperModelNudge(text: string): void {
+  if (cheaperNudgeShownThisSession) return;
+  if (localStorage.getItem(CHEAPER_NUDGE_SKIP_KEY) === "1") return;
+  if (!EXEC_COMMAND_RE.test(text)) return;
+  if (!currentModel) return;
+  const pricing = findPricing(currentModel);
+  if (!pricing || pricing.in < 10) return;  // mid-tier or cheaper — no nudge
+  cheaperNudgeShownThisSession = true;
+  chat.addInfoMessage(
+    `<i><strong>Heads up:</strong> running plan execution on ` +
+    `<code>${currentModel}</code> ($${pricing.in}/$${pricing.out} per 1M tokens). ` +
+    `Sonnet/Haiku-class models usually do equally well for execution at 5–20× ` +
+    `lower cost — try <code>/model sonnet</code> or <code>/model haiku</code> ` +
+    `before this turn if you want to save. ` +
+    `<a href="#" class="cheaper-nudge-dismiss">Don't show again</a></i>`
+  );
+}
+
+// Persist the dismiss click. Uses event delegation so it fires for any
+// nudge card (the chat replaces messages on /chat replay etc.).
+messagesEl.addEventListener("click", (e) => {
+  const target = e.target as HTMLElement | null;
+  if (!target?.classList.contains("cheaper-nudge-dismiss")) return;
+  e.preventDefault();
+  localStorage.setItem(CHEAPER_NUDGE_SKIP_KEY, "1");
+  target.replaceWith(document.createTextNode("(dismissed)"));
+});
+
 function submit(): void {
   const text = inputEl.value.trim();
   if (!text) return;
 
   appendHistoryEntry(text);
+
+  // Cheaper-model nudge fires before slash dispatch so /execute on Opus
+  // gets the hint inline above the agent's thinking response.
+  maybeShowCheaperModelNudge(text);
 
   // Slash commands — handled locally, no LLM round-trip (allowed even while streaming)
   if (text.startsWith("/")) {


### PR DESCRIPTION
Closes #73.

## Why

Plan execution is mostly mechanical — file edits, tool invocations, polling. Sonnet/Haiku-class models do equally well at 5-20× lower cost than Opus. Users routinely (myself included) burn Opus budget running plans Sonnet would handle fine. The model swap is one click away in Preferences but easy to forget at the exact moment it matters.

## What

When the user submits \`/execute\` or \`/run\` and \`currentModel\`'s input price is ≥ \$10/Mtok (Opus tier), emit a one-time chat info card:

> **Heads up:** running plan execution on \`claude-opus-4-7\` (\$15/\$75 per 1M tokens). Sonnet/Haiku-class models usually do equally well for execution at 5–20× lower cost — try \`/model sonnet\` or \`/model haiku\` before this turn if you want to save. *[Don't show again]*

Suppression:
- **per-session** flag — one nudge per launch, resets on reload
- **persistent** localStorage flag — \"Don't show again\" link, survives restarts

Skips when current model is mid-tier or cheaper. Reuses the existing \`findPricing\` for tier classification, no new pricing logic.

## Out of scope

- Inline buttons (\"Switch & Run\") — defer; needs the model-swap-then-resubmit dance and feels heavier than the bug warrants.
- Pattern-matching \"ok go\" replies after a plan turn — same.
- Plan-ready signal from the brain — same.

## Files

- \`app/src/renderer/app.ts\` — \`maybeShowCheaperModelNudge\` + dismiss-link delegated handler + hook into \`submit()\`. ~44 lines.

## Test

- \`npm run typecheck\` clean
- \`npm test\` 132/132
- Smoke: switch to Opus 4.7, type \`/execute\` → nudge appears once. Type \`/execute\` again same session → no second nudge. Click \"Don't show again\" → reload → no nudge on \`/execute\`.