### PR TITLE
Galaxy invocation background poller (closes #67)

### DIFF
--- a/extensions/loom/galaxy-poller.ts
+++ b/extensions/loom/galaxy-poller.ts
@@ -1,0 +1,93 @@
+/**
+ * Background poller for active Galaxy workflow invocations.
+ *
+ * Part 2 of #67. Part 1 added the YAML counters + the Activity-tab UI
+ * section that draws progress bars from them. This file is the timer
+ * that keeps those counters fresh between agent turns: every
+ * POLL_INTERVAL_MS, scan the notebook for in-flight blocks; if any
+ * exist, run `checkInvocations` to advance status and write updated
+ * counters back to notebook.md.
+ *
+ * Lifecycle:
+ *   - session_start → startGalaxyPoller(): unconditionally start the
+ *     timer. Each tick is cheap when no blocks are in-flight (one
+ *     notebook read + scan, no Galaxy call).
+ *   - session_shutdown → stopGalaxyPoller(): clear timer.
+ *   - Multiple session_start (brain restart) → start() stops any prior
+ *     timer first; idempotent.
+ *
+ * Why "always running" instead of stopping on idle:
+ *   If we stopped at "no in-flight blocks", the next time the agent
+ *   recorded a new invocation mid-session we'd never wake up — only
+ *   another session_start would. Avoids a circular import between
+ *   tools.ts (which records invocations) and this file. The cost is
+ *   one notebook read + scan per 15s, which is negligible.
+ *
+ * Concurrency: ticks are guarded by `inFlight` so a slow Galaxy GET
+ * doesn't stack ticks. The check itself uses the existing per-notebook
+ * lock in withNotebookLock, so a manual `galaxy_invocation_check_all`
+ * call from the agent doesn't race the poller.
+ */
+
+import { getNotebookPath } from "./state.js";
+import { findInvocationBlocks, readNotebook } from "./notebook-writer.js";
+import { checkInvocations } from "./tools.js";
+import { getGalaxyConfig } from "./galaxy-api.js";
+
+// 15s — ~4 polls/min × a few in-flight invocations stays well under
+// usegalaxy.org's per-user rate budget while still feeling live.
+const POLL_INTERVAL_MS = 15_000;
+
+let timer: ReturnType<typeof setInterval> | null = null;
+let inFlight = false;
+
+async function hasInProgressInvocations(): Promise<boolean> {
+  const nbPath = getNotebookPath();
+  if (!nbPath) return false;
+  try {
+    const content = await readNotebook(nbPath);
+    return findInvocationBlocks(content).some((b) => b.status === "in_progress");
+  } catch {
+    // Notebook missing or unreadable — no invocations to poll.
+    return false;
+  }
+}
+
+async function tick(): Promise<void> {
+  if (inFlight) return;
+  inFlight = true;
+  try {
+    // Cheap path when nothing's in-flight: read notebook, scan, return.
+    if (!(await hasInProgressInvocations())) return;
+    if (!getGalaxyConfig()) {
+      // Credentials disappeared (user disconnected mid-session). Skip
+      // this tick; if creds come back the next tick picks up.
+      return;
+    }
+    await checkInvocations(undefined);
+  } catch (err) {
+    // Don't kill the timer on a single bad poll — Galaxy may be
+    // briefly unreachable. Log and try again on the next tick.
+    console.error("[galaxy-poller] tick failed:", err);
+  } finally {
+    inFlight = false;
+  }
+}
+
+export function startGalaxyPoller(): void {
+  // Idempotent: a brain restart triggers a new session_start without
+  // session_shutdown firing first in some failure modes. Stop any
+  // pre-existing timer so we don't double-poll.
+  stopGalaxyPoller();
+  // Fire one immediate tick so a session resumed with in-flight blocks
+  // gets fresh counters within the first second instead of waiting 15s.
+  void tick();
+  timer = setInterval(tick, POLL_INTERVAL_MS);
+}
+
+export function stopGalaxyPoller(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}

--- a/extensions/loom/session-bootstrap.ts
+++ b/extensions/loom/session-bootstrap.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { resetState, initSessionArtifacts, getNotebookPath } from "./state.js";
+import { startGalaxyPoller, stopGalaxyPoller } from "./galaxy-poller.js";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -12,6 +13,10 @@ export function registerSessionLifecycle(pi: ExtensionAPI): void {
     syncSessionJsonlSymlink(ctx);
 
     initSessionArtifacts(process.cwd());
+
+    // Background poller for in-flight Galaxy invocations (#67 part 2).
+    // Idempotent — start() stops any prior timer first.
+    startGalaxyPoller();
 
     const freshSession = process.env.LOOM_FRESH_SESSION === "1";
 
@@ -31,6 +36,7 @@ export function registerSessionLifecycle(pi: ExtensionAPI): void {
   });
 
   pi.on("session_shutdown", async () => {
+    stopGalaxyPoller();
     snapshotNotebook(pi);
   });
 }


### PR DESCRIPTION
Closes #67 — part 2 of 2. Part 1 (#68) added the YAML counters + the Activity-tab UI section. Without a poller, those counters only updated when the agent called \`galaxy_invocation_check_all\` mid-turn. This adds the autonomous timer.

## Behavior

\`extensions/loom/galaxy-poller.ts\` (new). Hooked into the existing session lifecycle:

- \`session_start\` → \`startGalaxyPoller()\` (idempotent, one immediate tick + 15s interval)
- \`session_shutdown\` → \`stopGalaxyPoller()\`
- Brain restart → \`start()\` stops any prior timer first

Each tick:
1. Read \`notebook.md\`, scan for in-flight \`loom-invocation\` blocks.
2. If none → return (cheap path; one notebook read + scan per 15s while idle).
3. If Galaxy creds gone → return (silent; auto-resumes when they're back).
4. Else call \`checkInvocations(undefined)\` — same code path \`/galaxy_invocation_check_all\` uses. The existing \`withNotebookLock\` prevents racing manual agent calls.

\`inFlight\` guard skips ticks while a slow Galaxy GET is in progress.

## Lifecycle decision: always-running vs stop-on-idle

I considered stopping the timer when no in-flight blocks remain. Two reasons against:

1. New invocations recorded later in the same session would never get polled — only another \`session_start\` would wake the timer. The agent's \`galaxy_invocation_record\` would have to import \`nudgeGalaxyPoller\`, but that creates a circular import (\`galaxy-poller.ts\` already imports \`checkInvocations\` from \`tools.ts\`).
2. The cost of always-running is one notebook read + regex scan per 15s. Negligible.

So the timer runs continuously while the session is alive; the per-tick \`hasInProgressInvocations()\` cheap-path absorbs the idle case.

## Out of scope

- Per-poll Galaxy rate limit gating — at 4 polls/min × few invocations, well under usegalaxy.org's per-user budget. Revisit if alpha testers stack many concurrent invocations.
- Pausing during agent turns to avoid double-writes — \`withNotebookLock\` already serializes; concurrent agent + poller is correct, not racy.
- Backoff on Galaxy errors — single-tick failures are logged and retried next tick. Persistent failures are a separate concern (#72 resume-hardening).

## Test

- \`npm run typecheck\` clean
- \`npm test\` 132/132 (existing tests cover the YAML round-trip and \`checkInvocations\`)
- Manual: kick off a multi-step Galaxy workflow, leave Orbit alone for 30s, watch the Activity → Galaxy invocations bar tick up without any agent prompt. Counters in \`notebook.md\` update on disk.

99 lines new code; 2 lines wiring.