### PR TITLE
Bundle BRC Analytics MCP alongside galaxy-mcp

### DIFF
--- a/bin/loom.js
+++ b/bin/loom.js
@@ -174,6 +174,14 @@ if (!isInformationalCommand) {
     delete mcpConfig.mcpServers.galaxy;
   }
 
+  // BRC Analytics is a public, anonymous HTTP MCP -- no creds required, so we
+  // register it unconditionally. It exposes BRC genome/assembly/lineage
+  // lookups that the agent can call alongside Galaxy MCP.
+  mcpConfig.mcpServers["brc-analytics"] = {
+    url: "https://dev.brc-analytics.org/api/v1/mcp/",
+    directTools: true,
+  };
+
   mkdirSync(dirname(mcpConfigPath), { recursive: true });
   // mcp.json carries Galaxy credentials in its env block — keep file mode
   // 0600 so other users on a shared machine can't read the API key. The


### PR DESCRIPTION
## Summary
- Registers BRC Analytics as a remote HTTP MCP in `bin/loom.js`, mirroring the galaxy-mcp pattern but using the `url` field for HTTP transport (`pi-mcp-adapter`'s `ServerEntry`).
- Endpoint is `https://dev.brc-analytics.org/api/v1/mcp/`. Public, anonymous, no creds -- registered unconditionally next to the gated galaxy entry.
- Survives profile switches: `syncMcpConfig` only mutates `mcpServers.galaxy`, so the BRC entry round-trips untouched.

## Verification
- `npm run typecheck` clean
- `npm test` -- 23 files / 132 tests pass
- Direct protocol probe against the live endpoint: `initialize` -> 200, `BRC Analytics v3.0.2`; `tools/list` returns 12 tools (organism/assembly/workflow catalog + ENA sequencing search).

## Test plan
- [ ] Launch loom with no Galaxy credentials -- `~/.pi/agent/mcp.json` should contain `brc-analytics` and not `galaxy`.
- [ ] Launch loom with Galaxy credentials -- both entries present.
- [ ] Switch Galaxy profiles -- BRC entry preserved.
- [ ] Agent can call BRC tools (e.g. `search_organisms`, `list_workflow_categories`).