### PR TITLE
Stopgap hint for tool-name confusables (closes #100)

### DIFF
--- a/extensions/loom/confusables-hint.ts
+++ b/extensions/loom/confusables-hint.ts
@@ -1,0 +1,41 @@
+/**
+ * Tool-name confusables hint -- STOPGAP, see #100 + `confusables.ts`.
+ *
+ * Hooks `message_end` for tool-result messages. When pi-agent-core's
+ * exact-match dispatch fails because the LLM emitted a Cyrillic/Greek
+ * lookalike in the tool name, the resulting tool-result message carries
+ * `Tool <bad-name> not found` from agent-loop.js. We fold confusables
+ * against the active tool list and, if there's a real match, append a
+ * "Did you mean X?" hint so the agent recovers in one turn.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { findConfusablesMatch } from "./confusables";
+
+const NOT_FOUND_RE = /^Tool\s+(\S+)\s+not found\b/;
+
+export function registerConfusablesHint(pi: ExtensionAPI): void {
+  pi.on("message_end", (event) => {
+    const msg = event.message;
+    if (msg.role !== "toolResult" || !msg.isError) return;
+
+    const badName = msg.toolName;
+    if (!badName) return;
+
+    const textBlock = msg.content.find(
+      (c): c is { type: "text"; text: string } =>
+        c.type === "text" && typeof (c as { text?: unknown }).text === "string",
+    );
+    if (!textBlock || !NOT_FOUND_RE.test(textBlock.text)) return;
+
+    const match = findConfusablesMatch(badName, pi.getActiveTools());
+    if (!match) return;
+
+    const hint = `Did you mean \`${match}\`? The tool name you called contains Unicode confusables (visually similar non-Latin characters).`;
+    const updatedContent = msg.content.map((c) =>
+      c === textBlock ? { ...textBlock, text: `${textBlock.text}\n\n${hint}` } : c,
+    );
+
+    return { message: { ...msg, content: updatedContent } };
+  });
+}

--- a/extensions/loom/confusables.ts
+++ b/extensions/loom/confusables.ts
@@ -1,0 +1,90 @@
+/**
+ * Unicode-confusables fold for tool-name lookups. STOPGAP -- see #100.
+ *
+ * Some open-weights LLMs (gpt-oss, smaller frontier models) sample
+ * Cyrillic/Greek lookalikes for Latin letters when generating identifiers
+ * -- most often `с` (U+0441) where Latin `c` belongs. pi-agent-core's
+ * tool dispatch does an exact-string match (prepareToolCall in
+ * node_modules/@mariozechner/pi-agent-core/dist/agent-loop.js), so one
+ * Cyrillic char in `brс_analytics_*` is enough to surface "Tool not
+ * found" to the agent.
+ *
+ * Why this is a stopgap and not a proper fix: the right place to
+ * normalize is at the lookup layer in pi-agent-core (or pi-mcp-adapter
+ * for the proxy path). Upstream's stance on input normalization is in
+ * earendil-works/pi#638 (case-mismatch case): "this is not something pi
+ * will 'normalize', and the suggested fix is just plain wrong." So
+ * landing this upstream is unlikely. Meanwhile we can't intercept
+ * before pi-agent-core's find() from inside Loom either -- the
+ * message_end extension event is queued async by agent-session.js and
+ * races the synchronous tool dispatch.
+ *
+ * What this does: hook the tool-result message_end (which fires AFTER
+ * the not-found failure), fold confusables, and append a "Did you mean
+ * X?" hint to the error. The agent recovers in one turn instead of
+ * two or three. Drop this when upstream lookup becomes fold-aware or
+ * when models stop sampling lookalikes -- whichever comes first.
+ */
+const CONFUSABLES: Record<string, string> = {
+  // Cyrillic lowercase that look like Latin
+  а: "a",
+  е: "e",
+  о: "o",
+  р: "p",
+  с: "c",
+  х: "x",
+  у: "y",
+  // Cyrillic uppercase
+  А: "A",
+  Е: "E",
+  О: "O",
+  Р: "P",
+  С: "C",
+  Х: "X",
+  У: "Y",
+  // Greek lowercase
+  ν: "v",
+  τ: "t",
+};
+
+export function foldConfusables(s: string): string {
+  let changed = false;
+  let out = "";
+  for (const ch of s) {
+    const mapped = CONFUSABLES[ch];
+    if (mapped !== undefined) {
+      out += mapped;
+      changed = true;
+    } else {
+      out += ch;
+    }
+  }
+  return changed ? out : s;
+}
+
+export function hasConfusables(s: string): boolean {
+  for (const ch of s) {
+    if (CONFUSABLES[ch] !== undefined) return true;
+  }
+  return false;
+}
+
+/**
+ * Look up a folded match for `badName` against `candidateNames`. Returns
+ * the canonical name iff `badName` actually contains a confusable AND its
+ * folded form equals one of the candidates' folded forms. Returns
+ * undefined when there's nothing to suggest — including the case where
+ * `badName` is already pure ASCII and doesn't match anything (a real
+ * hallucination, not a confusables issue).
+ */
+export function findConfusablesMatch(
+  badName: string,
+  candidateNames: string[],
+): string | undefined {
+  if (!hasConfusables(badName)) return undefined;
+  const folded = foldConfusables(badName);
+  for (const name of candidateNames) {
+    if (foldConfusables(name) === folded) return name;
+  }
+  return undefined;
+}

--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -18,6 +18,7 @@ import { registerTeamTools } from "./teams/tool";
 import { isTeamDispatchEnabled } from "./teams/is-enabled";
 import { registerSessionIndexTools } from "./session-index/tools";
 import { isSessionIndexEnabled } from "./session-index/is-enabled";
+import { registerConfusablesHint } from "./confusables-hint";
 import * as fs from "fs";
 import { getState, getNotebookPath } from "./state";
 import {
@@ -38,6 +39,7 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
 
   registerPlanTools(pi);
   registerExecutionCommands(pi);
+  registerConfusablesHint(pi);
   if (isTeamDispatchEnabled()) {
     registerTeamTools(pi);
   }

--- a/tests/confusables.test.ts
+++ b/tests/confusables.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  foldConfusables,
+  hasConfusables,
+  findConfusablesMatch,
+} from "../extensions/loom/confusables";
+
+describe("foldConfusables", () => {
+  it("leaves pure ASCII unchanged (returns the same reference)", () => {
+    const s = "brc_analytics_get_organism";
+    expect(foldConfusables(s)).toBe(s);
+  });
+
+  it("folds the Cyrillic с (U+0441) to Latin c", () => {
+    // The captured failure from issue #100: gpt-oss-120b sampled с in place of c.
+    const bad = "brс_analytics_get_organism";
+    expect(bad).not.toBe("brc_analytics_get_organism"); // sanity: not equal as raw strings
+    expect(foldConfusables(bad)).toBe("brc_analytics_get_organism");
+  });
+
+  it("folds multiple Cyrillic letters in one name", () => {
+    // "р" (U+0440) → p, "о" (U+043E) → o, "а" (U+0430) → a
+    const bad = "рора";
+    expect(foldConfusables(bad)).toBe("popa");
+  });
+
+  it("folds Greek lookalikes ν → v, τ → t", () => {
+    expect(foldConfusables("νector")).toBe("vector");
+    expect(foldConfusables("geτ_data")).toBe("get_data");
+  });
+
+  it("folds uppercase Cyrillic (А, Е, О, Р, С, Х, У)", () => {
+    expect(foldConfusables("Саll")).toBe("Call");
+  });
+});
+
+describe("hasConfusables", () => {
+  it("returns false for pure ASCII", () => {
+    expect(hasConfusables("brc_analytics_get_organism")).toBe(false);
+    expect(hasConfusables("")).toBe(false);
+  });
+
+  it("returns true when any confusable codepoint is present", () => {
+    expect(hasConfusables("brс_analytics_get_organism")).toBe(true);
+  });
+
+  it("returns false for non-Latin chars that aren't in the confusables map", () => {
+    // Chinese / emoji / unrelated unicode shouldn't trigger
+    expect(hasConfusables("zh_中文_tool")).toBe(false);
+  });
+});
+
+describe("findConfusablesMatch", () => {
+  const candidates = [
+    "brc_analytics_get_organism",
+    "brc_analytics_search_organisms",
+    "galaxy_run_tool",
+    "web_search",
+  ];
+
+  it("returns the canonical name when the bad name folds to one of the candidates", () => {
+    const bad = "brс_analytics_get_organism";
+    expect(findConfusablesMatch(bad, candidates)).toBe("brc_analytics_get_organism");
+  });
+
+  it("returns undefined when the bad name has confusables but doesn't fold to any candidate", () => {
+    const bad = "fоo_bаr"; // "foo_bar" — not in candidates
+    expect(findConfusablesMatch(bad, candidates)).toBeUndefined();
+  });
+
+  it("returns undefined when the bad name is plain ASCII and unmatched (real hallucination)", () => {
+    // No confusables → not our problem to solve.
+    expect(findConfusablesMatch("totally_made_up_tool", candidates)).toBeUndefined();
+  });
+
+  it("returns undefined when the bad name is plain ASCII and DOES match (no confusables = no suggestion needed)", () => {
+    // The real tool was called correctly; nothing to suggest.
+    expect(findConfusablesMatch("brc_analytics_get_organism", candidates)).toBeUndefined();
+  });
+
+  it("handles the second case from the captured trace (search_organisms)", () => {
+    const bad = "brс_analytics_search_organisms";
+    expect(findConfusablesMatch(bad, candidates)).toBe("brc_analytics_search_organisms");
+  });
+});


### PR DESCRIPTION
## Summary

When some open-weights LLMs (notably gpt-oss-120b) sample Cyrillic/Greek lookalikes for Latin letters in tool names (`brс_analytics_get_organism` -- that's a Cyrillic с in the middle), pi-agent-core's exact-match `prepareToolCall().find()` returns `Tool <name> not found` and the agent burns 2-3 turns recovering. This adds a `message_end` hook on tool-result messages that folds confusables against the active tool list and appends `Did you mean \`<canonical>\`?` to the error -- usually cuts recovery to one turn.

Worth noting: this is largely a smaller / open-weights-model artifact. Claude (Sonnet, Opus) and other frontier models don't sample lookalikes in identifiers in practice; we've only observed it with gpt-oss-120b via litellm so far. So most users running Loom against Anthropic/OpenAI frontier models won't hit this -- the hint is defensive for the local-model and litellm-proxy paths.

- `extensions/loom/confusables.ts` -- static map of the seven Cyrillic lowercase + uppercase Latin lookalikes plus Greek ν/τ, fold helper, candidate matcher
- `extensions/loom/confusables-hint.ts` -- the message_end hook
- `extensions/loom/index.ts` -- one-line wire-up
- `tests/confusables.test.ts` -- 13 tests including the captured `brс_analytics_*` traces from #100

## Why this is a stopgap and not a real fix

The clean fix is fold-aware lookup at pi-agent-core's `prepareToolCall` (or pi-mcp-adapter for the proxy path). The closest upstream analog -- earendil-works/pi#638, same `validateToolCall` strict-equality failure but case-mismatch trigger -- was closed by the maintainer with *"this is not something pi will 'normalize', and the suggested fix is just plain wrong."* So an upstream PR is unlikely to land. From inside Loom we also can't intercept *before* the dispatch: the only relevant hook (`message_end` for the assistant message) is queued async by agent-session.js and races the synchronous tool dispatch. Hint-only it is. Drop when upstream becomes fold-aware, or when even the local/open-weights models we care about stop sampling lookalikes.

The stopgap nature is called out at the top of both new files so a future maintainer doesn't have to reverse-engineer the why.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npx tsc --noEmit` (app/) clean
- [x] `npm test` -- 145/145 (13 new)
- [x] `npm run lint` -- 0 errors on new files
- [x] `npm run format:check` clean

Closes #100.