### PR TITLE
File tab: head-preview large text files instead of rejecting (closes #58)

### DIFF
--- a/app/src/main/files-handler.ts
+++ b/app/src/main/files-handler.ts
@@ -43,6 +43,36 @@ const MAX_PREVIEW_BYTES = 1024 * 1024 * 1024; // 1 GB — hard refuse above this
 const PREVIEW_LINE_COUNT = 10;
 const PREVIEW_BYTE_BUDGET = 64 * 1024; // 64 KB cap on the head we read
 
+// Mirrors the renderer's TEXT_EXTS in file-viewer.ts -- the head-preview
+// path only makes sense for files the renderer would draw as text. Returning
+// 64 KB of head bytes for an image / pdf / binary would just produce a
+// broken <img> or corrupted pdf in the renderer, with no useful signal to
+// the user. Files outside this set in the (5 MB, 1 GB] band get the same
+// "too large" rejection they got before head-preview existed.
+const TEXT_PREVIEW_EXTS = new Set([
+  ".md", ".txt", ".log", ".rst",
+  ".py", ".js", ".ts", ".tsx", ".jsx", ".sh", ".rb", ".pl", ".r", ".go", ".rs",
+  ".json", ".jsonl", ".yml", ".yaml", ".toml", ".ini", ".cfg", ".conf",
+  ".xml", ".html", ".htm", ".css",
+  ".csv", ".tsv", ".tab",
+  ".fa", ".fasta", ".fna", ".faa", ".ffn",
+  ".fastq", ".fq",
+  ".vcf",
+  ".bed", ".bedgraph", ".wig",
+  ".gff", ".gff3", ".gtf",
+  ".sam",
+  ".pdb", ".cif",
+  ".nwk", ".newick", ".tree",
+  ".phy", ".phylip",
+]);
+
+function isTextLikeForPreview(name: string): boolean {
+  const dot = name.lastIndexOf(".");
+  // No extension -- the renderer treats these as text (READMEs, configs).
+  if (dot <= 0) return true;
+  return TEXT_PREVIEW_EXTS.has(name.slice(dot).toLowerCase());
+}
+
 /**
  * Clamp a user-supplied path to the current cwd. Throws if it escapes.
  * Returns the absolute, normalized path.
@@ -212,6 +242,18 @@ export function registerFilesIpc(getCwd: () => string): void {
         return {
           ok: false,
           error: `File too large (${stat.size} bytes, hard limit ${MAX_PREVIEW_BYTES})`,
+          size: stat.size,
+        };
+      }
+
+      // Head preview only makes sense for text-like files. For images /
+      // pdfs / binaries in the (5 MB, 1 GB] band, fall back to the
+      // pre-existing "too large" rejection so the renderer surfaces a
+      // clear error instead of trying to draw 64 KB of mangled bytes.
+      if (!isTextLikeForPreview(path.basename(abs))) {
+        return {
+          ok: false,
+          error: `File too large (${stat.size} bytes, limit ${MAX_READ_BYTES})`,
           size: stat.size,
         };
       }

--- a/app/src/main/files-handler.ts
+++ b/app/src/main/files-handler.ts
@@ -38,7 +38,10 @@ const FS_BLOCKLIST = new Set([
 
 const MAX_DEPTH = 8;
 const MAX_ENTRIES_PER_DIR = 2000;    // refuse to enumerate pathological dirs
-const MAX_READ_BYTES = 5 * 1024 * 1024; // 5 MB — protect the renderer from huge files
+const MAX_READ_BYTES = 5 * 1024 * 1024; // 5 MB — full read up to here
+const MAX_PREVIEW_BYTES = 1024 * 1024 * 1024; // 1 GB — hard refuse above this
+const PREVIEW_LINE_COUNT = 10;
+const PREVIEW_BYTE_BUDGET = 64 * 1024; // 64 KB cap on the head we read
 
 /**
  * Clamp a user-supplied path to the current cwd. Throws if it escapes.
@@ -196,15 +199,48 @@ export function registerFilesIpc(getCwd: () => string): void {
       const abs = resolveWithin(cwd, relPath);
       const stat = await fsp.stat(abs);
       if (!stat.isFile()) return { ok: false, error: "Not a regular file" };
-      if (stat.size > MAX_READ_BYTES) {
+
+      // Full read up to MAX_READ_BYTES.
+      if (stat.size <= MAX_READ_BYTES) {
+        const buf = await fsp.readFile(abs);
+        return { ok: true, size: stat.size, bytes: buf };
+      }
+
+      // Hard refuse pathological sizes (>1 GB) — even a head preview
+      // shouldn't justify opening it.
+      if (stat.size > MAX_PREVIEW_BYTES) {
         return {
           ok: false,
-          error: `File too large (${stat.size} bytes, limit ${MAX_READ_BYTES})`,
+          error: `File too large (${stat.size} bytes, hard limit ${MAX_PREVIEW_BYTES})`,
           size: stat.size,
         };
       }
-      const buf = await fsp.readFile(abs);
-      return { ok: true, size: stat.size, bytes: buf };
+
+      // Head preview: read at most PREVIEW_BYTE_BUDGET bytes from the
+      // start, slice to the first PREVIEW_LINE_COUNT newlines. Single
+      // very-long lines (uncompressed VCF data, packed JSON) get
+      // truncated at the byte cap with a marker.
+      const fd = await fsp.open(abs, "r");
+      try {
+        const headBuf = Buffer.alloc(PREVIEW_BYTE_BUDGET);
+        const { bytesRead } = await fd.read(headBuf, 0, PREVIEW_BYTE_BUDGET, 0);
+        const head = headBuf.subarray(0, bytesRead).toString("utf-8");
+        const lines = head.split("\n").slice(0, PREVIEW_LINE_COUNT);
+        const previewText = lines.join("\n");
+        const truncatedAtByteBudget = bytesRead === PREVIEW_BYTE_BUDGET && lines.length < PREVIEW_LINE_COUNT;
+        return {
+          ok: true,
+          size: stat.size,
+          bytes: Buffer.from(previewText, "utf-8"),
+          preview: {
+            kind: "head" as const,
+            lineCount: lines.length,
+            byteBudgetHit: truncatedAtByteBudget,
+          },
+        };
+      } finally {
+        await fd.close();
+      }
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -55,7 +55,13 @@ export interface OrbitAPI {
     | { ok: false; error: string }
   >;
   readFile(relPath: string): Promise<
-    | { ok: true; size: number; bytes: Uint8Array }
+    | {
+        ok: true;
+        size: number;
+        bytes: Uint8Array;
+        // Set when bytes is a head-only excerpt of a file too large for full read.
+        preview?: { kind: "head"; lineCount: number; byteBudgetHit: boolean };
+      }
     | { ok: false; error: string; size?: number }
   >;
   writeFile(relPath: string, content: string): Promise<{ ok: true } | { ok: false; error: string }>;

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -58,7 +58,7 @@ async function openFileFromTree(relPath: string): Promise<void> {
     chat.addErrorMessage(`Failed to open ${relPath}${sizeHint}: ${res.error}`);
     return;
   }
-  const proceed = fileViewer.open(relPath, res.bytes, res.size);
+  const proceed = fileViewer.open(relPath, res.bytes, res.size, res.preview);
   if (proceed) {
     artifacts.showFileTab();
     setArtifactCollapsed(false);

--- a/app/src/renderer/files/file-viewer.ts
+++ b/app/src/renderer/files/file-viewer.ts
@@ -104,8 +104,17 @@ export class FileViewer {
   /**
    * Replace the container with a viewer for `relPath`. Returns true if the
    * open went ahead, false if the user cancelled due to unsaved changes.
+   *
+   * `preview` is set when bytes is a head-only excerpt of a file too large
+   * for full read; the text view renders read-only with a banner explaining
+   * the truncation (#58).
    */
-  open(relPath: string, bytes: Uint8Array, size: number): boolean {
+  open(
+    relPath: string,
+    bytes: Uint8Array,
+    size: number,
+    preview?: { kind: "head"; lineCount: number; byteBudgetHit: boolean },
+  ): boolean {
     if (this.dirty && this.currentPath && this.currentPath !== relPath) {
       const ok = window.confirm(`Discard unsaved changes in ${this.currentPath}?`);
       if (!ok) return false;
@@ -126,7 +135,7 @@ export class FileViewer {
     root.className = "file-viewer-root";
 
     if (this.currentKind === "text") {
-      this.renderText(root, relPath, bytes);
+      this.renderText(root, relPath, bytes, preview, size);
     } else if (this.currentKind === "image") {
       this.renderImage(root, relPath, bytes, size);
     } else if (this.currentKind === "pdf") {
@@ -270,10 +279,48 @@ export class FileViewer {
     }
   }
 
-  private renderText(root: HTMLElement, relPath: string, bytes: Uint8Array): void {
+  private renderText(
+    root: HTMLElement,
+    relPath: string,
+    bytes: Uint8Array,
+    headPreview?: { kind: "head"; lineCount: number; byteBudgetHit: boolean },
+    size?: number,
+  ): void {
     const ext = extOf(relPath);
     const isMarkdown = ext === ".md";
     const text = new TextDecoder("utf-8").decode(bytes);
+
+    // Head-preview path: render read-only with a banner. Skip the
+    // editor + Save toolbar + markdown preview toggle entirely — the
+    // user can't usefully edit a 200 MB file's first 10 lines.
+    if (headPreview) {
+      const toolbar = document.createElement("div");
+      toolbar.className = "file-viewer-toolbar";
+      const filename = document.createElement("span");
+      filename.className = "file-viewer-filename";
+      filename.textContent = relPath;
+      filename.title = relPath;
+      toolbar.appendChild(filename);
+      const sizeLabel = document.createElement("span");
+      sizeLabel.className = "file-viewer-status";
+      sizeLabel.textContent = typeof size === "number" ? formatBytes(size) : "";
+      toolbar.appendChild(sizeLabel);
+      root.appendChild(toolbar);
+
+      const banner = document.createElement("div");
+      banner.className = "file-viewer-preview-banner";
+      const truncated = headPreview.byteBudgetHit
+        ? `Preview only — first ${headPreview.lineCount} lines (truncated mid-line: lines longer than 64 KB are clipped).`
+        : `Preview only — first ${headPreview.lineCount} lines.`;
+      banner.textContent = `${truncated} Open externally to see the full file.`;
+      root.appendChild(banner);
+
+      const pre = document.createElement("pre");
+      pre.className = "file-viewer-preview-text";
+      pre.textContent = text;
+      root.appendChild(pre);
+      return;
+    }
 
     // Toolbar ---------------------------------------------------------
     const toolbar = document.createElement("div");

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -484,6 +484,29 @@ body:not(.artifact-collapsed) #artifact-toggle {
   color: var(--error);
 }
 
+.file-viewer-preview-banner {
+  background: var(--accent-bg);
+  border-bottom: 1px solid var(--accent);
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--text);
+  flex-shrink: 0;
+}
+.file-viewer-preview-text {
+  flex: 1;
+  width: 100%;
+  margin: 0;
+  padding: 12px;
+  background: var(--bg-deep);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre;
+  overflow: auto;
+  tab-size: 2;
+}
+
 /* Galaxy connection indicator — pure color/dot variant atop .footer-control. */
 .status-dot::before {
   content: "";

--- a/tests/agent-manager.test.ts
+++ b/tests/agent-manager.test.ts
@@ -8,6 +8,10 @@ const readdirSyncMock = vi.fn(() => []);
 
 vi.mock("node:child_process", () => ({
   spawn: spawnMock,
+  // execFile is pulled in transitively via agent.ts -> proc-monitor.ts
+  // (collectDescendantsOf walks `ps` for the abort-kill path, #64). Tests
+  // don't trigger abort, but the import must resolve.
+  execFile: vi.fn(),
 }));
 
 vi.mock("node:readline", () => ({


### PR DESCRIPTION
Closes #58. Last item from Phase 2 of the alpha-prep batch.

## Behavior

- **≤ 5 MB:** full read (unchanged).
- **5 MB to 1 GB:** streaming head preview — read up to 64 KB from the start, slice to the first 10 lines, return as bytes + a \`preview: { kind: \"head\", lineCount, byteBudgetHit }\` marker. Renderer draws a read-only \`<pre>\` with a gold banner explaining truncation.
- **> 1 GB:** still hard-refused — a head preview isn't worth opening 1 GB+ of file handle for.

## Edge case

Single very-long lines (uncompressed VCF data, packed JSON) get clipped at the 64 KB byte budget. The banner says so:

> Preview only — first 10 lines (truncated mid-line: lines longer than 64 KB are clipped). Open externally to see the full file.

## Files

- \`app/src/main/files-handler.ts\` — \`MAX_PREVIEW_BYTES\`, \`PREVIEW_LINE_COUNT\`, \`PREVIEW_BYTE_BUDGET\` constants + new branch in the \`files:read\` handler.
- \`app/src/preload/preload.ts\` — \`readFile\` return shape gains optional \`preview\` field.
- \`app/src/renderer/files/file-viewer.ts\` — \`renderText\` takes optional \`headPreview\` param; preview path renders read-only and skips the editor / Save / markdown toggle entirely. \`refreshFromDisk\` no-ops because preview path doesn't set \`this.editor\` (existing guard).
- \`app/src/renderer/styles.css\` — \`.file-viewer-preview-banner\` (gold-tinted) + \`.file-viewer-preview-text\` (mono \`<pre>\`).
- \`app/src/renderer/app.ts\` — pass \`res.preview\` through to \`fileViewer.open()\`.

## Test

- \`npm run typecheck\` clean (root + app)
- \`npm test\` 132/132
- Smoke: open a small text file → editable as before. Open a 50 MB FASTQ → preview banner + first 10 lines, no editor.

122 lines net.