### PR TITLE
Files panel: right-click → copy path

### DIFF
--- a/app/src/renderer/files/files-panel.ts
+++ b/app/src/renderer/files/files-panel.ts
@@ -92,6 +92,12 @@ export class FilesPanel {
     row.dataset.type = node.type;
     row.style.paddingLeft = `${10 + depth * 12}px`;
 
+    row.addEventListener("contextmenu", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      showFilePathContextMenu(e.clientX, e.clientY, node.relPath);
+    });
+
     const icon = document.createElement("span");
     icon.className = "files-tree-icon";
 
@@ -159,6 +165,84 @@ export class FilesPanel {
     }
     return wrap;
   }
+}
+
+/**
+ * Lightweight right-click menu for a file/folder row in the files panel.
+ * Floats at the cursor; click anywhere outside (or Escape) closes it.
+ * One submenu only — keep it short until users tell us they want more.
+ */
+function showFilePathContextMenu(x: number, y: number, relPath: string): void {
+  // Tear down any prior menu first so a fast double-right-click doesn't
+  // leave orphans.
+  document.getElementById("files-tree-ctx-menu")?.remove();
+
+  const menu = document.createElement("div");
+  menu.id = "files-tree-ctx-menu";
+  menu.className = "files-tree-ctx-menu";
+  menu.style.left = `${x}px`;
+  menu.style.top = `${y}px`;
+
+  const addItem = (label: string, onClick: () => void | Promise<void>): void => {
+    const item = document.createElement("button");
+    item.type = "button";
+    item.className = "files-tree-ctx-item";
+    item.textContent = label;
+    item.addEventListener("click", (e) => {
+      e.stopPropagation();
+      void Promise.resolve(onClick()).finally(close);
+    });
+    menu.appendChild(item);
+  };
+
+  const close = (): void => {
+    menu.remove();
+    document.removeEventListener("click", closeOnOutside, true);
+    document.removeEventListener("keydown", closeOnEscape, true);
+    window.removeEventListener("blur", close);
+  };
+  const closeOnOutside = (e: Event): void => {
+    if (!menu.contains(e.target as Node)) close();
+  };
+  const closeOnEscape = (e: KeyboardEvent): void => {
+    if (e.key === "Escape") close();
+  };
+
+  addItem("Copy relative path", async () => {
+    await navigator.clipboard.writeText(relPath);
+  });
+  addItem("Copy absolute path", async () => {
+    const cwd = await window.orbit.getCwd();
+    // cwd is OS-native; relPath uses forward slashes (per files-handler's
+    // toPosix). Joining with "/" works on Linux/macOS and Windows accepts
+    // mixed separators — good enough for clipboard fodder.
+    const sep = cwd.includes("\\") && !cwd.includes("/") ? "\\" : "/";
+    await navigator.clipboard.writeText(`${cwd}${sep}${relPath}`);
+  });
+  addItem("Copy file name", async () => {
+    const parts = relPath.split("/");
+    await navigator.clipboard.writeText(parts[parts.length - 1] ?? relPath);
+  });
+
+  document.body.appendChild(menu);
+
+  // Clamp to viewport so a right-click near the right/bottom edge doesn't
+  // place the menu off-screen.
+  const rect = menu.getBoundingClientRect();
+  if (rect.right > window.innerWidth) {
+    menu.style.left = `${Math.max(0, window.innerWidth - rect.width - 4)}px`;
+  }
+  if (rect.bottom > window.innerHeight) {
+    menu.style.top = `${Math.max(0, window.innerHeight - rect.height - 4)}px`;
+  }
+
+  // Defer the outside-click handler so this very right-click doesn't
+  // immediately close the menu we just opened.
+  setTimeout(() => {
+    document.addEventListener("click", closeOnOutside, true);
+    document.addEventListener("keydown", closeOnEscape, true);
+    window.addEventListener("blur", close);
+  }, 0);
 }
 
 function iconFor(name: string): string {

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -301,6 +301,35 @@ body.files-collapsed #files-divider {
   display: none;
 }
 
+/* Right-click context menu on a file/folder row. Floats at cursor. */
+.files-tree-ctx-menu {
+  position: fixed;
+  z-index: 1000;
+  min-width: 180px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  padding: 4px 0;
+  font-family: var(--font-sans);
+  font-size: 12px;
+}
+.files-tree-ctx-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  color: var(--text);
+  padding: 6px 12px;
+  cursor: pointer;
+  font: inherit;
+}
+.files-tree-ctx-item:hover {
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
 .files-tree-empty {
   padding: 12px 14px;
   color: var(--text-dim);


### PR DESCRIPTION
Right-click on any file or folder row in the left Files pane now pops a small context menu:

- **Copy relative path** — \`subdir/results/sample.bam\`
- **Copy absolute path** — \`/home/anton/sandbox/run/subdir/results/sample.bam\`
- **Copy file name** — \`sample.bam\`

## Implementation

- New \`contextmenu\` listener on each row in \`files-panel.ts\` calling a small \`showFilePathContextMenu(x, y, relPath)\` function.
- Pure DOM menu, floats at the cursor — no IPC except the existing \`getCwd()\` for the absolute variant.
- Dismisses on outside-click, Escape, or window blur.
- Clamps to viewport so right-clicks near the edge don't place the menu off-screen.
- Fast double-right-click tears down the prior menu before showing a new one.

CSS reuses existing tokens (\`--bg-surface\`, \`--border-strong\`, \`--accent-bg\`).

## Test

- \`npm run typecheck\` clean
- \`npm test\` 132/132
- Manual: right-click any row → menu appears. Click \"Copy relative path\" → paste somewhere → got the relPath. Same for absolute / filename. Click outside or press Escape → menu closes.

113 lines net (mostly the menu helper + CSS).