### PR TITLE
Make /execute and /run more robust with precondition checks

### DIFF
--- a/extensions/loom/execution-commands.ts
+++ b/extensions/loom/execution-commands.ts
@@ -1,16 +1,36 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { getNotebookPath } from "./state.js";
+import { checkPreconditions, renderFailures } from "./init-gate.js";
 
 /**
  * Plan/execution commands. Plans live as markdown sections in `notebook.md`;
  * these commands send the agent an instruction to read the notebook and act.
+ *
+ * Before sending the agent off, run a precondition check (see init-gate.ts):
+ * - hard failures (no notebook; plan needs Galaxy but disconnected) refuse
+ *   to send the agent prompt at all
+ * - soft failures (no plan; weak acceptance criteria; no history selected
+ *   for a Galaxy plan) still prompt, but the prompt carries the failure
+ *   list so the agent resolves with the user before invoking anything
  */
 
 export function registerExecutionCommands(pi: ExtensionAPI): void {
   const executeHandler = async (_args: string | undefined, ctx: ExtensionContext) => {
     const nbPath = getNotebookPath();
-    if (!nbPath) {
-      ctx.ui.notify("No notebook open in this directory.", "warning");
+    const gate = checkPreconditions();
+
+    if (gate.hardFailed) {
+      ctx.ui.notify(renderFailures(gate.failures), "warning");
+      return;
+    }
+
+    if (!gate.ok) {
+      ctx.ui.notify(renderFailures(gate.failures), "info");
+      pi.sendUserMessage(
+        `The user typed /execute (or /run) but the precondition check did not pass:\n\n${renderFailures(
+          gate.failures,
+        )}\n\nResolve these with the user first. Do NOT invoke Galaxy workflows or run local pipeline steps until the gate passes.`,
+      );
       return;
     }
 

--- a/extensions/loom/init-gate.ts
+++ b/extensions/loom/init-gate.ts
@@ -1,0 +1,237 @@
+/**
+ * Precondition check for /execute and /run.
+ *
+ * Galaxy workflows can run for hours and cost real compute, so the cost of
+ * a bad launch is high. This gate runs before the slash command tells the
+ * agent to work, catching the cheap failures (no plan; stale Galaxy creds;
+ * step without acceptance criteria) up front so we don't burn an
+ * invocation on a half-formed input.
+ *
+ * Two-layer policy:
+ * - **Hard fail** -- env-broken cases (no notebook; plan needs Galaxy but
+ *   no active connection). The slash command does not send the agent
+ *   prompt. The user gets a remediation message in chat.
+ * - **Soft fail** -- everything else. The slash command still sends the
+ *   prompt, but the prompt carries the failure list so the agent can
+ *   resolve with the user before invoking anything.
+ */
+
+import * as fs from "fs";
+import { getNotebookPath, isGalaxyConnected, getCurrentHistoryId } from "./state.js";
+
+export type Routing = "local" | "galaxy" | "hybrid" | "remote" | "unknown";
+
+export interface ParsedPlanRef {
+  title: string;
+  routing: Routing;
+  nextStep: { line: number; raw: string; descriptionLength: number } | null;
+}
+
+export interface GateFailure {
+  name: "notebook" | "plan" | "galaxy_connection" | "history" | "acceptance";
+  severity: "hard" | "soft";
+  remediation: string;
+}
+
+export interface GateResult {
+  ok: boolean;
+  hardFailed: boolean;
+  failures: GateFailure[];
+  plan: ParsedPlanRef | null;
+}
+
+export interface ProjectContext {
+  historyId?: string;
+  galaxyUrl?: string;
+}
+
+/**
+ * Find the most recent `## Plan X: <title> [routing]` section. Returns
+ * the heading info plus the first pending (`- [ ]`) step in that section.
+ * Returns null if no plan heading is present.
+ */
+export function parseMostRecentPlan(content: string): ParsedPlanRef | null {
+  const lines = content.split("\n");
+  let latestPlanLine = -1;
+  let latestPlanTitle = "";
+  let latestPlanRouting: Routing = "unknown";
+
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(
+      /^##\s+Plan\s+([^:]+):\s*(.+?)(?:\s*\[(local|galaxy|hybrid|remote)\])?\s*$/i,
+    );
+    if (m) {
+      latestPlanLine = i;
+      latestPlanTitle = `${m[1].trim()}: ${m[2].trim()}`;
+      latestPlanRouting = (m[3]?.toLowerCase() as Routing) ?? "unknown";
+    }
+  }
+
+  if (latestPlanLine === -1) return null;
+
+  // Find first `- [ ]` line within the plan section (until the next `## ` h2).
+  let nextStep: ParsedPlanRef["nextStep"] = null;
+  for (let i = latestPlanLine + 1; i < lines.length; i++) {
+    if (/^##\s+/.test(lines[i])) break; // next section
+    const stepMatch = lines[i].match(/^\s*-\s+\[\s\]\s+(.*)$/);
+    if (stepMatch) {
+      nextStep = {
+        line: i,
+        raw: stepMatch[1],
+        descriptionLength: measureStepDescription(stepMatch[1]),
+      };
+      break;
+    }
+  }
+
+  return { title: latestPlanTitle, routing: latestPlanRouting, nextStep };
+}
+
+/**
+ * Heuristic: does the step have anything beyond a bare `**Title**`? Strips
+ * the leading number, the bold-wrapped title, the optional `{#anchor}`,
+ * and any em-dash separator, then counts what remains. Used by the
+ * acceptance-criteria check.
+ */
+function measureStepDescription(raw: string): number {
+  const stripped = raw
+    .replace(/^\d+\.\s*/, "")
+    .replace(/\*\*[^*]+\*\*/, "")
+    .replace(/\{#[^}]+\}/, "")
+    .replace(/^[\s—\-:|]+/, "")
+    .trim();
+  return stripped.length;
+}
+
+/**
+ * Parse the optional `## Project context` block. The block is plain
+ * key-value lines beneath the heading, terminated by the next `## ` h2 or
+ * EOF. Today this only carries `history_id` and `galaxy_url`; future
+ * fields can join the same shape.
+ */
+export function parseProjectContext(content: string): ProjectContext | null {
+  const lines = content.split("\n");
+  const startIdx = lines.findIndex((l) => /^##\s+Project\s+context\s*$/i.test(l));
+  if (startIdx === -1) return null;
+
+  const ctx: ProjectContext = {};
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (/^##\s+/.test(lines[i])) break;
+    const m = lines[i].match(/^([a-z_]+):\s*(.+)$/i);
+    if (!m) continue;
+    const key = m[1].toLowerCase();
+    const value = m[2].trim();
+    if (key === "history_id") ctx.historyId = value;
+    else if (key === "galaxy_url") ctx.galaxyUrl = value;
+  }
+  return ctx;
+}
+
+/**
+ * Run the precondition checks. Pure of side effects -- the caller (the
+ * /execute or /run handler) decides whether to notify, whether to still
+ * send the agent prompt, etc.
+ */
+export function checkPreconditions(): GateResult {
+  const failures: GateFailure[] = [];
+
+  const nbPath = getNotebookPath();
+  if (!nbPath || !fs.existsSync(nbPath)) {
+    return {
+      ok: false,
+      hardFailed: true,
+      failures: [
+        {
+          name: "notebook",
+          severity: "hard",
+          remediation: "No notebook open in this directory.",
+        },
+      ],
+      plan: null,
+    };
+  }
+
+  let content: string;
+  try {
+    content = fs.readFileSync(nbPath, "utf-8");
+  } catch {
+    return {
+      ok: false,
+      hardFailed: true,
+      failures: [
+        {
+          name: "notebook",
+          severity: "hard",
+          remediation: `Could not read ${nbPath}.`,
+        },
+      ],
+      plan: null,
+    };
+  }
+
+  const plan = parseMostRecentPlan(content);
+
+  if (!plan || !plan.nextStep) {
+    failures.push({
+      name: "plan",
+      severity: "soft",
+      remediation: plan
+        ? `Plan "${plan.title}" has no pending (\`- [ ]\`) steps. Ask the user whether to draft a follow-up plan or pick a different one.`
+        : `No plan section in ${nbPath}. Don't auto-draft one -- ask the user what they want to work on first.`,
+    });
+    return { ok: false, hardFailed: false, failures, plan };
+  }
+
+  const needsGalaxy =
+    plan.routing === "galaxy" || plan.routing === "hybrid" || plan.routing === "remote";
+
+  let hardFailed = false;
+  if (needsGalaxy && !isGalaxyConnected()) {
+    hardFailed = true;
+    failures.push({
+      name: "galaxy_connection",
+      severity: "hard",
+      remediation: `Plan "${plan.title}" routes to Galaxy but there's no active connection. Run /connect to (re)authenticate.`,
+    });
+  }
+
+  if (needsGalaxy && !getCurrentHistoryId()) {
+    const ctx = parseProjectContext(content);
+    if (!ctx?.historyId) {
+      failures.push({
+        name: "history",
+        severity: "soft",
+        remediation:
+          "No Galaxy history selected for this project. Ask the user which history to use, or create a fresh one before invoking workflows.",
+      });
+    }
+  }
+
+  // Acceptance-criteria heuristic: a step with no description beyond the
+  // bold title is a poor target. Loose threshold (>= 8 chars of remaining
+  // text after stripping number/title/anchor) so well-formed plans pass
+  // and only truly-empty ones trip.
+  if (plan.nextStep.descriptionLength < 8) {
+    failures.push({
+      name: "acceptance",
+      severity: "soft",
+      remediation: `Step on line ${plan.nextStep.line + 1} has no description beyond its title. Confirm the acceptance criteria with the user before running.`,
+    });
+  }
+
+  return {
+    ok: failures.length === 0,
+    hardFailed,
+    failures,
+    plan,
+  };
+}
+
+/**
+ * Render the failure list as a short markdown bullet list, suitable for
+ * embedding in either the chat notification or the agent prompt.
+ */
+export function renderFailures(failures: GateFailure[]): string {
+  if (failures.length === 0) return "";
+  return failures.map((f) => `- **${f.name}**: ${f.remediation}`).join("\n");
+}

--- a/tests/init-gate.test.ts
+++ b/tests/init-gate.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import {
+  parseMostRecentPlan,
+  parseProjectContext,
+  checkPreconditions,
+  renderFailures,
+} from "../extensions/loom/init-gate";
+import { setNotebookPath, setGalaxyConnection, resetState } from "../extensions/loom/state";
+
+let tmpDir: string;
+let nbPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "loom-init-gate-"));
+  nbPath = path.join(tmpDir, "notebook.md");
+  resetState();
+});
+
+afterEach(() => {
+  resetState();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeNotebook(contents: string) {
+  fs.writeFileSync(nbPath, contents, "utf-8");
+  setNotebookPath(nbPath);
+}
+
+describe("parseMostRecentPlan", () => {
+  it("returns null when no plan heading is present", () => {
+    expect(parseMostRecentPlan("# nb\n\nsome notes\n")).toBeNull();
+  });
+
+  it("extracts title, routing, and the first pending step", () => {
+    const plan = parseMostRecentPlan(`
+# nb
+
+## Plan A: chrM Variant Calling [hybrid]
+
+### Steps
+
+- [ ] 1. **QC FASTQ** {#plan-a-step-1} -- fastp adapter trim + per-base QC
+- [ ] 2. **Reference index** {#plan-a-step-2} -- bwa index of chrM
+`);
+    expect(plan).not.toBeNull();
+    expect(plan!.title).toBe("A: chrM Variant Calling");
+    expect(plan!.routing).toBe("hybrid");
+    expect(plan!.nextStep).not.toBeNull();
+    expect(plan!.nextStep!.raw).toContain("QC FASTQ");
+  });
+
+  it("returns the LAST plan when multiple coexist", () => {
+    const plan = parseMostRecentPlan(`
+## Plan A: First [local]
+
+- [x] 1. **Done** -- already complete
+
+## Plan B: Second [galaxy]
+
+- [ ] 1. **Active step** -- run something
+`);
+    expect(plan!.title).toBe("B: Second");
+    expect(plan!.routing).toBe("galaxy");
+    expect(plan!.nextStep!.raw).toContain("Active step");
+  });
+
+  it("skips completed (`- [x]`) and failed (`- [!]`) steps", () => {
+    const plan = parseMostRecentPlan(`
+## Plan A: Test [local]
+
+- [x] 1. **Done** -- ok
+- [!] 2. **Failed** -- ouch
+- [ ] 3. **Pending** -- this one
+- [ ] 4. **Later** -- skip me
+`);
+    expect(plan!.nextStep!.raw).toContain("Pending");
+    expect(plan!.nextStep!.raw).not.toContain("Later");
+  });
+
+  it("returns nextStep null when all steps are complete", () => {
+    const plan = parseMostRecentPlan(`
+## Plan A: Done [local]
+
+- [x] 1. **Step 1** -- ok
+- [x] 2. **Step 2** -- ok
+`);
+    expect(plan!.nextStep).toBeNull();
+  });
+
+  it("does not look past the next h2 boundary for pending steps", () => {
+    const plan = parseMostRecentPlan(`
+## Plan A: Test [local]
+
+- [x] 1. **Done** -- ok
+
+## Notes
+
+- [ ] this is not a step in the plan
+`);
+    // The latest plan is Plan A (Notes is not a Plan heading); its only
+    // step is complete; the bullet under Notes is outside the plan section.
+    expect(plan!.title).toBe("A: Test");
+    expect(plan!.nextStep).toBeNull();
+  });
+
+  it("treats a missing routing tag as `unknown`", () => {
+    const plan = parseMostRecentPlan(`
+## Plan X: Untagged
+
+- [ ] 1. **Step** -- description
+`);
+    expect(plan!.routing).toBe("unknown");
+  });
+
+  it("flags a bare-title step as having a tiny description", () => {
+    const plan = parseMostRecentPlan(`
+## Plan A: Skinny [local]
+
+- [ ] 1. **Hi**
+`);
+    expect(plan!.nextStep!.descriptionLength).toBeLessThan(8);
+  });
+});
+
+describe("parseProjectContext", () => {
+  it("returns null when no `## Project context` block exists", () => {
+    expect(parseProjectContext("# nb\n\nno context\n")).toBeNull();
+  });
+
+  it("extracts history_id and galaxy_url", () => {
+    const ctx = parseProjectContext(`
+# nb
+
+## Project context
+
+history_id: f5912ab34
+galaxy_url: https://usegalaxy.org
+
+## Plan A: Foo [local]
+`);
+    expect(ctx).toEqual({
+      historyId: "f5912ab34",
+      galaxyUrl: "https://usegalaxy.org",
+    });
+  });
+
+  it("stops at the next h2 boundary", () => {
+    const ctx = parseProjectContext(`
+## Project context
+
+history_id: only_this
+
+## Other
+
+history_id: not_this
+`);
+    expect(ctx?.historyId).toBe("only_this");
+  });
+});
+
+describe("checkPreconditions -- hard failures", () => {
+  it("hard-fails with notebook=hard when no notebook is set", () => {
+    const result = checkPreconditions();
+    expect(result.ok).toBe(false);
+    expect(result.hardFailed).toBe(true);
+    expect(result.failures.map((f) => f.name)).toEqual(["notebook"]);
+    expect(result.failures[0].severity).toBe("hard");
+  });
+
+  it("hard-fails when a galaxy plan has no active connection", () => {
+    writeNotebook(`
+## Plan A: Run remotely [galaxy]
+
+- [ ] 1. **Heavy alignment** -- bwa-mem on big WGS
+`);
+    setGalaxyConnection(false);
+    const result = checkPreconditions();
+    expect(result.hardFailed).toBe(true);
+    expect(result.failures.find((f) => f.name === "galaxy_connection")).toBeTruthy();
+  });
+
+  it("does not hard-fail on missing connection for a local plan", () => {
+    writeNotebook(`
+## Plan A: Local stuff [local]
+
+- [ ] 1. **Parse data** -- awk magic over CSV
+`);
+    setGalaxyConnection(false);
+    const result = checkPreconditions();
+    expect(result.ok).toBe(true);
+    expect(result.hardFailed).toBe(false);
+  });
+});
+
+describe("checkPreconditions -- soft failures", () => {
+  it("soft-fails when there's no plan section", () => {
+    writeNotebook("# nb\n\nfreeform notes only\n");
+    const result = checkPreconditions();
+    expect(result.ok).toBe(false);
+    expect(result.hardFailed).toBe(false);
+    expect(result.failures.map((f) => f.name)).toEqual(["plan"]);
+  });
+
+  it("soft-fails when galaxy plan has no history", () => {
+    writeNotebook(`
+## Plan A: Galaxy [galaxy]
+
+- [ ] 1. **Step** -- with a description that exceeds the threshold
+`);
+    setGalaxyConnection(true); // connected, but no history
+    const result = checkPreconditions();
+    expect(result.failures.find((f) => f.name === "history")).toBeTruthy();
+    expect(result.failures.find((f) => f.name === "history")!.severity).toBe("soft");
+  });
+
+  it("clears the history failure when Project context provides one", () => {
+    writeNotebook(`
+## Project context
+
+history_id: f5912ab34
+
+## Plan A: Galaxy [galaxy]
+
+- [ ] 1. **Step** -- with a description that exceeds the threshold
+`);
+    setGalaxyConnection(true);
+    const result = checkPreconditions();
+    expect(result.failures.find((f) => f.name === "history")).toBeUndefined();
+  });
+
+  it("clears the history failure when state has currentHistoryId", () => {
+    writeNotebook(`
+## Plan A: Galaxy [galaxy]
+
+- [ ] 1. **Step** -- adequate description here
+`);
+    setGalaxyConnection(true, "history_from_state");
+    const result = checkPreconditions();
+    expect(result.failures.find((f) => f.name === "history")).toBeUndefined();
+  });
+
+  it("soft-fails on a bare-title step (no acceptance description)", () => {
+    writeNotebook(`
+## Plan A: Skinny [local]
+
+- [ ] 1. **Hi**
+`);
+    const result = checkPreconditions();
+    expect(result.failures.find((f) => f.name === "acceptance")).toBeTruthy();
+    expect(result.failures.find((f) => f.name === "acceptance")!.severity).toBe("soft");
+  });
+});
+
+describe("checkPreconditions -- happy path", () => {
+  it("passes for a well-formed local plan", () => {
+    writeNotebook(`
+## Plan A: chrM [local]
+
+- [ ] 1. **QC FASTQ** {#plan-a-step-1} -- fastp adapter trim + per-base QC
+`);
+    const result = checkPreconditions();
+    expect(result.ok).toBe(true);
+    expect(result.hardFailed).toBe(false);
+    expect(result.failures).toEqual([]);
+    expect(result.plan?.routing).toBe("local");
+  });
+
+  it("passes for a galaxy plan when connection + history are present", () => {
+    writeNotebook(`
+## Plan A: Aligned [galaxy]
+
+- [ ] 1. **bwa-mem PE** {#plan-a-step-1} -- 4 samples on chrM reference
+`);
+    setGalaxyConnection(true, "abc123");
+    const result = checkPreconditions();
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("renderFailures", () => {
+  it("renders failures as a markdown bullet list", () => {
+    const out = renderFailures([
+      { name: "plan", severity: "soft", remediation: "no plan" },
+      { name: "history", severity: "soft", remediation: "no history" },
+    ]);
+    expect(out).toContain("- **plan**: no plan");
+    expect(out).toContain("- **history**: no history");
+  });
+
+  it("returns empty string when there are no failures", () => {
+    expect(renderFailures([])).toBe("");
+  });
+});
+
+describe("checkPreconditions handles unreadable notebook", () => {
+  it("hard-fails when the path exists but isn't a readable file", () => {
+    // Point notebookPath at the directory itself: existsSync returns true,
+    // but readFileSync throws EISDIR. Exercises the catch branch in
+    // checkPreconditions without needing an ESM-incompatible spy.
+    setNotebookPath(tmpDir);
+    const result = checkPreconditions();
+    expect(result.hardFailed).toBe(true);
+    expect(result.failures[0].name).toBe("notebook");
+  });
+});


### PR DESCRIPTION
## Why

`/execute` and `/run` are the deliberate "kick off the next pipeline step" entry points. Today they read `notebook.md` and immediately tell the agent "go" with no independent check that:

- There's actually a plan in the notebook
- The Galaxy connection is still alive (creds could be expired)
- A target history is selected (otherwise the agent guesses or creates a fresh one)
- The active step has any acceptance criteria

For Galaxy plans the cost of a half-formed launch is high -- workflows can run for hours and burn real compute. This makes the two commands check those preconditions before sending the agent off.

**Scope:** only `/execute` and `/run`. Ad-hoc exploration is unchanged -- regular chat, direct MCP tool calls the agent makes during exploration (`galaxy_search_tools_by_name`, `galaxy_get_history_contents`, one-off `galaxy_run_tool`, etc.), Pi built-ins, notebook edits the user asks for -- none of those route through this code.

## How it behaves

Two-layer policy:

- **Hard fail** (no notebook; active plan routes to Galaxy but no connection is live) -- the slash command does not send the agent prompt at all. User gets a remediation message in chat.
- **Soft fail** (no plan in the notebook; no history selected for a Galaxy plan; bare-title step missing acceptance criteria) -- the prompt still goes out, but it carries the failure list so the agent resolves with the user before invoking anything.

The acceptance check is a loose `>= 8 chars` heuristic on the step description, so well-formed plans pass and only truly-empty ones trip. It strengthens automatically when richer step blocks land later (the parser just inspects what's in the notebook).

## Files

- `extensions/loom/init-gate.ts` -- new. Plan parser (latest `## Plan X: <title> [routing]` section + first `- [ ]` step), `## Project context` block parser (`history_id`, `galaxy_url`), and the precondition checker.
- `extensions/loom/execution-commands.ts` -- calls into the checker before sending the agent prompt; renders failures into both the chat notification and the agent prompt.
- `tests/init-gate.test.ts` -- 24 tests across plan parsing, project-context parsing, hard/soft failures, and the happy path.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npx tsc --noEmit` (app/) clean
- [x] `npm test` -- 178/178 (24 new in tests/init-gate.test.ts)
- [x] `npm run lint` -- 0 errors
- [x] `npm run format:check` clean