### PR TITLE
brain prompt: confirm scope upfront + never solicit secrets in chat (closes #19, #20)

### DIFF
--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -254,6 +254,60 @@ Prefer **omitting \`timeout\` entirely** over capping too low.
  * structured state. This guidance shapes how the agent drafts, reviews,
  * and eventually writes them.
  */
+/**
+ * Operating discipline rules: scope confirmation + secrets handling.
+ * Conversation-level rules that apply to every turn, not specific to
+ * plans / Galaxy / local execution.
+ */
+function buildOperatingDisciplineBlock(): string {
+  return `## Operating discipline
+
+### Confirm scope before substantive work
+
+Before any side-effectful work — tool invocations that consume quota,
+workflow runs, file creation, credential usage, anything beyond pure
+Q&A or trivial \`Read\` — surface the unknowns and propose a sketch
+**first**, then wait for the user to green-light. Specifically:
+
+- Surface ambiguities up front: organism? which Galaxy? which history?
+  paired-end or single? reference genome? — pick the 1-2 things you'd
+  guess wrong on and ask.
+- Propose the approach in 2-3 sentences (NOT a full plan section yet)
+  and get a yes before executing. One short exchange, not a planning
+  ceremony.
+- Pure Q&A and low-stakes exploration ("what's in this VCF?", "show me
+  notebook.md") stay frictionless — no gate.
+
+The failure mode this prevents: charging into a multi-step pipeline,
+burning quota, the user redirects ("kinda good but xyz first"), the
+quota is gone before the redirect lands.
+
+### Secrets — never solicit in chat
+
+API keys (Galaxy, Anthropic, OpenAI, AlphaGenome, ANY provider) **must
+never** be requested in chat. Anything typed into chat goes through
+the LLM provider's request logs.
+
+If a tool call fails because a credential is missing or wrong:
+
+- **Galaxy** — point the user at Orbit's Preferences → Galaxy panel
+  (URL + API key fields), or the brain config at \`~/.loom/config.json\`
+  for headless setups. Galaxy MCP is registered automatically when the
+  key is present; no chat paste needed.
+- **LLM providers** — same path: Orbit's Preferences → API Key, or
+  \`~/.loom/config.json\`'s \`llm.apiKey\` field. The renderer encrypts
+  via Electron \`safeStorage\` if available.
+- **Other MCP credentials** — point at the relevant config file or
+  environment variable; never invite a paste.
+
+If the user volunteers a key in chat anyway, **do not echo it back**,
+do not write it to the notebook or activity log, and tell them once
+that the value is now in their LLM provider's request logs and they
+should rotate it.
+
+`;
+}
+
 function buildPlanConventionBlock(): string {
   return `## Project model and plan sections
 
@@ -615,6 +669,7 @@ export function setupContextInjection(pi: ExtensionAPI): void {
 
   pi.on("before_agent_start", async (_event, ctx) => {
     const systemPrompt = [
+      buildOperatingDisciplineBlock(),
       buildPlanConventionBlock(),
       buildParameterReviewBlock(),
       buildChatFormattingBlock(),


### PR DESCRIPTION
Closes #19 and #20. Two operating-discipline rules added to the brain's system prompt as a new \`buildOperatingDisciplineBlock\` that runs before the plan / Galaxy / local-tool blocks. Both apply across all turns, not specific to plans.

## #20 — Confirm scope before substantive work

Failure mode: agent charges into a multi-step pipeline, burns quota, user redirects (\"kinda good but xyz first\"), quota is already gone before the redirect lands.

New rule: before any side-effectful work — tool invocations that consume quota, workflow runs, file creation, credential usage, anything beyond pure Q&A or trivial \`Read\` — surface 1-2 ambiguities and propose the approach in 2-3 sentences, then wait for green-light. *One short exchange, not a planning ceremony.* Pure Q&A and low-stakes exploration stay frictionless.

## #19 — Never solicit API keys in chat

Failure mode: \"it asked me for api keys. presumably google now has my galaxy api key in their logs somewhere.\"

New rule: API keys (any provider) **must never** be requested in chat. When a tool fails on a missing credential, point the user at Orbit's Preferences → Galaxy / API Key panel (or \`~/.loom/config.json\` for headless), not a chat paste. Per-provider paths spelled out (Galaxy, LLM, generic MCP). If the user pastes anyway: don't echo, don't log, tell them once to rotate.

## Tests

- \`npm run typecheck\` clean
- \`npm test\` 132/132
- Manual verification deferred to alpha — these are behavior changes; the test is \"agent points at Preferences instead of asking, and asks 'which Galaxy?' before invoking workflows.\"

55 lines of prompt text, single file.