### PR TITLE
Add eval suite + Loom prompt fixes the matrix surfaced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ session.jsonl
 # Agent worktrees
 .worktrees/
 .claude/
+
+# Eval run artifacts (Phase 5+; not committed)
+evals/results/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ session.jsonl
 
 # Eval run artifacts (Phase 5+; not committed)
 evals/results/
+
+# Eval credentials (TACC proxy etc; per-machine)
+evals/.env

--- a/docs/superpowers/specs/2026-05-09-orbit-web-remote-only-design.md
+++ b/docs/superpowers/specs/2026-05-09-orbit-web-remote-only-design.md
@@ -1,0 +1,157 @@
+# Orbit Web -- remote-only design
+
+## Background
+
+`docs/architecture.md` flags an unresolved decision for the web shell: thin local shell vs. hosted multi-user service. This spec resolves it by carving out a third, smaller shape that subsumes both:
+
+A **single-user, container-shaped, remote-only Loom shell** -- same brain, same renderer, env-var-injected credentials, no local execution surface. One image runs three deployments without code changes:
+
+1. Standalone (`docker run` on a server, single user reaches it via URL)
+2. Galaxy interactive tool (Galaxy spawns the container per user, injects scoped creds, proxies the user in)
+3. Eventual hosted multi-tenant front (out of scope here; the IT shape gives most of what we'd want without a multi-tenant server)
+
+The long-term framing is that this surface replaces ChatGXY as the actual analysis-driving interface for Galaxy users. v1 is the runtime shell; ChatGXY parity is a downstream concern.
+
+## Non-goals (v1)
+
+- Multi-user-in-one-container. One container per user. The IT pathway gives us per-user isolation for free.
+- OIDC / Galaxy SSO. v1 is API-key, env-injected. The env-var contract is the seam where SSO eventually plugs in.
+- Notebook persistence to a Galaxy History dataset. Notebook lives in the container's ephemeral cwd. The IT path will eventually map this into a Galaxy job working directory; out of scope here.
+- Public hosted multi-tenant front, quotas, abuse controls, rate limiting.
+- Galaxy-side IT wrapper code. v1 documents the env contract; the wrapper is a separate task that can land later without changing this image.
+
+## Architecture
+
+Same brain, same renderer, same shell contract. What changes:
+
+- `web/server.ts` (the shell side) curates what the brain it spawns is allowed to do.
+- The renderer learns it's in "remote mode" via a flag in the initial state response and hides local-only affordances.
+- Config flows from env vars only -- no `~/.loom/config.json`, no `/connect` flow.
+- The whole thing packages as a container image.
+
+The brain stays shell-neutral per `CLAUDE.md`. Mode flag and tool restrictions are passed _into_ the brain at spawn time by the shell -- not encoded as a "web mode" branch inside `extensions/loom/`.
+
+```text
+Galaxy IT wrapper (or docker run) sets env vars
+  ↓
+Container starts: web/server.ts (Express + WS, tsx)
+  ↓ spawns once at startup
+bin/loom.js --mode rpc (brain subprocess; inherits env)
+  ↓
+Galaxy MCP + BRC-Analytics MCP + brain tools (HTTP only)
+  ↓
+notebook.md in /tmp/loom-session (ephemeral, container-local)
+
+Browser ←(WS)→ web/server.ts ←(JSON-line stdio)→ brain subprocess
+                  ↓ serves
+            built renderer bundle (web/dist/, from app/src/renderer)
+```
+
+## Curation: what's disabled, what's kept
+
+Two Pi mechanisms do the work:
+
+- **Tool allowlist at spawn** -- `bin/loom.js` is launched with `--tools <list>`, the Pi CLI flag for restricting built-in, extension, and custom tools. Anything not in the list is unavailable to the agent. `web/server.ts` builds the list when `LOOM_MODE=remote`.
+- **Runtime tool-call gating** -- a small dedicated Pi extension loaded only by the web shell hooks `on("tool_call")` and rejects calls that violate the path allowlist (the pattern Pi documents as `permission-gate.ts`). This is what enforces "`Edit`/`Write` only against `<cwd>/notebook.md`." Living under `web/` keeps the loom brain extension shell-neutral.
+
+Renderer-side curation is just branches keyed off `mode === "remote"` in the initial state.
+
+| Capability                                                    | Web mode                                               |
+| ------------------------------------------------------------- | ------------------------------------------------------ |
+| `Bash`                                                        | disabled                                               |
+| `Edit` / `Write` / `Read` for arbitrary paths                 | disabled except an allowlist of `notebook.md` in cwd   |
+| `executionMode: local`                                        | force `cloud`; override ignored                        |
+| `/connect` flow                                               | bypassed; creds env-injected at startup                |
+| `/run`, `/execute` slash commands                             | kept (prompt nudges; semantics already Galaxy-first)   |
+| File tree pane                                                | hidden in renderer when `mode=remote`                  |
+| `selectDirectory`, `browseDirectory`, `openFile` shim methods | stubbed/no-op in remote mode                           |
+| Galaxy MCP                                                    | kept -- primary surface                                |
+| BRC-Analytics MCP                                             | kept                                                   |
+| `gtn_search`, `gtn_fetch`, `skills_fetch`                     | kept (HTTP-based)                                      |
+| `galaxy_invocation_record`, `galaxy_invocation_check_*`       | kept                                                   |
+| Notebook chokidar watcher + auto-commit                       | kept inside container; user never sees the git history |
+
+### Notebook persistence under curation
+
+The brain currently mutates `notebook.md` via the agent's general-purpose `Edit`/`Write` tools. Killing those wholesale would break notebook persistence. The chosen approach is **(a) path-allowlist constraint**: `Edit`/`Write` stay in the spawn allowlist, but a web-shell-only Pi extension hooks `on("tool_call")` and rejects any `Edit`/`Write` that resolves outside `<cwd>/notebook.md`. This keeps the loom brain extension shell-neutral, reuses existing notebook-writing plumbing, and gives a real security boundary even in v1. A dedicated `notebook_write` brain tool is the cleaner long-term answer but is deferred -- it would require brain refactoring beyond this design's scope.
+
+## Mode signaling
+
+- **Server → brain (at spawn):** `LOOM_MODE=remote` env var, the `--tools` allowlist, and the path-gate extension loaded via Pi's extension-loading mechanism. Brain code does not branch on `LOOM_MODE`; the env var is informational so the brain can include "you are operating remotely against a Galaxy instance, no local execution" in the system prompt context.
+- **Server → renderer (at handshake):** the existing `getState()` IPC response gains a `mode: "remote" | "desktop"` field. Renderer reads this once at startup and uses it to suppress file-tree/local-only UI.
+- **Renderer behavior:** when `mode === "remote"`:
+  - File tree pane is not rendered
+  - `selectDirectory` / `browseDirectory` UI is hidden
+  - Preferences pane hides Galaxy connection fields (since creds are server-injected)
+  - "Open file" affordances on artifacts are hidden
+
+## Config flow
+
+When `LOOM_MODE=remote`, `web/server.ts`:
+
+- Reads `GALAXY_URL`, `GALAXY_API_KEY` from env and inherits them to the brain subprocess.
+- Reads `LOOM_LLM_PROVIDER` (default `anthropic`) and optional `LOOM_LLM_MODEL`; passes them as `--provider`/`--model` to `bin/loom.js`.
+- Inherits whichever provider key env var is set (`ANTHROPIC_API_KEY` / `XAI_API_KEY` / `AI_GATEWAY_API_KEY`) -- `bin/loom.js` already handles this mapping.
+- Skips `loadConfig`/`saveConfig` for `~/.loom/config.json`. The `config:get` IPC channel returns a synthesized read-only config; `config:save` returns an error.
+- Forces `executionMode: cloud` in the synthesized config regardless of any inherited override.
+- Uses a per-container ephemeral cwd at `/tmp/loom-session/`, created on startup, cleaned on shutdown.
+
+## Container
+
+New `Dockerfile` at repo root.
+
+- Base image: `node:22-slim` (matches existing tooling; revisit if root engines pin a different version).
+- Build steps:
+  - `npm ci` at root
+  - `npm ci` in `app/` (renderer source)
+  - `npm ci` in `web/`
+  - `npm run build` in `web/` -- emits the renderer bundle to `web/dist/` (`vite build` configured to point at `app/src/renderer` with `orbit-shim.ts` injected, mirroring the dev-mode Vite middleware setup in `web/server.ts`).
+- Runtime: `tsx web/server.ts`.
+- Production branch in `web/server.ts`: when `NODE_ENV=production`, serve the static `web/dist/` bundle instead of spawning Vite middleware. WS bridge unchanged.
+- Default `CMD ["npx", "tsx", "web/server.ts"]`.
+- Image listens on `$PORT` (default 3000).
+- One image, one user, one brain subprocess per container.
+
+## Env contract
+
+| Env var                                                          | Required                        | Notes                                                |
+| ---------------------------------------------------------------- | ------------------------------- | ---------------------------------------------------- |
+| `GALAXY_URL`                                                     | yes                             | inherited to brain                                   |
+| `GALAXY_API_KEY`                                                 | yes                             | inherited to brain                                   |
+| `LOOM_MODE`                                                      | yes (`remote`)                  | triggers shell-side curation                         |
+| `LOOM_LLM_PROVIDER`                                              | no                              | default `anthropic`; passed as `--provider` to brain |
+| `LOOM_LLM_MODEL`                                                 | no                              | passed as `--model` to brain                         |
+| `ANTHROPIC_API_KEY` _or_ `XAI_API_KEY` _or_ `AI_GATEWAY_API_KEY` | yes (one of, matching provider) | brain inherits as-is                                 |
+| `PORT`                                                           | no                              | default 3000                                         |
+| `NODE_ENV`                                                       | no                              | `production` triggers static-bundle serving          |
+
+## Galaxy IT integration
+
+v1 only documents the env contract above. The IT wrapper -- a Galaxy tool XML that launches the container with `GALAXY_URL` and a signed scoped API key from the IT context -- is a separate piece of work that can land independently without changing this image. The contract here is what that wrapper needs to honor.
+
+## Validation
+
+- **Smoke:** `docker run` with the env vars above, browser connects, agent responds, a Galaxy MCP tool round-trips end to end.
+- **Curation:**
+  - Agent attempts `Bash` → blocked by Pi tool gating.
+  - Agent attempts `Edit` to `/etc/passwd` → blocked.
+  - Agent attempts `Edit` to `<cwd>/notebook.md` → succeeds.
+- **Renderer:** in remote mode, file-tree pane is not rendered; `getState()` returns `mode: "remote"`.
+- **Existing checks:** root `npm test` and `cd app && npx tsc --noEmit` remain green.
+
+## Decisions made (and why)
+
+- **B (self-hostable companion) as the architectural target.** Aligns with Galaxy's federated/open ethos and turns "ChatGXY replacement" into a per-instance opt-in. The IT pathway falls out for free because the runtime shape is already container + env-injected creds + single-user.
+- **Curation lives in the shell, not the brain.** Brain stays shell-neutral per the repo guardrail. Mode flag and tool allowlist are passed in by `web/server.ts`.
+- **Path-allowlist for Edit/Write rather than a new `notebook_write` tool.** Smallest change, real security boundary, defers the brain refactor.
+- **`tsx` rather than compile-to-JS.** Iteration speed in v1 outweighs ~200ms cold-start cost. Trivial to switch later.
+- **Provider env var pass-through rather than picking one.** `bin/loom.js` already maps provider to env var; container just inherits.
+
+## Open questions (revisit before implementation)
+
+None blocking. Plan-writing should pin down two implementation details:
+
+- The exact Pi tool names to put in the `--tools` allowlist (verify against the running brain's tool registry; `Edit`, `Write`, `Read`, `Bash` are the conventional names but should be confirmed before writing the list).
+- Where the path-gate Pi extension lives in the tree (`web/extensions/path-gate/` is the obvious home; confirm Pi's extension-loading API supports a path argument so the web shell can load it without modifying root `package.json`'s `pi.extensions`).
+
+The notebook-persistence-to-Galaxy story and the IT wrapper itself are both deferred and called out as non-goals.

--- a/evals/README.md
+++ b/evals/README.md
@@ -12,8 +12,9 @@ npm run evals -- <scenario> --model <id>
 ```
 
 Scenarios live under `evals/scenarios/<name>/`. The model matrix lives in
-`evals/models.json`. See the `loom-evals` plan in your brain vault for the
-full design.
+`evals/models.json`. `evals/findings.md` records what the suite has
+turned up so far -- both Loom-side bugs the matrix surfaced and
+per-model behavioral observations.
 
 ## Models
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -5,30 +5,49 @@ non-interactively against a fixture cwd, parses the JSON event stream,
 asserts on tool calls / chat text / final notebook state.
 
 ```bash
-npm run evals             # run all scenarios
-npm run evals -- <name>   # run a single scenario by directory name
+npm run evals                          # all scenarios x all available models
+npm run evals -- <scenario>            # filter to one scenario directory
+npm run evals -- --model <id>          # filter to one model id (or comma list)
+npm run evals -- <scenario> --model <id>
 ```
 
-Scenarios live under `evals/scenarios/<name>/`. See `loom-evals` plan in
-`~/work/brain/plans/` for the full design.
+Scenarios live under `evals/scenarios/<name>/`. The model matrix lives in
+`evals/models.json`. See the `loom-evals` plan in your brain vault for the
+full design.
+
+## Models
+
+Tier 2 scenarios (those with `requiresModel: true`) run against every model
+in `evals/models.json` whose required env vars are set; the rest are skipped
+with a warning. Missing env vars don't fail the run -- they just shrink the
+matrix. Tier 1 scenarios that exercise synchronous Loom paths (slash-command
+preflight, etc.) run once with no model.
+
+Drop credentials in `evals/.env` (gitignored). Example contents:
+
+```
+PROXY_URL=https://ai.tejas.tacc.utexas.edu/v1
+PROXY_API_KEY=<your-key>
+```
+
+(Variable names match `~/work/tacc-inference/.env` so symlinking that file
+straight in works: `ln -s ~/work/tacc-inference/.env evals/.env`.)
 
 ## Tier today
 
-Phase 1 (this PR): runner plumbing + one Tier 1 scenario that exercises a
-slash-command path which doesn't require an LLM call.
+Phase 2: matrix runner + TACC-only Tier 2 (Llama-3.3-70B, Llama-4-Maverick,
+Qwen3-32B). One smoke-test scenario verifies the matrix wiring end-to-end.
 
-Phase 2 will add an LLM stub (subprocess Anthropic-API-compatible server)
-and an MCP stub, unlocking deterministic scenarios that exercise the
-agent loop.
+Phase 3+ fills out the scenario set (init-gate variants, plan navigation,
+notebook discipline, confusables hint, session lifecycle), with Tier 2
+scenarios automatically running across the matrix. See the plan for the
+full sequencing.
 
 ## Known issue
 
-Loom currently does not exit cleanly under `--mode json` after a single
-slash-command invocation. The Galaxy poller's `setInterval` keeps the
-event loop alive even when print mode finishes, so the runner has to
-SIGTERM each scenario at its `timeoutMs`. Hard-fail scenarios (this
-phase) emit all their events synchronously, so the runner-driven kill
-doesn't lose data -- the assertions are evaluated against everything
-that came out of the JSON stream before the timeout. Worth filing as a
-Loom-side fix in print mode (galaxy poller should `unref()` its interval
-or print mode should call `stopGalaxyPoller` on dispose).
+Loom does not exit cleanly under `--mode json` after a single slash-command
+invocation -- the Galaxy poller's `setInterval` keeps the event loop alive
+even when print mode finishes. The runner SIGTERMs each scenario at its
+`timeoutMs`, so this doesn't break evals, but it bloats wall-clock and is
+worth fixing Loom-side (either `unref()` the poller's timer or wire
+`stopGalaxyPoller` into print-mode dispose).

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,34 @@
+# Loom evals
+
+Scenario-driven integration tests for Loom. Spawns `loom --mode json`
+non-interactively against a fixture cwd, parses the JSON event stream,
+asserts on tool calls / chat text / final notebook state.
+
+```bash
+npm run evals             # run all scenarios
+npm run evals -- <name>   # run a single scenario by directory name
+```
+
+Scenarios live under `evals/scenarios/<name>/`. See `loom-evals` plan in
+`~/work/brain/plans/` for the full design.
+
+## Tier today
+
+Phase 1 (this PR): runner plumbing + one Tier 1 scenario that exercises a
+slash-command path which doesn't require an LLM call.
+
+Phase 2 will add an LLM stub (subprocess Anthropic-API-compatible server)
+and an MCP stub, unlocking deterministic scenarios that exercise the
+agent loop.
+
+## Known issue
+
+Loom currently does not exit cleanly under `--mode json` after a single
+slash-command invocation. The Galaxy poller's `setInterval` keeps the
+event loop alive even when print mode finishes, so the runner has to
+SIGTERM each scenario at its `timeoutMs`. Hard-fail scenarios (this
+phase) emit all their events synchronously, so the runner-driven kill
+doesn't lose data -- the assertions are evaluated against everything
+that came out of the JSON stream before the timeout. Worth filing as a
+Loom-side fix in print mode (galaxy poller should `unref()` its interval
+or print mode should call `stopGalaxyPoller` on dispose).

--- a/evals/findings.md
+++ b/evals/findings.md
@@ -64,12 +64,18 @@ real error message:
     JSONDecodeError: Expecting property name enclosed in double quotes
     when trying to decode function call string: {#plan-a-step-1}
 
-Fix: drop `{#anchor}` from the worked example and add a sentence
-telling the agent not to write them. The init-gate parser still
-recognizes anchors when present (preserved as an optional extension),
-so notebooks that already carry them keep working. After the fix,
-Maverick passes the RNA-seq scenario for the first time and the
-"Invalid function calling output" error class is gone from the matrix.
+First fix was a blunt drop: remove anchor guidance from the prompt
+entirely. That worked for Maverick but cost Opus/Sonnet some
+step-reference precision they'd been using fine. So the actual fix is
+conditional: `setupContextInjection` reads `ctx.model` at session start
+and passes `omitAnchors: true` to `buildPlanConventionBlock` only when
+the model id matches `/llama-?4|maverick|scout/i`. Anthropic, OpenAI,
+Google, Llama-3 et al. keep full anchor guidance; only the Llama-4
+deployments that trip the proxy bug get the workaround. Init-gate
+parser accepts anchors when present regardless of which prompt path
+ran, so the suppression is fail-soft. Verified on the matrix: zero
+"Invalid function calling" errors, 40+ `{#plan-...}` anchor
+occurrences in Llama-3.3 + Qwen3 output, pass rate stable.
 
 ## Eval-side iterations
 

--- a/evals/findings.md
+++ b/evals/findings.md
@@ -1,0 +1,172 @@
+# Loom evals -- harness findings log
+
+What we learned by iterating on the eval suite against the TACC SambaNova
+matrix (Llama-3.3-70B, Llama-4-Maverick, Qwen3-32B). Useful both as a
+record of why the suite is shaped the way it is, and as a starter list
+for future runs.
+
+## Loom-side bugs surfaced by the matrix
+
+These are real product bugs the eval suite caught. Each shipped to the
+branch as its own atomic commit.
+
+### Routing-tag enum was missing `[galaxy]`
+
+`extensions/loom/context.ts` -- the worked example showed
+`## Plan A: <Title> [local|hybrid|remote]` and the conventions list said
+"Routing tag: `[local]`, `[hybrid]`, or `[remote]`." But every other
+piece of Loom (init-gate parser, AGENTS.md hard constraints, the
+routing dispatch in execution-commands.ts) treats `galaxy` as a
+first-class routing tag _and_ the primary execution path. Models trying
+to follow the literal template had no syntactically valid way to say
+`[galaxy]`. Visible symptom: every model in the matrix picked `[local]`
+on every plan-creation scenario, regardless of how Galaxy-flavored the
+request was.
+
+Fix: list `[galaxy]` first in the example heading, expand the
+conventions paragraph to spell out when each tag applies (galaxy as
+default for matchable workflows, hybrid for mixed, local for ad-hoc).
+
+### Abstract `<Title>` placeholders weren't grounding template-following
+
+The plan-section template used `## Plan A: <Title> [<routing>]` with
+each angle-bracket as a substitution placeholder, plus step lines like
+`- [ ] 1. **<Step name>** -- <one-line purpose>`. Llama-3.3-70B in
+particular kept dropping the letter and the routing tag and emitting
+`## Plan: <title>` instead -- the abstract syntax wasn't strong enough
+signal.
+
+Fix: replace abstract placeholders with a concrete worked example
+(`## Plan A: chrM Variant Calling [galaxy]` with three real steps and a
+populated parameter table), and add an explicit positive/negative-example
+list of what the heading line must look like.
+
+Result: every Llama-3.3 notebook after the change uses
+`## Plan A: <title> [<routing>]` correctly. Plan-creation pass rate
+moved from 1/15 to 4/15 on this single change.
+
+### `{#anchor}` syntax collided with litellm's Llama-4 tool-call detector
+
+The plan-section template told the model to write step anchors like
+`{#plan-a-step-1}`. Litellm's Llama-4 adapter on the SambaNova-on-TACC
+proxy mistakes any `{...}` pattern in the model's chat output for a
+tool-call boundary and tries to JSON-parse the contents. `{#plan-a-step-1}`
+isn't valid JSON, so the proxy rejects the whole response with
+"Invalid function calling output."
+
+Visible symptom: Maverick failed every plan-creation eval with a
+confused error wrapping its chat text. Took two false-trail
+investigations (a SambaNova API replay-arguments bug surfaced via
+litellm's source on GitHub; a Pi serialization patch that turned out
+not to apply) before capturing the full Pi event stream surfaced the
+real error message:
+
+    JSONDecodeError: Expecting property name enclosed in double quotes
+    when trying to decode function call string: {#plan-a-step-1}
+
+Fix: drop `{#anchor}` from the worked example and add a sentence
+telling the agent not to write them. The init-gate parser still
+recognizes anchors when present (preserved as an optional extension),
+so notebooks that already carry them keep working. After the fix,
+Maverick passes the RNA-seq scenario for the first time and the
+"Invalid function calling output" error class is gone from the matrix.
+
+## Eval-side iterations
+
+### Stripping `--no-skills --no-context-files` was the wrong default
+
+Initial scenarios had `loomArgs: ["--tools", "read,write,edit",
+"--no-skills", "--no-context-files"]` in the name of "isolating the
+variable being tested." The flags were stripping Pi's AGENTS.md / skills
+discovery, but Loom's hard-constraint guidance is injected via a
+`before_agent_start` extension hook (`extensions/loom/context.ts`) --
+not through Pi's discovery -- so most of the Loom system prompt was
+always in play regardless. Even so, the framing was wrong: the eval
+suite exists to measure how the harness _as it ships_ behaves on each
+model and to iterate on Loom's prompts/skills based on what we learn.
+Stripping context defeats that.
+
+Fix: drop the strip flags and trim prompts to a naturalistic ask
+("I have RNA-seq FASTQ files, help me draft a plan") instead of
+hand-spelling the notebook conventions inside each prompt.
+
+### chatPlan vs notebook.plan: protocol gate is too strict for the matrix
+
+Loom's plan-convention block documents a four-stage approval gate
+(chat draft -> approve -> param table -> approve -> notebook write).
+Adding `chatPlan` (looking for the formal `## Plan A:` block in chat
+text) plus `notebook.plan.exists: false` to enforce "no notebook write
+before approval" produced 0/15 on the matrix, because no model in the
+TACC matrix actually follows the documented gate. Qwen3 collapses to
+two stages (clarify, then write), Llama-3.3 to one stage (write
+immediately on turn 1). Forcing the eval to enforce a protocol the
+matrix won't follow is a stuck-loop.
+
+Fix: relax to "by end of run, a structurally valid plan exists in the
+notebook (the durable record)." This is what end-user UX actually
+wants. The `chatPlan` primitive stays in the assertion library for
+future scenarios that explicitly want to test the gate (e.g. a "model
+paused for approval before writing" check).
+
+### Sub-bullet descriptions need to count
+
+`eachStepHasDescription` originally only counted text on the step's
+main line after stripping number/title/anchor. Some models put
+descriptive content (`Routing: <x>`, `Tool: <y>`) in indented
+sub-bullets and leave the main line as just `**Title**`. Parser saw
+descriptionLength=0 and failed the heuristic.
+
+Fix: fold immediate sub-bullet text into the description measurement.
+
+## Per-model behavioral observations
+
+(From the latest matrix run, with caveats: single runs are noisy, and
+Maverick especially shows nondeterminism on tool-call format.)
+
+|                  | Plan-creation pass | Notable behavior                                                                                                                                                                                                                                                                          |
+| ---------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Qwen3-32B        | 4-5 / 5            | Most consistent. Rich plans with parameter tables. Honors Galaxy routing more than the Llamas. Sometimes paraphrases instead of formal-block on turn 1, then writes properly on turn 2. Occasional hallucinated Galaxy toolshed URLs (caught in galaxy harness with LLMJudge, not by us). |
+| Llama-3.3-70B    | 1 / 5              | Writes to notebook on turn 1 (skips chat-draft stage). Defaults to `[local]` routing despite Galaxy-first guidance in the prompt. Heading format now correct after the worked-example fix.                                                                                                |
+| Llama-4-Maverick | 1 / 5              | Most fragile on the proxy. Even after the anchor fix, several scenarios end with empty notebooks -- Maverick chats but never invokes the write tool. Possible follow-ups: tool-bias adjustment in the prompt, or treat as a known limitation.                                             |
+
+## What the eval is good at, and what it isn't
+
+**Good at:**
+
+- Catching Loom-side prompt regressions (any of the three above bugs would have shown up immediately).
+- Per-model leaderboard for _shell contract compliance_ -- "did the agent honor our notebook conventions when asked for a plan."
+- Spotting upstream proxy/model issues (the litellm Llama-4 adapter bug surfaced cleanly).
+
+**Not good at, by design:**
+
+- Content quality scoring. No LLMJudge. The galaxy harness handles that
+  (`/Users/dannon/work/galaxy__worktrees/agent-evals-harness/`); duplicating
+  it here would mean re-implementing pydantic-evals in TypeScript.
+- Catching subtle regressions in Loom's _non-prompt_ code paths (init-gate,
+  notebook-writer, session-lifecycle). Those need their own scenarios that
+  exercise the slash commands and the lifecycle hooks directly.
+- Single-run reliability. Real comparison needs n>=3 runs per (scenario,
+  model) tuple with median scoring. Phase 6 in the plan covers this.
+
+## Suggested next iterations
+
+1. **Maverick "chats but never writes" on 4/5.** Look at the chat content for
+   each failing case to characterize what Maverick does instead of writing.
+   If it's a token-budget issue, raise max_tokens on the matrix entry. If
+   it's prompt-following, add a short "use the write tool to save" reminder
+   to the convention block. If it's a Maverick-specific limit, accept and
+   document.
+2. **Shell-contract scenarios that don't ride the matrix.** Init-gate
+   variants (no plan, weak step), confusables hint (#102), notebook
+   discipline (does the agent flip `- [ ]` to `- [x]` after completion).
+   These exercise Loom-the-shell rather than model behavior.
+3. **n=3 median runs (Phase 6 of the plan).** TACC is free; we just need a
+   `--repeat N` flag in the runner that aggregates results per
+   (scenario, model) tuple.
+4. **Markdown report with per-(scenario, model) detail.** Today's stdout
+   tells you pass/fail counts but burying the comparative content in
+   `LOOM_EVALS_VERBOSE` is fragile. A report file written under
+   `evals/results/` (gitignored or committed-baseline) gives a real
+   artifact to diff between runs.
+5. **Once init-gate.ts (#104) is on main, replace the stub
+   evals/lib/notebook-parser.ts with a direct import.** Less duplication.

--- a/evals/findings.md
+++ b/evals/findings.md
@@ -123,11 +123,11 @@ Fix: fold immediate sub-bullet text into the description measurement.
 (From the latest matrix run, with caveats: single runs are noisy, and
 Maverick especially shows nondeterminism on tool-call format.)
 
-|                  | Plan-creation pass | Notable behavior                                                                                                                                                                                                                                                                          |
-| ---------------- | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Qwen3-32B        | 4-5 / 5            | Most consistent. Rich plans with parameter tables. Honors Galaxy routing more than the Llamas. Sometimes paraphrases instead of formal-block on turn 1, then writes properly on turn 2. Occasional hallucinated Galaxy toolshed URLs (caught in galaxy harness with LLMJudge, not by us). |
-| Llama-3.3-70B    | 1 / 5              | Writes to notebook on turn 1 (skips chat-draft stage). Defaults to `[local]` routing despite Galaxy-first guidance in the prompt. Heading format now correct after the worked-example fix.                                                                                                |
-| Llama-4-Maverick | 1 / 5              | Most fragile on the proxy. Even after the anchor fix, several scenarios end with empty notebooks -- Maverick chats but never invokes the write tool. Possible follow-ups: tool-bias adjustment in the prompt, or treat as a known limitation.                                             |
+|                  | Plan-creation pass | Notable behavior                                                                                                                                                                                                                                                                                                                                                                              |
+| ---------------- | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Qwen3-32B        | 4-5 / 5            | Most consistent. Rich plans with parameter tables. Honors Galaxy routing more than the Llamas. Sometimes paraphrases instead of formal-block on turn 1, then writes properly on turn 2. Occasional hallucinated Galaxy toolshed URLs (caught in galaxy harness with LLMJudge, not by us).                                                                                                     |
+| Llama-3.3-70B    | 2 / 5              | Writes to notebook on turn 1 (skips chat-draft stage). Defaults to `[local]` routing despite Galaxy-first guidance in the prompt. Heading format now correct after the worked-example fix.                                                                                                                                                                                                    |
+| Llama-4-Maverick | 3 / 5              | Highest variance run-to-run. Mostly correct format when it does write; failures are nondeterministic "drafted in chat, never invoked write tool" -- not a fundamental limit. A direct re-run of one of the eval-runner failures (pharmacogenomics) produced a perfect 5-step plan. n=3 median scoring (Phase 6) will smooth this out; today's single-run snapshot under-represents the model. |
 
 ## What the eval is good at, and what it isn't
 
@@ -150,23 +150,24 @@ Maverick especially shows nondeterminism on tool-call format.)
 
 ## Suggested next iterations
 
-1. **Maverick "chats but never writes" on 4/5.** Look at the chat content for
-   each failing case to characterize what Maverick does instead of writing.
-   If it's a token-budget issue, raise max_tokens on the matrix entry. If
-   it's prompt-following, add a short "use the write tool to save" reminder
-   to the convention block. If it's a Maverick-specific limit, accept and
-   document.
+1. **n=3 median runs (Phase 6 of the plan).** TACC is free; we just need a
+   `--repeat N` flag in the runner that aggregates results per
+   (scenario, model) tuple. Maverick's run-to-run variance is the strongest
+   single argument for this -- single-run scoring under-represents it
+   meaningfully.
 2. **Shell-contract scenarios that don't ride the matrix.** Init-gate
    variants (no plan, weak step), confusables hint (#102), notebook
    discipline (does the agent flip `- [ ]` to `- [x]` after completion).
-   These exercise Loom-the-shell rather than model behavior.
-3. **n=3 median runs (Phase 6 of the plan).** TACC is free; we just need a
-   `--repeat N` flag in the runner that aggregates results per
-   (scenario, model) tuple.
-4. **Markdown report with per-(scenario, model) detail.** Today's stdout
+   These exercise Loom-the-shell rather than model behavior, complement
+   the model leaderboard.
+3. **Markdown report with per-(scenario, model) detail.** Today's stdout
    tells you pass/fail counts but burying the comparative content in
    `LOOM_EVALS_VERBOSE` is fragile. A report file written under
-   `evals/results/` (gitignored or committed-baseline) gives a real
-   artifact to diff between runs.
-5. **Once init-gate.ts (#104) is on main, replace the stub
+   `evals/results/` (gitignored, with a committed `baseline.md`) gives a
+   real artifact to diff between runs.
+4. **Once init-gate.ts (#104) is on main, replace the stub
    evals/lib/notebook-parser.ts with a direct import.** Less duplication.
+5. **Llama-3.3 protocol-following.** It writes to notebook on turn 1
+   (skipping chat-draft) and picks `[local]` routing despite the
+   Galaxy-first prompt. Worth a focused prompt-tightening cycle if we
+   want it to score above 2/5.

--- a/evals/lib/assertions.ts
+++ b/evals/lib/assertions.ts
@@ -1,0 +1,134 @@
+/**
+ * Evaluate scenario assertions against a captured event stream.
+ *
+ * Tool calls live in `tool_execution_start` events. Chat text is the
+ * concatenated `text_delta` from `message_update` events. We deliberately
+ * keep the matchers simple (substring / ordered subsequence) -- if a
+ * scenario needs more, it should be expressed as multiple assertions.
+ */
+
+import type { AnyEvent, Assertions, ScenarioFailure, ScenarioRun } from "./types.js";
+
+export function evaluate(run: ScenarioRun): ScenarioFailure[] {
+  const failures: ScenarioFailure[] = [];
+  const a = run.scenario.assertions;
+
+  if (a.exitCode !== undefined && run.exitCode !== a.exitCode) {
+    failures.push({
+      assertion: "exitCode",
+      detail: `expected ${a.exitCode}, got ${run.exitCode}`,
+    });
+  }
+
+  evaluateToolCalls(run.events, a, failures);
+  evaluateEvents(run.events, a, failures);
+  evaluateChatText(run.events, a, failures);
+
+  return failures;
+}
+
+function evaluateToolCalls(events: AnyEvent[], a: Assertions, failures: ScenarioFailure[]): void {
+  if (!a.toolCalls) return;
+  const toolCalls = events.filter((e) => e.type === "tool_execution_start");
+  const toolNames = toolCalls.map((e) => String(e.toolName));
+
+  for (const banned of a.toolCalls.mustNotInclude ?? []) {
+    if (toolNames.includes(banned)) {
+      failures.push({
+        assertion: "toolCalls.mustNotInclude",
+        detail: `banned tool '${banned}' was called`,
+      });
+    }
+  }
+
+  if (a.toolCalls.mustInclude && a.toolCalls.mustInclude.length > 0) {
+    let cursor = 0;
+    for (const expected of a.toolCalls.mustInclude) {
+      const idx = findToolCall(toolCalls, expected.name, expected.argsContains, cursor);
+      if (idx === -1) {
+        failures.push({
+          assertion: "toolCalls.mustInclude",
+          detail: `expected tool '${expected.name}' not found in remaining sequence`,
+        });
+        break;
+      }
+      cursor = idx + 1;
+    }
+  }
+}
+
+function findToolCall(
+  toolCalls: AnyEvent[],
+  name: string,
+  argsContains: Record<string, string> | undefined,
+  startIdx: number,
+): number {
+  for (let i = startIdx; i < toolCalls.length; i++) {
+    if (toolCalls[i].toolName !== name) continue;
+    if (!argsContains) return i;
+    const args = toolCalls[i].args as Record<string, unknown> | undefined;
+    if (!args) continue;
+    const ok = Object.entries(argsContains).every(([k, v]) => {
+      const actual = args[k];
+      return typeof actual === "string" && actual.includes(v);
+    });
+    if (ok) return i;
+  }
+  return -1;
+}
+
+function evaluateEvents(events: AnyEvent[], a: Assertions, failures: ScenarioFailure[]): void {
+  if (!a.events) return;
+  const types = new Set(events.map((e) => e.type));
+
+  for (const required of a.events.mustInclude ?? []) {
+    if (!types.has(required)) {
+      failures.push({
+        assertion: "events.mustInclude",
+        detail: `expected event type '${required}' was not emitted`,
+      });
+    }
+  }
+  for (const banned of a.events.mustNotInclude ?? []) {
+    if (types.has(banned)) {
+      failures.push({
+        assertion: "events.mustNotInclude",
+        detail: `banned event type '${banned}' was emitted`,
+      });
+    }
+  }
+}
+
+function evaluateChatText(events: AnyEvent[], a: Assertions, failures: ScenarioFailure[]): void {
+  if (!a.chatText) return;
+  const text = collectChatText(events);
+
+  for (const needle of a.chatText.mustInclude ?? []) {
+    if (!text.includes(needle)) {
+      failures.push({
+        assertion: "chatText.mustInclude",
+        detail: `chat text did not include '${needle}'`,
+      });
+    }
+  }
+  for (const needle of a.chatText.mustNotInclude ?? []) {
+    if (text.includes(needle)) {
+      failures.push({
+        assertion: "chatText.mustNotInclude",
+        detail: `chat text included banned '${needle}'`,
+      });
+    }
+  }
+}
+
+function collectChatText(events: AnyEvent[]): string {
+  const parts: string[] = [];
+  for (const e of events) {
+    if (e.type !== "message_update") continue;
+    const inner = e.assistantMessageEvent as { type?: string; delta?: string } | undefined;
+    if (inner?.type === "text_delta" && typeof inner.delta === "string") {
+      parts.push(inner.delta);
+    }
+  }
+  return parts.join("");
+}

--- a/evals/lib/assertions.ts
+++ b/evals/lib/assertions.ts
@@ -22,7 +22,7 @@ export function evaluate(run: ScenarioRun): ScenarioFailure[] {
 
   evaluateToolCalls(run.events, a, failures);
   evaluateEvents(run.events, a, failures);
-  evaluateChatText(run.events, a, failures);
+  evaluateChatText(run.events, a, run.model?.stripThinkingTags ?? false, failures);
 
   return failures;
 }
@@ -99,9 +99,15 @@ function evaluateEvents(events: AnyEvent[], a: Assertions, failures: ScenarioFai
   }
 }
 
-function evaluateChatText(events: AnyEvent[], a: Assertions, failures: ScenarioFailure[]): void {
+function evaluateChatText(
+  events: AnyEvent[],
+  a: Assertions,
+  stripThinkingTags: boolean,
+  failures: ScenarioFailure[],
+): void {
   if (!a.chatText) return;
-  const text = collectChatText(events);
+  let text = collectChatText(events);
+  if (stripThinkingTags) text = stripThinking(text);
 
   for (const needle of a.chatText.mustInclude ?? []) {
     if (!text.includes(needle)) {
@@ -131,4 +137,8 @@ function collectChatText(events: AnyEvent[]): string {
     }
   }
   return parts.join("");
+}
+
+function stripThinking(text: string): string {
+  return text.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
 }

--- a/evals/lib/assertions.ts
+++ b/evals/lib/assertions.ts
@@ -7,7 +7,15 @@
  * scenario needs more, it should be expressed as multiple assertions.
  */
 
-import type { AnyEvent, Assertions, ScenarioFailure, ScenarioRun } from "./types.js";
+import { parseLatestPlan } from "./notebook-parser.js";
+import type {
+  AnyEvent,
+  Assertions,
+  NotebookAssertions,
+  PlanAssertions,
+  ScenarioFailure,
+  ScenarioRun,
+} from "./types.js";
 
 export function evaluate(run: ScenarioRun): ScenarioFailure[] {
   const failures: ScenarioFailure[] = [];
@@ -23,6 +31,7 @@ export function evaluate(run: ScenarioRun): ScenarioFailure[] {
   evaluateToolCalls(run.events, a, failures);
   evaluateEvents(run.events, a, failures);
   evaluateChatText(run.events, a, run.model?.stripThinkingTags ?? false, failures);
+  evaluateNotebook(run.notebookContent, a.notebook, failures);
 
   return failures;
 }
@@ -141,4 +150,91 @@ function collectChatText(events: AnyEvent[]): string {
 
 function stripThinking(text: string): string {
   return text.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
+}
+
+function evaluateNotebook(
+  content: string | null,
+  a: NotebookAssertions | undefined,
+  failures: ScenarioFailure[],
+): void {
+  if (!a) return;
+
+  if (a.exists !== undefined) {
+    const present = content !== null;
+    if (present !== a.exists) {
+      failures.push({
+        assertion: "notebook.exists",
+        detail: `expected exists=${a.exists}, got ${present}`,
+      });
+    }
+  }
+
+  if (content === null) {
+    // remaining checks need content; bail with a clear failure if any were asked for
+    if (a.contains?.length || a.mustNotContain?.length || a.plan) {
+      failures.push({
+        assertion: "notebook",
+        detail: "notebook.md was not present at end of run",
+      });
+    }
+    return;
+  }
+
+  for (const needle of a.contains ?? []) {
+    if (!content.includes(needle)) {
+      failures.push({
+        assertion: "notebook.contains",
+        detail: `notebook did not contain '${needle}'`,
+      });
+    }
+  }
+  for (const needle of a.mustNotContain ?? []) {
+    if (content.includes(needle)) {
+      failures.push({
+        assertion: "notebook.mustNotContain",
+        detail: `notebook contained banned '${needle}'`,
+      });
+    }
+  }
+
+  if (a.plan) evaluatePlan(content, a.plan, failures);
+}
+
+function evaluatePlan(content: string, a: PlanAssertions, failures: ScenarioFailure[]): void {
+  const plan = parseLatestPlan(content);
+  if (!plan) {
+    if (a.exists || a.routingIn || a.minPendingSteps !== undefined || a.eachStepHasDescription) {
+      failures.push({
+        assertion: "notebook.plan.exists",
+        detail: "no `## Plan X: <title> [routing]` heading found in notebook",
+      });
+    }
+    return;
+  }
+
+  if (a.routingIn && !a.routingIn.includes(plan.routing as (typeof a.routingIn)[number])) {
+    failures.push({
+      assertion: "notebook.plan.routingIn",
+      detail: `plan routing '${plan.routing}' not in [${a.routingIn.join(", ")}]`,
+    });
+  }
+
+  if (a.minPendingSteps !== undefined && plan.pendingSteps.length < a.minPendingSteps) {
+    failures.push({
+      assertion: "notebook.plan.minPendingSteps",
+      detail: `expected >= ${a.minPendingSteps} pending steps, got ${plan.pendingSteps.length}`,
+    });
+  }
+
+  if (a.eachStepHasDescription) {
+    const skinny = plan.pendingSteps.filter((s) => s.descriptionLength < 8);
+    if (skinny.length > 0) {
+      failures.push({
+        assertion: "notebook.plan.eachStepHasDescription",
+        detail: `${skinny.length} step(s) lack a description >= 8 chars (lines ${skinny
+          .map((s) => s.line + 1)
+          .join(", ")})`,
+      });
+    }
+  }
 }

--- a/evals/lib/assertions.ts
+++ b/evals/lib/assertions.ts
@@ -28,9 +28,11 @@ export function evaluate(run: ScenarioRun): ScenarioFailure[] {
     });
   }
 
+  const stripThink = run.model?.stripThinkingTags ?? false;
   evaluateToolCalls(run.events, a, failures);
   evaluateEvents(run.events, a, failures);
-  evaluateChatText(run.events, a, run.model?.stripThinkingTags ?? false, failures);
+  evaluateChatText(run.events, a, stripThink, failures);
+  evaluateChatPlan(run.events, a.chatPlan, stripThink, failures);
   evaluateNotebook(run.notebookContent, a.notebook, failures);
 
   return failures;
@@ -197,31 +199,64 @@ function evaluateNotebook(
     }
   }
 
-  if (a.plan) evaluatePlan(content, a.plan, failures);
+  if (a.plan) evaluatePlan(content, a.plan, failures, "notebook.plan", "notebook");
 }
 
-function evaluatePlan(content: string, a: PlanAssertions, failures: ScenarioFailure[]): void {
+function evaluateChatPlan(
+  events: AnyEvent[],
+  a: PlanAssertions | undefined,
+  stripThinkingTags: boolean,
+  failures: ScenarioFailure[],
+): void {
+  if (!a) return;
+  let text = collectChatText(events);
+  if (stripThinkingTags) text = stripThinking(text);
+  evaluatePlan(text, a, failures, "chatPlan", "chat text");
+}
+
+/**
+ * Apply PlanAssertions to a content string. `prefix` is the assertion-name
+ * prefix used in failure detail (e.g. "notebook.plan", "chatPlan");
+ * `surfaceLabel` names the source for human-readable failure text
+ * ("notebook", "chat text").
+ */
+function evaluatePlan(
+  content: string,
+  a: PlanAssertions,
+  failures: ScenarioFailure[],
+  prefix: string,
+  surfaceLabel: string,
+): void {
   const plan = parseLatestPlan(content);
+
   if (!plan) {
     if (a.exists || a.routingIn || a.minPendingSteps !== undefined || a.eachStepHasDescription) {
       failures.push({
-        assertion: "notebook.plan.exists",
-        detail: "no `## Plan X: <title> [routing]` heading found in notebook",
+        assertion: `${prefix}.exists`,
+        detail: `no \`## Plan X: <title> [routing]\` heading found in ${surfaceLabel}`,
       });
     }
     return;
   }
 
+  if (a.exists === false) {
+    failures.push({
+      assertion: `${prefix}.exists`,
+      detail: `expected no plan heading in ${surfaceLabel} but found "${plan.title}"`,
+    });
+    return;
+  }
+
   if (a.routingIn && !a.routingIn.includes(plan.routing as (typeof a.routingIn)[number])) {
     failures.push({
-      assertion: "notebook.plan.routingIn",
+      assertion: `${prefix}.routingIn`,
       detail: `plan routing '${plan.routing}' not in [${a.routingIn.join(", ")}]`,
     });
   }
 
   if (a.minPendingSteps !== undefined && plan.pendingSteps.length < a.minPendingSteps) {
     failures.push({
-      assertion: "notebook.plan.minPendingSteps",
+      assertion: `${prefix}.minPendingSteps`,
       detail: `expected >= ${a.minPendingSteps} pending steps, got ${plan.pendingSteps.length}`,
     });
   }
@@ -230,7 +265,7 @@ function evaluatePlan(content: string, a: PlanAssertions, failures: ScenarioFail
     const skinny = plan.pendingSteps.filter((s) => s.descriptionLength < 8);
     if (skinny.length > 0) {
       failures.push({
-        assertion: "notebook.plan.eachStepHasDescription",
+        assertion: `${prefix}.eachStepHasDescription`,
         detail: `${skinny.length} step(s) lack a description >= 8 chars (lines ${skinny
           .map((s) => s.line + 1)
           .join(", ")})`,

--- a/evals/lib/env.ts
+++ b/evals/lib/env.ts
@@ -1,0 +1,38 @@
+/**
+ * Minimal .env loader for the eval runner. Reads evals/.env (gitignored) if
+ * present and sets any unset variables in process.env. Lines like KEY=value;
+ * blanks and `#`-comments ignored; surrounding quotes on the value stripped.
+ *
+ * Tiny on purpose -- the eval runner needs at most a handful of creds, and
+ * pulling in dotenv just for that doesn't earn its keep.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const evalsDir = path.resolve(path.dirname(__filename), "..");
+
+export function loadDotEnv(): void {
+  const envPath = path.join(evalsDir, ".env");
+  if (!fs.existsSync(envPath)) return;
+  const content = fs.readFileSync(envPath, "utf-8");
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eqIdx = line.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = line.slice(0, eqIdx).trim();
+    let value = line.slice(eqIdx + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}

--- a/evals/lib/matrix.ts
+++ b/evals/lib/matrix.ts
@@ -1,0 +1,77 @@
+/**
+ * Load the curated model matrix and decide which entries can actually run.
+ *
+ * Skip-with-warning rather than fail-on-missing-env: most contributors won't
+ * have every credential (Anthropic + TACC + OpenAI + ...), and we want the
+ * subset they do have to keep working locally.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import type { ModelEntry, ModelMatrix } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const evalsDir = path.resolve(path.dirname(__filename), "..");
+const modelsJsonPath = path.join(evalsDir, "models.json");
+
+export interface MatrixLoadResult {
+  available: ModelEntry[];
+  skipped: { model: ModelEntry; missing: string[] }[];
+}
+
+export function loadMatrix(filterIds?: string[]): MatrixLoadResult {
+  const raw = JSON.parse(fs.readFileSync(modelsJsonPath, "utf-8")) as ModelMatrix;
+  const available: ModelEntry[] = [];
+  const skipped: MatrixLoadResult["skipped"] = [];
+
+  for (const model of raw.models) {
+    if (filterIds && filterIds.length > 0 && !filterIds.includes(model.id)) continue;
+    const missing = (model.envRequires ?? []).filter((v) => !process.env[v]);
+    if (missing.length > 0) {
+      skipped.push({ model, missing });
+      continue;
+    }
+    available.push(model);
+  }
+  return { available, skipped };
+}
+
+/**
+ * Synthesize a Pi-shaped models.json into the temp agent dir for any
+ * OpenAI-compatible custom provider. First-class providers (anthropic et al.)
+ * are no-ops -- Pi loads them from its built-in registry.
+ */
+export function writePiModelsConfig(model: ModelEntry, agentDir: string): void {
+  if (!model.providerConfig) return;
+
+  const cfg = model.providerConfig;
+  const baseUrl = cfg.baseUrlIsEnvVar ? process.env[cfg.baseUrl] : cfg.baseUrl;
+  if (!baseUrl) {
+    throw new Error(`Model ${model.id}: providerConfig.baseUrl env var '${cfg.baseUrl}' is unset`);
+  }
+
+  const piModels = {
+    providers: {
+      [model.provider]: {
+        baseUrl,
+        api: "openai-completions",
+        apiKey: cfg.apiKeyEnvVar,
+        models: [
+          {
+            id: model.model,
+            name: model.model,
+            reasoning: false,
+            input: ["text"],
+            contextWindow: cfg.contextWindow ?? 32000,
+            maxTokens: cfg.maxTokens ?? 4096,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          },
+        ],
+      },
+    },
+  };
+
+  fs.mkdirSync(agentDir, { recursive: true });
+  fs.writeFileSync(path.join(agentDir, "models.json"), JSON.stringify(piModels, null, 2));
+}

--- a/evals/lib/notebook-parser.ts
+++ b/evals/lib/notebook-parser.ts
@@ -1,0 +1,59 @@
+/**
+ * Subset of extensions/loom/init-gate.ts's plan parser, scoped to what the
+ * notebook assertions need. Once init-gate.ts is on main (PR #104) this can
+ * be replaced with an import; in the meantime, behavior is intentionally
+ * a faithful subset so scenarios written against this parser keep passing
+ * after the swap.
+ */
+
+export type Routing = "local" | "galaxy" | "hybrid" | "remote" | "unknown";
+
+export interface ParsedPlan {
+  title: string;
+  routing: Routing;
+  pendingSteps: { line: number; raw: string; descriptionLength: number }[];
+}
+
+export function parseLatestPlan(content: string): ParsedPlan | null {
+  const lines = content.split("\n");
+  let latestPlanLine = -1;
+  let latestPlanTitle = "";
+  let latestPlanRouting: Routing = "unknown";
+
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(
+      /^##\s+Plan\s+([^:]+):\s*(.+?)(?:\s*\[(local|galaxy|hybrid|remote)\])?\s*$/i,
+    );
+    if (m) {
+      latestPlanLine = i;
+      latestPlanTitle = `${m[1].trim()}: ${m[2].trim()}`;
+      latestPlanRouting = (m[3]?.toLowerCase() as Routing) ?? "unknown";
+    }
+  }
+
+  if (latestPlanLine === -1) return null;
+
+  const pendingSteps: ParsedPlan["pendingSteps"] = [];
+  for (let i = latestPlanLine + 1; i < lines.length; i++) {
+    if (/^##\s+/.test(lines[i])) break;
+    const stepMatch = lines[i].match(/^\s*-\s+\[\s\]\s+(.*)$/);
+    if (stepMatch) {
+      pendingSteps.push({
+        line: i,
+        raw: stepMatch[1],
+        descriptionLength: measureStepDescription(stepMatch[1]),
+      });
+    }
+  }
+
+  return { title: latestPlanTitle, routing: latestPlanRouting, pendingSteps };
+}
+
+function measureStepDescription(raw: string): number {
+  return raw
+    .replace(/^\d+\.\s*/, "")
+    .replace(/\*\*[^*]+\*\*/, "")
+    .replace(/\{#[^}]+\}/, "")
+    .replace(/^[\s\-:|]+/, "")
+    .trim().length;
+}

--- a/evals/lib/notebook-parser.ts
+++ b/evals/lib/notebook-parser.ts
@@ -38,10 +38,11 @@ export function parseLatestPlan(content: string): ParsedPlan | null {
     if (/^##\s+/.test(lines[i])) break;
     const stepMatch = lines[i].match(/^\s*-\s+\[\s\]\s+(.*)$/);
     if (stepMatch) {
+      const subBullets = collectSubBullets(lines, i + 1);
       pendingSteps.push({
         line: i,
         raw: stepMatch[1],
-        descriptionLength: measureStepDescription(stepMatch[1]),
+        descriptionLength: measureStepDescription(stepMatch[1], subBullets),
       });
     }
   }
@@ -49,11 +50,42 @@ export function parseLatestPlan(content: string): ParsedPlan | null {
   return { title: latestPlanTitle, routing: latestPlanRouting, pendingSteps };
 }
 
-function measureStepDescription(raw: string): number {
-  return raw
+/**
+ * Gather indented sub-bullet lines following the step's main line. Stops at
+ * the next top-level `- [ ]` bullet, the next `##` section, a blank line that
+ * terminates the step block, or end-of-content.
+ */
+function collectSubBullets(lines: string[], startIdx: number): string[] {
+  const out: string[] = [];
+  for (let i = startIdx; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^##\s+/.test(line)) break;
+    if (/^\s*-\s+\[[ x!]\]\s+/.test(line)) break; // next top-level step
+    if (/^\s+-\s+/.test(line)) {
+      out.push(line.replace(/^\s+-\s+/, "").trim());
+      continue;
+    }
+    if (line.trim() === "") break;
+    // any other shape (paragraph continuation) -- stop
+    break;
+  }
+  return out;
+}
+
+/**
+ * Measure the descriptive text attached to a step. Strips numeric prefix,
+ * the bold-wrapped title, optional `{#anchor}`, and leading separators from
+ * the main line; then concatenates indented sub-bullet content. Sub-bullets
+ * count because some models put `Routing: <x>` and `Tool: <y>` there
+ * instead of (or in addition to) a same-line description.
+ */
+function measureStepDescription(raw: string, subBullets: string[]): number {
+  const sameLine = raw
     .replace(/^\d+\.\s*/, "")
     .replace(/\*\*[^*]+\*\*/, "")
     .replace(/\{#[^}]+\}/, "")
     .replace(/^[\s\-:|]+/, "")
-    .trim().length;
+    .trim();
+  const subText = subBullets.join(" ").trim();
+  return [sameLine, subText].filter(Boolean).join(" ").length;
 }

--- a/evals/lib/report.ts
+++ b/evals/lib/report.ts
@@ -1,0 +1,39 @@
+/**
+ * Plain-stdout reporter. One line per scenario; per-failure detail when red.
+ */
+
+import type { ScenarioRun } from "./types.js";
+
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const DIM = "\x1b[2m";
+const RESET = "\x1b[0m";
+
+export function report(runs: ScenarioRun[]): { passed: number; failed: number } {
+  let passed = 0;
+  let failed = 0;
+  for (const run of runs) {
+    const ok = run.failures.length === 0;
+    if (ok) passed++;
+    else failed++;
+    const tag = ok ? `${GREEN}PASS${RESET}` : `${RED}FAIL${RESET}`;
+    const ms = `${DIM}(${run.durationMs}ms)${RESET}`;
+    console.log(`${tag} ${run.scenario.name} ${ms}`);
+    if (!ok) {
+      for (const f of run.failures) {
+        console.log(`  - ${f.assertion}: ${f.detail}`);
+      }
+      if (process.env.LOOM_EVALS_VERBOSE) {
+        console.log(`  --- stdout (last 500 chars) ---`);
+        console.log(`  ${run.stdout.slice(-500).split("\n").join("\n  ")}`);
+        if (run.stderr.trim()) {
+          console.log(`  --- stderr (last 500 chars) ---`);
+          console.log(`  ${run.stderr.slice(-500).split("\n").join("\n  ")}`);
+        }
+      }
+    }
+  }
+  console.log("");
+  console.log(`${passed} passed, ${failed} failed`);
+  return { passed, failed };
+}

--- a/evals/lib/report.ts
+++ b/evals/lib/report.ts
@@ -18,7 +18,8 @@ export function report(runs: ScenarioRun[]): { passed: number; failed: number } 
     else failed++;
     const tag = ok ? `${GREEN}PASS${RESET}` : `${RED}FAIL${RESET}`;
     const ms = `${DIM}(${run.durationMs}ms)${RESET}`;
-    console.log(`${tag} ${run.scenario.name} ${ms}`);
+    const modelTag = run.model ? ` ${DIM}[${run.model.id}]${RESET}` : "";
+    console.log(`${tag} ${run.scenario.name}${modelTag} ${ms}`);
     if (!ok) {
       for (const f of run.failures) {
         console.log(`  - ${f.assertion}: ${f.detail}`);

--- a/evals/lib/report.ts
+++ b/evals/lib/report.ts
@@ -24,17 +24,29 @@ export function report(runs: ScenarioRun[]): { passed: number; failed: number } 
       for (const f of run.failures) {
         console.log(`  - ${f.assertion}: ${f.detail}`);
       }
-      if (process.env.LOOM_EVALS_VERBOSE) {
-        console.log(`  --- stdout (last 500 chars) ---`);
-        console.log(`  ${run.stdout.slice(-500).split("\n").join("\n  ")}`);
-        if (run.stderr.trim()) {
-          console.log(`  --- stderr (last 500 chars) ---`);
-          console.log(`  ${run.stderr.slice(-500).split("\n").join("\n  ")}`);
-        }
+    }
+    if ((!ok || process.env.LOOM_EVALS_VERBOSE) && run.notebookContent !== null) {
+      console.log(`  --- notebook.md (${run.notebookContent.length} bytes) ---`);
+      console.log(indent(run.notebookContent));
+      console.log(`  --- end notebook ---`);
+    }
+    if (!ok && process.env.LOOM_EVALS_VERBOSE) {
+      console.log(`  --- stdout (last 500 chars) ---`);
+      console.log(`  ${run.stdout.slice(-500).split("\n").join("\n  ")}`);
+      if (run.stderr.trim()) {
+        console.log(`  --- stderr (last 500 chars) ---`);
+        console.log(`  ${run.stderr.slice(-500).split("\n").join("\n  ")}`);
       }
     }
   }
   console.log("");
   console.log(`${passed} passed, ${failed} failed`);
   return { passed, failed };
+}
+
+function indent(text: string): string {
+  return text
+    .split("\n")
+    .map((l) => `  | ${l}`)
+    .join("\n");
 }

--- a/evals/lib/runner.ts
+++ b/evals/lib/runner.ts
@@ -1,0 +1,131 @@
+/**
+ * Spawn `loom --mode json` against a fixture cwd, capture the JSON event
+ * stream, and return the parsed events for assertion.
+ *
+ * Each scenario gets its own temp directory containing both the agent dir
+ * (PI_CODING_AGENT_DIR) and the working directory. This keeps runs isolated
+ * from the user's real ~/.pi/agent and ~/.loom config.
+ */
+
+import { spawn } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import type { AnyEvent, Scenario, ScenarioRun } from "./types.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(__filename), "..", "..");
+const loomBin = path.join(repoRoot, "bin", "loom.js");
+
+export async function runScenario(scenarioDir: string): Promise<ScenarioRun> {
+  const scenarioPath = path.join(scenarioDir, "scenario.json");
+  const scenario = JSON.parse(fs.readFileSync(scenarioPath, "utf-8")) as Scenario;
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "loom-eval-"));
+  const tmpCwd = path.join(tmpRoot, "cwd");
+  const tmpAgentDir = path.join(tmpRoot, "agent");
+  fs.mkdirSync(tmpCwd);
+  fs.mkdirSync(tmpAgentDir, { recursive: true });
+
+  const fixtureCwd = path.join(scenarioDir, "cwd");
+  if (fs.existsSync(fixtureCwd)) {
+    copyDir(fixtureCwd, tmpCwd);
+  }
+
+  const start = Date.now();
+  try {
+    const result = await spawnLoom(scenario, tmpCwd, tmpAgentDir);
+    const events = parseJsonLines(result.stdout);
+    return {
+      scenarioDir,
+      scenario,
+      exitCode: result.exitCode,
+      events,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      failures: [],
+      durationMs: Date.now() - start,
+    };
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+interface SpawnResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+function spawnLoom(scenario: Scenario, cwd: string, agentDir: string): Promise<SpawnResult> {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...(scenario.env ?? {}),
+    PI_CODING_AGENT_DIR: agentDir,
+    PI_SKIP_VERSION_CHECK: "1",
+    PI_TELEMETRY: "0",
+    LOOM_FRESH_SESSION: "1",
+    HOME: agentDir, // isolates ~/.loom/config.json reads
+  };
+
+  const args = ["--mode", "json"];
+  for (const input of scenario.inputs) args.push(input);
+
+  const timeoutMs = scenario.timeoutMs ?? 15000;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [loomBin, ...args], {
+      cwd,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    child.stdout.on("data", (d) => (stdout += d.toString()));
+    child.stderr.on("data", (d) => (stderr += d.toString()));
+    child.on("error", reject);
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      // SIGKILL fallback if SIGTERM doesn't take in 2s
+      setTimeout(() => child.kill("SIGKILL"), 2000);
+    }, timeoutMs);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({
+        exitCode: timedOut ? -2 : (code ?? -1),
+        stdout,
+        stderr: stderr + (timedOut ? `\n[runner] timed out after ${timeoutMs}ms\n` : ""),
+      });
+    });
+  });
+}
+
+function parseJsonLines(stdout: string): AnyEvent[] {
+  const events: AnyEvent[] = [];
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    try {
+      events.push(JSON.parse(trimmed));
+    } catch {
+      // non-JSON line (banner, etc.); skip
+    }
+  }
+  return events;
+}
+
+function copyDir(src: string, dest: string): void {
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      fs.mkdirSync(d, { recursive: true });
+      copyDir(s, d);
+    } else if (entry.isFile()) {
+      fs.copyFileSync(s, d);
+    }
+  }
+}

--- a/evals/lib/runner.ts
+++ b/evals/lib/runner.ts
@@ -5,6 +5,12 @@
  * Each scenario gets its own temp directory containing both the agent dir
  * (PI_CODING_AGENT_DIR) and the working directory. This keeps runs isolated
  * from the user's real ~/.pi/agent and ~/.loom config.
+ *
+ * Tier 2 scenarios (`requiresModel: true`) are run once per available model
+ * in evals/models.json. The runner synthesizes a Pi-shaped models.json into
+ * the temp agent dir so OpenAI-compatible custom providers (TACC, litellm)
+ * become first-class for that one spawn, then passes `--provider` and
+ * `--model` to point loom at it.
  */
 
 import { spawn } from "child_process";
@@ -12,19 +18,23 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { fileURLToPath } from "url";
-import type { AnyEvent, Scenario, ScenarioRun } from "./types.js";
+import { writePiModelsConfig } from "./matrix.js";
+import type { AnyEvent, ModelEntry, Scenario, ScenarioRun } from "./types.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(__filename), "..", "..");
 const loomBin = path.join(repoRoot, "bin", "loom.js");
 
-export async function runScenario(scenarioDir: string): Promise<ScenarioRun> {
+export async function runScenario(
+  scenarioDir: string,
+  model: ModelEntry | null,
+): Promise<ScenarioRun> {
   const scenarioPath = path.join(scenarioDir, "scenario.json");
   const scenario = JSON.parse(fs.readFileSync(scenarioPath, "utf-8")) as Scenario;
 
   const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "loom-eval-"));
   const tmpCwd = path.join(tmpRoot, "cwd");
-  const tmpAgentDir = path.join(tmpRoot, "agent");
+  const tmpAgentDir = path.join(tmpRoot, ".pi", "agent");
   fs.mkdirSync(tmpCwd);
   fs.mkdirSync(tmpAgentDir, { recursive: true });
 
@@ -33,13 +43,18 @@ export async function runScenario(scenarioDir: string): Promise<ScenarioRun> {
     copyDir(fixtureCwd, tmpCwd);
   }
 
+  if (model) {
+    writePiModelsConfig(model, tmpAgentDir);
+  }
+
   const start = Date.now();
   try {
-    const result = await spawnLoom(scenario, tmpCwd, tmpAgentDir);
+    const result = await spawnLoom(scenario, model, tmpCwd, tmpAgentDir, tmpRoot);
     const events = parseJsonLines(result.stdout);
     return {
       scenarioDir,
       scenario,
+      model,
       exitCode: result.exitCode,
       events,
       stdout: result.stdout,
@@ -58,7 +73,13 @@ interface SpawnResult {
   stderr: string;
 }
 
-function spawnLoom(scenario: Scenario, cwd: string, agentDir: string): Promise<SpawnResult> {
+function spawnLoom(
+  scenario: Scenario,
+  model: ModelEntry | null,
+  cwd: string,
+  agentDir: string,
+  fakeHome: string,
+): Promise<SpawnResult> {
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     ...(scenario.env ?? {}),
@@ -66,10 +87,14 @@ function spawnLoom(scenario: Scenario, cwd: string, agentDir: string): Promise<S
     PI_SKIP_VERSION_CHECK: "1",
     PI_TELEMETRY: "0",
     LOOM_FRESH_SESSION: "1",
-    HOME: agentDir, // isolates ~/.loom/config.json reads
+    HOME: fakeHome, // isolates ~/.loom/config.json reads
   };
 
   const args = ["--mode", "json"];
+  if (model) {
+    args.push("--provider", model.provider, "--model", model.model);
+  }
+  for (const arg of scenario.loomArgs ?? []) args.push(arg);
   for (const input of scenario.inputs) args.push(input);
 
   const timeoutMs = scenario.timeoutMs ?? 15000;
@@ -89,7 +114,6 @@ function spawnLoom(scenario: Scenario, cwd: string, agentDir: string): Promise<S
     const timer = setTimeout(() => {
       timedOut = true;
       child.kill("SIGTERM");
-      // SIGKILL fallback if SIGTERM doesn't take in 2s
       setTimeout(() => child.kill("SIGKILL"), 2000);
     }, timeoutMs);
     child.on("close", (code) => {

--- a/evals/lib/runner.ts
+++ b/evals/lib/runner.ts
@@ -51,6 +51,7 @@ export async function runScenario(
   try {
     const result = await spawnLoom(scenario, model, tmpCwd, tmpAgentDir, tmpRoot);
     const events = parseJsonLines(result.stdout);
+    const notebookContent = readNotebook(tmpCwd);
     return {
       scenarioDir,
       scenario,
@@ -59,11 +60,22 @@ export async function runScenario(
       events,
       stdout: result.stdout,
       stderr: result.stderr,
+      notebookContent,
       failures: [],
       durationMs: Date.now() - start,
     };
   } finally {
     fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+function readNotebook(cwd: string): string | null {
+  const nbPath = path.join(cwd, "notebook.md");
+  if (!fs.existsSync(nbPath)) return null;
+  try {
+    return fs.readFileSync(nbPath, "utf-8");
+  } catch {
+    return null;
   }
 }
 

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -22,6 +22,14 @@ export interface Assertions {
     mustNotInclude?: string[];
   };
   /**
+   * Structural plan checks parsed from the agent's chat text. Use this for
+   * single-turn plan-creation scenarios -- Loom's plan-convention block
+   * tells the agent to draft plans IN CHAT first and only write to
+   * notebook.md after explicit user approval, so for a one-shot eval the
+   * correct plan is in chat, not in the file.
+   */
+  chatPlan?: PlanAssertions;
+  /**
    * Structural assertions on the post-run notebook.md. Reads the file from
    * the scenario's temp cwd after loom exits (or times out -- the runner
    * captures notebook state before cleanup). Content quality (right tools,

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -21,7 +21,40 @@ export interface Assertions {
     mustInclude?: string[];
     mustNotInclude?: string[];
   };
+  /**
+   * Structural assertions on the post-run notebook.md. Reads the file from
+   * the scenario's temp cwd after loom exits (or times out -- the runner
+   * captures notebook state before cleanup). Content quality (right tools,
+   * right reasoning) is intentionally out of scope here; that lives in
+   * the galaxy/brc Python harnesses with LLMJudge.
+   */
+  notebook?: NotebookAssertions;
   exitCode?: number;
+}
+
+export interface NotebookAssertions {
+  /** notebook.md must (or must not) exist after the run */
+  exists?: boolean;
+  /** every string must appear in the notebook content */
+  contains?: string[];
+  /** none of these strings may appear */
+  mustNotContain?: string[];
+  /** structural checks on the latest plan section */
+  plan?: PlanAssertions;
+}
+
+export interface PlanAssertions {
+  /** at least one `## Plan X: ... [routing]` heading must exist */
+  exists?: boolean;
+  /** routing tag in the heading must be one of these */
+  routingIn?: ("local" | "galaxy" | "hybrid" | "remote")[];
+  /** plan section must have at least N pending (`- [ ]`) steps */
+  minPendingSteps?: number;
+  /**
+   * Every pending step must carry a description beyond just `**Title**`.
+   * Mirrors init-gate's >= 8 chars heuristic (number/title/anchor stripped).
+   */
+  eachStepHasDescription?: boolean;
 }
 
 export interface Scenario {
@@ -106,6 +139,8 @@ export interface ScenarioRun {
   events: AnyEvent[];
   stdout: string;
   stderr: string;
+  /** Final notebook.md content from the scenario's temp cwd, null if absent. */
+  notebookContent: string | null;
   failures: ScenarioFailure[];
   durationMs: number;
 }

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -28,8 +28,22 @@ export interface Scenario {
   name: string;
   description?: string;
   tier: 1 | 2;
+  /**
+   * Tier 2 scenarios that exercise the agent loop set this true; the runner
+   * crosses them with every model in evals/models.json that has its env
+   * requirements satisfied. Tier 1 scenarios that hit a synchronous code
+   * path (slash-command preflight, etc.) leave it false and run once.
+   */
+  requiresModel?: boolean;
   inputs: string[];
   env?: Record<string, string>;
+  /**
+   * Extra CLI flags forwarded verbatim to the loom invocation. Useful for
+   * `--no-tools`, `--tools read,bash`, etc. -- different scenarios want
+   * different tool surfaces. Comes after `--mode json` and any
+   * `--provider`/`--model` injected by the runner.
+   */
+  loomArgs?: string[];
   /** Hard wall-clock cap for the loom invocation. Defaults to 15s. */
   timeoutMs?: number;
   assertions: Assertions;
@@ -40,9 +54,54 @@ export interface ScenarioFailure {
   detail: string;
 }
 
+/**
+ * Curated matrix of models. First-class Pi providers (anthropic/openai/google)
+ * just need env vars set. OpenAI-compatible custom providers (TACC, litellm)
+ * also carry a `providerConfig` block that the runner synthesizes into a Pi
+ * models.json before spawning.
+ */
+export interface ModelEntry {
+  /** Stable id for reporting, e.g. "tacc:llama-3.3-70b" */
+  id: string;
+  /** Pi `--provider` argument */
+  provider: string;
+  /** Pi `--model` argument */
+  model: string;
+  /**
+   * Env vars that must be set for this model to run. Missing vars cause a
+   * skip (with a warning), not a failure.
+   */
+  envRequires?: string[];
+  /**
+   * For OpenAI-compatible custom providers: enough to write a Pi models.json
+   * entry. First-class providers leave this undefined.
+   */
+  providerConfig?: {
+    type: "openai-compatible";
+    /** Either a literal URL or the env var name to read it from. */
+    baseUrl: string;
+    baseUrlIsEnvVar?: boolean;
+    /** Env var name holding the API key. */
+    apiKeyEnvVar: string;
+    contextWindow?: number;
+    maxTokens?: number;
+  };
+  /**
+   * Strip <think>...</think> blocks from chat text before assertion. Some
+   * thinking-mode models (Qwen3-32B) emit them by default.
+   */
+  stripThinkingTags?: boolean;
+}
+
+export interface ModelMatrix {
+  models: ModelEntry[];
+}
+
 export interface ScenarioRun {
   scenarioDir: string;
   scenario: Scenario;
+  /** null for Tier 1 scenarios that don't traverse the matrix. */
+  model: ModelEntry | null;
   exitCode: number;
   events: AnyEvent[];
   stdout: string;

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Scenario file format. A scenario lives at evals/scenarios/<name>/scenario.json
+ * with optional fixture files in cwd/ and golden files in expected/.
+ */
+
+export interface ToolCallExpectation {
+  name: string;
+  argsContains?: Record<string, string>;
+}
+
+export interface Assertions {
+  toolCalls?: {
+    mustInclude?: ToolCallExpectation[];
+    mustNotInclude?: string[];
+  };
+  events?: {
+    mustInclude?: string[];
+    mustNotInclude?: string[];
+  };
+  chatText?: {
+    mustInclude?: string[];
+    mustNotInclude?: string[];
+  };
+  exitCode?: number;
+}
+
+export interface Scenario {
+  name: string;
+  description?: string;
+  tier: 1 | 2;
+  inputs: string[];
+  env?: Record<string, string>;
+  /** Hard wall-clock cap for the loom invocation. Defaults to 15s. */
+  timeoutMs?: number;
+  assertions: Assertions;
+}
+
+export interface ScenarioFailure {
+  assertion: string;
+  detail: string;
+}
+
+export interface ScenarioRun {
+  scenarioDir: string;
+  scenario: Scenario;
+  exitCode: number;
+  events: AnyEvent[];
+  stdout: string;
+  stderr: string;
+  failures: ScenarioFailure[];
+  durationMs: number;
+}
+
+export interface AnyEvent {
+  type: string;
+  [k: string]: unknown;
+}

--- a/evals/models.json
+++ b/evals/models.json
@@ -1,0 +1,48 @@
+{
+  "_comment": "Curated model matrix for the eval suite. Models with missing envRequires are skipped (not failed) so local runs work without every credential. To add Anthropic / OpenAI / Google, append entries with provider set to that name and envRequires set to the appropriate API_KEY env var. The TACC entries below use the SambaNova-on-TACC OpenAI-compatible proxy; see ~/work/tacc-inference for credentials and access notes.",
+  "models": [
+    {
+      "id": "tacc:llama-3.3-70b",
+      "provider": "tacc-sambanova",
+      "model": "Meta-Llama-3.3-70B-Instruct",
+      "envRequires": ["PROXY_URL", "PROXY_API_KEY"],
+      "providerConfig": {
+        "type": "openai-compatible",
+        "baseUrl": "PROXY_URL",
+        "baseUrlIsEnvVar": true,
+        "apiKeyEnvVar": "PROXY_API_KEY",
+        "contextWindow": 128000,
+        "maxTokens": 4096
+      }
+    },
+    {
+      "id": "tacc:llama-4-maverick",
+      "provider": "tacc-sambanova",
+      "model": "Llama-4-Maverick-17B-128E-Instruct",
+      "envRequires": ["PROXY_URL", "PROXY_API_KEY"],
+      "providerConfig": {
+        "type": "openai-compatible",
+        "baseUrl": "PROXY_URL",
+        "baseUrlIsEnvVar": true,
+        "apiKeyEnvVar": "PROXY_API_KEY",
+        "contextWindow": 128000,
+        "maxTokens": 4096
+      }
+    },
+    {
+      "id": "tacc:qwen3-32b",
+      "provider": "tacc-sambanova",
+      "model": "Qwen3-32B",
+      "stripThinkingTags": true,
+      "envRequires": ["PROXY_URL", "PROXY_API_KEY"],
+      "providerConfig": {
+        "type": "openai-compatible",
+        "baseUrl": "PROXY_URL",
+        "baseUrlIsEnvVar": true,
+        "apiKeyEnvVar": "PROXY_API_KEY",
+        "contextWindow": 32000,
+        "maxTokens": 4096
+      }
+    }
+  ]
+}

--- a/evals/run.ts
+++ b/evals/run.ts
@@ -1,0 +1,54 @@
+/**
+ * Eval runner entry point. Discovers scenarios under evals/scenarios/,
+ * runs each, evaluates assertions, prints a report, and exits non-zero
+ * on any failure.
+ *
+ * Usage:
+ *   npm run evals               -- run all scenarios
+ *   npm run evals -- <name>     -- run a single scenario by directory name
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { evaluate } from "./lib/assertions.js";
+import { report } from "./lib/report.js";
+import { runScenario } from "./lib/runner.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const evalsDir = path.dirname(__filename);
+const scenariosDir = path.join(evalsDir, "scenarios");
+
+async function main() {
+  const filter = process.argv[2];
+  const scenarioDirs = discoverScenarios(filter);
+  if (scenarioDirs.length === 0) {
+    console.error(filter ? `no scenario matches '${filter}'` : "no scenarios found");
+    process.exit(2);
+  }
+
+  const runs = [];
+  for (const dir of scenarioDirs) {
+    const run = await runScenario(dir);
+    run.failures = evaluate(run);
+    runs.push(run);
+  }
+
+  const { failed } = report(runs);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+function discoverScenarios(filter: string | undefined): string[] {
+  const all = fs
+    .readdirSync(scenariosDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => path.join(scenariosDir, e.name))
+    .filter((dir) => fs.existsSync(path.join(dir, "scenario.json")));
+  if (!filter) return all;
+  return all.filter((dir) => path.basename(dir) === filter);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(2);
+});

--- a/evals/run.ts
+++ b/evals/run.ts
@@ -1,41 +1,99 @@
 /**
  * Eval runner entry point. Discovers scenarios under evals/scenarios/,
- * runs each, evaluates assertions, prints a report, and exits non-zero
- * on any failure.
+ * crosses Tier 2 scenarios with the model matrix in evals/models.json,
+ * runs each (scenario × model) cell, evaluates assertions, prints a report,
+ * and exits non-zero on any failure.
+ *
+ * Tier 1 scenarios that don't traverse the matrix run once with model=null.
  *
  * Usage:
- *   npm run evals               -- run all scenarios
- *   npm run evals -- <name>     -- run a single scenario by directory name
+ *   npm run evals                       -- run all scenarios × all available models
+ *   npm run evals -- <scenario>         -- filter to a single scenario directory
+ *   npm run evals -- --model <id>       -- filter to a single model id
+ *   npm run evals -- <scenario> --model <id>
  */
 
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { evaluate } from "./lib/assertions.js";
+import { loadDotEnv } from "./lib/env.js";
+import { loadMatrix } from "./lib/matrix.js";
 import { report } from "./lib/report.js";
 import { runScenario } from "./lib/runner.js";
+import type { ModelEntry, Scenario, ScenarioRun } from "./lib/types.js";
+
+loadDotEnv();
 
 const __filename = fileURLToPath(import.meta.url);
 const evalsDir = path.dirname(__filename);
 const scenariosDir = path.join(evalsDir, "scenarios");
 
+interface CliArgs {
+  scenarioFilter?: string;
+  modelFilter?: string[];
+}
+
 async function main() {
-  const filter = process.argv[2];
-  const scenarioDirs = discoverScenarios(filter);
+  const args = parseArgs(process.argv.slice(2));
+
+  const scenarioDirs = discoverScenarios(args.scenarioFilter);
   if (scenarioDirs.length === 0) {
-    console.error(filter ? `no scenario matches '${filter}'` : "no scenarios found");
+    console.error(
+      args.scenarioFilter ? `no scenario matches '${args.scenarioFilter}'` : "no scenarios found",
+    );
     process.exit(2);
   }
 
-  const runs = [];
+  const matrix = loadMatrix(args.modelFilter);
+  for (const { model, missing } of matrix.skipped) {
+    console.warn(`[skip] ${model.id} -- missing env: ${missing.join(", ")}`);
+  }
+
+  const runs: ScenarioRun[] = [];
   for (const dir of scenarioDirs) {
-    const run = await runScenario(dir);
-    run.failures = evaluate(run);
-    runs.push(run);
+    const scenario = readScenario(dir);
+    const cells: (ModelEntry | null)[] = scenario.requiresModel ? [...matrix.available] : [null];
+    for (const model of cells) {
+      const run = await runScenario(dir, model);
+      run.failures = evaluate(run);
+      runs.push(run);
+    }
+    if (scenario.requiresModel && matrix.available.length === 0) {
+      console.warn(`[skip] ${scenario.name} -- requiresModel but no available models in matrix`);
+    }
   }
 
   const { failed } = report(runs);
   process.exit(failed === 0 ? 0 : 1);
+}
+
+function readScenario(dir: string): Scenario {
+  return JSON.parse(fs.readFileSync(path.join(dir, "scenario.json"), "utf-8")) as Scenario;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const out: CliArgs = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--model") {
+      const next = argv[++i];
+      if (!next) {
+        console.error("--model requires an id (or comma-separated ids)");
+        process.exit(2);
+      }
+      out.modelFilter = next
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else if (!a.startsWith("--") && !out.scenarioFilter) {
+      out.scenarioFilter = a;
+    } else {
+      console.error(`unknown argument: ${a}`);
+      process.exit(2);
+    }
+  }
+  return out;
 }
 
 function discoverScenarios(filter: string | undefined): string[] {

--- a/evals/scenarios/init-gate-galaxy-no-connection/cwd/notebook.md
+++ b/evals/scenarios/init-gate-galaxy-no-connection/cwd/notebook.md
@@ -1,0 +1,7 @@
+# Eval fixture notebook
+
+## Plan A: chrM variant calling [galaxy]
+
+### Steps
+
+- [ ] 1. **Run bwa-mem on chrM** {#plan-a-step-1} -- 4 PE samples on chrM reference, IWC workflow

--- a/evals/scenarios/init-gate-galaxy-no-connection/scenario.json
+++ b/evals/scenarios/init-gate-galaxy-no-connection/scenario.json
@@ -1,0 +1,15 @@
+{
+  "name": "/execute hard-fails when a [galaxy] plan has no active connection",
+  "description": "init-gate (#104) refuses to send the agent prompt when the latest plan is tagged [galaxy] but isGalaxyConnected() is false. The slash command short-circuits before any LLM call, so this scenario exercises Loom's command path without needing model auth or a network call.",
+  "tier": 1,
+  "inputs": ["/execute"],
+  "env": {
+    "ANTHROPIC_API_KEY": "fake-eval-key"
+  },
+  "timeoutMs": 5000,
+  "assertions": {
+    "events": {
+      "mustNotInclude": ["agent_start", "tool_execution_start", "turn_start"]
+    }
+  }
+}

--- a/evals/scenarios/plan-creation-metagenomics/scenario.json
+++ b/evals/scenarios/plan-creation-metagenomics/scenario.json
@@ -5,9 +5,10 @@
   "requiresModel": true,
   "loomArgs": ["--tools", "read,write,edit"],
   "inputs": [
-    "I have shotgun metagenomic sequencing data from a soil sample. Help me draft a plan to identify which organisms are present and their relative abundances. Don't execute anything yet."
+    "I have shotgun metagenomic sequencing data from a soil sample. Help me draft a plan to identify which organisms are present and their relative abundances. Don't execute anything yet.",
+    "Yes, those assumptions all look right. Illumina paired-end 150bp, ~30M reads per sample, 6 samples total. Go ahead and draft the formal plan now."
   ],
-  "timeoutMs": 90000,
+  "timeoutMs": 150000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
     "chatPlan": {

--- a/evals/scenarios/plan-creation-metagenomics/scenario.json
+++ b/evals/scenarios/plan-creation-metagenomics/scenario.json
@@ -11,12 +11,14 @@
   "timeoutMs": 150000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
-    "chatPlan": {
+    "notebook": {
       "exists": true,
-      "routingIn": ["galaxy", "hybrid", "local", "remote"],
-      "minPendingSteps": 4,
-      "eachStepHasDescription": true
-    },
-    "notebook": { "plan": { "exists": false } }
+      "plan": {
+        "exists": true,
+        "routingIn": ["galaxy", "hybrid", "local", "remote"],
+        "minPendingSteps": 4,
+        "eachStepHasDescription": true
+      }
+    }
   }
 }

--- a/evals/scenarios/plan-creation-metagenomics/scenario.json
+++ b/evals/scenarios/plan-creation-metagenomics/scenario.json
@@ -3,9 +3,9 @@
   "description": "Researcher persona, soil shotgun metagenomics. Phrasing adapted from the galaxy harness's bioinformatics_workflows.metagenomics_community_composition case + claw's claw-metagenomics skill. Tests SHELL CONTRACT only -- whether the agent emits a structurally valid plan. Whether it picks Kraken2 vs MetaPhlAn or balances profiling-vs-assembly is content quality (galaxy harness's job).",
   "tier": 2,
   "requiresModel": true,
-  "loomArgs": ["--tools", "read,write,edit", "--no-skills", "--no-context-files"],
+  "loomArgs": ["--tools", "read,write,edit"],
   "inputs": [
-    "I have shotgun metagenomic sequencing data from a soil sample. Help me draft a plan in notebook.md to identify which organisms are present and their relative abundances. Follow Loom conventions: `## Plan A: <title> [<routing>]` heading (routing is one of [local|galaxy|hybrid|remote]), `### Steps` section, steps as `- [ ] 1. **Step title** -- description with acceptance criteria`. At least 4 pending steps. Don't execute -- just draft."
+    "I have shotgun metagenomic sequencing data from a soil sample. Help me draft a plan to identify which organisms are present and their relative abundances. Don't execute anything yet."
   ],
   "timeoutMs": 90000,
   "assertions": {

--- a/evals/scenarios/plan-creation-metagenomics/scenario.json
+++ b/evals/scenarios/plan-creation-metagenomics/scenario.json
@@ -10,14 +10,12 @@
   "timeoutMs": 90000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
-    "notebook": {
+    "chatPlan": {
       "exists": true,
-      "plan": {
-        "exists": true,
-        "routingIn": ["galaxy", "hybrid", "local", "remote"],
-        "minPendingSteps": 4,
-        "eachStepHasDescription": true
-      }
-    }
+      "routingIn": ["galaxy", "hybrid", "local", "remote"],
+      "minPendingSteps": 4,
+      "eachStepHasDescription": true
+    },
+    "notebook": { "plan": { "exists": false } }
   }
 }

--- a/evals/scenarios/plan-creation-metagenomics/scenario.json
+++ b/evals/scenarios/plan-creation-metagenomics/scenario.json
@@ -1,0 +1,23 @@
+{
+  "name": "plan creation: shotgun metagenomics community composition",
+  "description": "Researcher persona, soil shotgun metagenomics. Phrasing adapted from the galaxy harness's bioinformatics_workflows.metagenomics_community_composition case + claw's claw-metagenomics skill. Tests SHELL CONTRACT only -- whether the agent emits a structurally valid plan. Whether it picks Kraken2 vs MetaPhlAn or balances profiling-vs-assembly is content quality (galaxy harness's job).",
+  "tier": 2,
+  "requiresModel": true,
+  "loomArgs": ["--tools", "read,write,edit", "--no-skills", "--no-context-files"],
+  "inputs": [
+    "I have shotgun metagenomic sequencing data from a soil sample. Help me draft a plan in notebook.md to identify which organisms are present and their relative abundances. Follow Loom conventions: `## Plan A: <title> [<routing>]` heading (routing is one of [local|galaxy|hybrid|remote]), `### Steps` section, steps as `- [ ] 1. **Step title** -- description with acceptance criteria`. At least 4 pending steps. Don't execute -- just draft."
+  ],
+  "timeoutMs": 90000,
+  "assertions": {
+    "events": { "mustInclude": ["agent_start", "turn_end"] },
+    "notebook": {
+      "exists": true,
+      "plan": {
+        "exists": true,
+        "routingIn": ["galaxy", "hybrid", "local", "remote"],
+        "minPendingSteps": 4,
+        "eachStepHasDescription": true
+      }
+    }
+  }
+}

--- a/evals/scenarios/plan-creation-pharmacogenomics/scenario.json
+++ b/evals/scenarios/plan-creation-pharmacogenomics/scenario.json
@@ -10,14 +10,12 @@
   "timeoutMs": 90000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
-    "notebook": {
+    "chatPlan": {
       "exists": true,
-      "plan": {
-        "exists": true,
-        "routingIn": ["local", "hybrid"],
-        "minPendingSteps": 3,
-        "eachStepHasDescription": true
-      }
-    }
+      "routingIn": ["local", "hybrid"],
+      "minPendingSteps": 3,
+      "eachStepHasDescription": true
+    },
+    "notebook": { "plan": { "exists": false } }
   }
 }

--- a/evals/scenarios/plan-creation-pharmacogenomics/scenario.json
+++ b/evals/scenarios/plan-creation-pharmacogenomics/scenario.json
@@ -11,12 +11,14 @@
   "timeoutMs": 150000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
-    "chatPlan": {
+    "notebook": {
       "exists": true,
-      "routingIn": ["local", "hybrid"],
-      "minPendingSteps": 3,
-      "eachStepHasDescription": true
-    },
-    "notebook": { "plan": { "exists": false } }
+      "plan": {
+        "exists": true,
+        "routingIn": ["local", "hybrid"],
+        "minPendingSteps": 3,
+        "eachStepHasDescription": true
+      }
+    }
   }
 }

--- a/evals/scenarios/plan-creation-pharmacogenomics/scenario.json
+++ b/evals/scenarios/plan-creation-pharmacogenomics/scenario.json
@@ -1,0 +1,23 @@
+{
+  "name": "plan creation: pharmacogenomics from consumer genotyping (consumer register)",
+  "description": "Consumer-tier persona, casual phrasing, personal-data analysis. Adapted from claw's pharmgx-reporter skill ('Give me my pharmacogenomic summary'). Tests whether the model handles a non-researcher register without losing plan structure. We allow a smaller minPendingSteps (3) because consumer pipelines tend to be flatter (parse genotype -> match drug list -> report) than researcher pipelines, and we're testing structure not depth.",
+  "tier": 2,
+  "requiresModel": true,
+  "loomArgs": ["--tools", "read,write,edit", "--no-skills", "--no-context-files"],
+  "inputs": [
+    "I uploaded my 23andMe raw data file. Help me make a plan in notebook.md to figure out which medications might affect me differently because of my genetics. Use this format: a `## Plan A: <title> [<routing>]` heading where routing is one of [local|galaxy|hybrid|remote] (this is personal-scale local-data work so probably `local`), then a `### Steps` section with `- [ ] 1. **Step title** -- short description` for each step. At least 3 steps. Just write the plan, don't run anything yet."
+  ],
+  "timeoutMs": 90000,
+  "assertions": {
+    "events": { "mustInclude": ["agent_start", "turn_end"] },
+    "notebook": {
+      "exists": true,
+      "plan": {
+        "exists": true,
+        "routingIn": ["local", "hybrid"],
+        "minPendingSteps": 3,
+        "eachStepHasDescription": true
+      }
+    }
+  }
+}

--- a/evals/scenarios/plan-creation-pharmacogenomics/scenario.json
+++ b/evals/scenarios/plan-creation-pharmacogenomics/scenario.json
@@ -5,9 +5,10 @@
   "requiresModel": true,
   "loomArgs": ["--tools", "read,write,edit"],
   "inputs": [
-    "I uploaded my 23andMe raw data file. Help me figure out which medications might affect me differently because of my genetics. Don't run anything yet -- just draft me a plan."
+    "I uploaded my 23andMe raw data file. Help me figure out which medications might affect me differently because of my genetics. Don't run anything yet -- just draft me a plan.",
+    "Yes, that approach sounds fine. The file is the standard 23andMe v5 raw data txt, just on my laptop, no Galaxy needed. Go ahead and draft the formal plan."
   ],
-  "timeoutMs": 90000,
+  "timeoutMs": 150000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
     "chatPlan": {

--- a/evals/scenarios/plan-creation-pharmacogenomics/scenario.json
+++ b/evals/scenarios/plan-creation-pharmacogenomics/scenario.json
@@ -3,9 +3,9 @@
   "description": "Consumer-tier persona, casual phrasing, personal-data analysis. Adapted from claw's pharmgx-reporter skill ('Give me my pharmacogenomic summary'). Tests whether the model handles a non-researcher register without losing plan structure. We allow a smaller minPendingSteps (3) because consumer pipelines tend to be flatter (parse genotype -> match drug list -> report) than researcher pipelines, and we're testing structure not depth.",
   "tier": 2,
   "requiresModel": true,
-  "loomArgs": ["--tools", "read,write,edit", "--no-skills", "--no-context-files"],
+  "loomArgs": ["--tools", "read,write,edit"],
   "inputs": [
-    "I uploaded my 23andMe raw data file. Help me make a plan in notebook.md to figure out which medications might affect me differently because of my genetics. Use this format: a `## Plan A: <title> [<routing>]` heading where routing is one of [local|galaxy|hybrid|remote] (this is personal-scale local-data work so probably `local`), then a `### Steps` section with `- [ ] 1. **Step title** -- short description` for each step. At least 3 steps. Just write the plan, don't run anything yet."
+    "I uploaded my 23andMe raw data file. Help me figure out which medications might affect me differently because of my genetics. Don't run anything yet -- just draft me a plan."
   ],
   "timeoutMs": 90000,
   "assertions": {

--- a/evals/scenarios/plan-creation-rnaseq/scenario.json
+++ b/evals/scenarios/plan-creation-rnaseq/scenario.json
@@ -1,6 +1,6 @@
 {
-  "name": "plan creation: agent drafts an RNA-seq plan in notebook.md",
-  "description": "User asks Loom to draft a bulk RNA-seq differential-expression plan. Tests the SHELL CONTRACT for plan creation -- did the agent honor the notebook conventions (`## Plan X: <title> [<routing>]` heading, step list with `- [ ] N. **Title** -- description`, acceptance criteria of reasonable length)? Content quality (right tools, right ordering, biological correctness) is intentionally NOT scored here -- that lives in the galaxy harness with LLMJudge. We're answering 'does Loom-the-shell get a usable plan into the notebook?', not 'is this a *good* RNA-seq plan?'.",
+  "name": "plan creation: agent drafts an RNA-seq plan in chat",
+  "description": "User asks Loom to draft a bulk RNA-seq differential-expression plan. Tests the SHELL CONTRACT for plan creation -- per Loom's plan-convention block, the agent must draft the plan IN CHAT first (four-stage approval gate), and only write to notebook.md after explicit user approval. So for a single-turn ask we assert: chat carries a structurally valid `## Plan X: <title> [<routing>]` block, and the notebook stays empty of plan content. Writing to notebook on turn 1 is a protocol violation. Content quality (right tools, right ordering, biological correctness) stays out of scope -- that's the galaxy harness's job.",
   "tier": 2,
   "requiresModel": true,
   "loomArgs": ["--tools", "read,write,edit"],
@@ -12,13 +12,15 @@
     "events": {
       "mustInclude": ["agent_start", "turn_end"]
     },
-    "notebook": {
+    "chatPlan": {
       "exists": true,
+      "routingIn": ["galaxy", "hybrid", "local", "remote"],
+      "minPendingSteps": 4,
+      "eachStepHasDescription": true
+    },
+    "notebook": {
       "plan": {
-        "exists": true,
-        "routingIn": ["galaxy", "hybrid", "local", "remote"],
-        "minPendingSteps": 4,
-        "eachStepHasDescription": true
+        "exists": false
       }
     }
   }

--- a/evals/scenarios/plan-creation-rnaseq/scenario.json
+++ b/evals/scenarios/plan-creation-rnaseq/scenario.json
@@ -3,9 +3,9 @@
   "description": "User asks Loom to draft a bulk RNA-seq differential-expression plan. Tests the SHELL CONTRACT for plan creation -- did the agent honor the notebook conventions (`## Plan X: <title> [<routing>]` heading, step list with `- [ ] N. **Title** -- description`, acceptance criteria of reasonable length)? Content quality (right tools, right ordering, biological correctness) is intentionally NOT scored here -- that lives in the galaxy harness with LLMJudge. We're answering 'does Loom-the-shell get a usable plan into the notebook?', not 'is this a *good* RNA-seq plan?'.",
   "tier": 2,
   "requiresModel": true,
-  "loomArgs": ["--tools", "read,write,edit", "--no-skills", "--no-context-files"],
+  "loomArgs": ["--tools", "read,write,edit"],
   "inputs": [
-    "I have paired-end RNA-seq FASTQ files from two conditions (treated vs control, 4 replicates each). Help me draft a plan in notebook.md to identify differentially expressed genes. Use the Loom notebook conventions: a `## Plan A: <title> [<routing>]` heading where routing is one of [local|galaxy|hybrid|remote], followed by a `### Steps` section with steps like `- [ ] 1. **Step title** -- description with acceptance criteria`. At least 4 pending steps. Do NOT execute anything -- just write the plan into notebook.md."
+    "I have paired-end RNA-seq FASTQ files from two conditions (treated vs control, 4 replicates each). Help me draft a plan to identify differentially expressed genes. Don't execute anything yet."
   ],
   "timeoutMs": 90000,
   "assertions": {

--- a/evals/scenarios/plan-creation-rnaseq/scenario.json
+++ b/evals/scenarios/plan-creation-rnaseq/scenario.json
@@ -1,6 +1,6 @@
 {
-  "name": "plan creation: agent drafts an RNA-seq plan in chat",
-  "description": "User asks Loom to draft a bulk RNA-seq differential-expression plan. Tests the SHELL CONTRACT for plan creation -- per Loom's plan-convention block, the agent must draft the plan IN CHAT first (four-stage approval gate), and only write to notebook.md after explicit user approval. So for a single-turn ask we assert: chat carries a structurally valid `## Plan X: <title> [<routing>]` block, and the notebook stays empty of plan content. Writing to notebook on turn 1 is a protocol violation. Content quality (right tools, right ordering, biological correctness) stays out of scope -- that's the galaxy harness's job.",
+  "name": "plan creation: agent ends up with an RNA-seq plan",
+  "description": "Multi-turn: user asks for a bulk RNA-seq DE plan, then confirms assumptions on turn 2. SUCCESS = a structurally valid `## Plan X: <title> [<routing>]` block ends up in notebook.md by end of run. We don't care which protocol stage produced it (chat-first-then-write, write-immediately, etc) -- the matrix collapses Loom's 4-stage gate in different ways and prescribing which stage produced the plan is process pedantry that doesn't reflect end-user UX. Content quality (right tools, biological correctness) stays out of scope -- that's the galaxy harness's job with LLMJudge.",
   "tier": 2,
   "requiresModel": true,
   "loomArgs": ["--tools", "read,write,edit"],
@@ -13,15 +13,13 @@
     "events": {
       "mustInclude": ["agent_start", "turn_end"]
     },
-    "chatPlan": {
-      "exists": true,
-      "routingIn": ["galaxy", "hybrid", "local", "remote"],
-      "minPendingSteps": 4,
-      "eachStepHasDescription": true
-    },
     "notebook": {
+      "exists": true,
       "plan": {
-        "exists": false
+        "exists": true,
+        "routingIn": ["galaxy", "hybrid", "local", "remote"],
+        "minPendingSteps": 4,
+        "eachStepHasDescription": true
       }
     }
   }

--- a/evals/scenarios/plan-creation-rnaseq/scenario.json
+++ b/evals/scenarios/plan-creation-rnaseq/scenario.json
@@ -5,9 +5,10 @@
   "requiresModel": true,
   "loomArgs": ["--tools", "read,write,edit"],
   "inputs": [
-    "I have paired-end RNA-seq FASTQ files from two conditions (treated vs control, 4 replicates each). Help me draft a plan to identify differentially expressed genes. Don't execute anything yet."
+    "I have paired-end RNA-seq FASTQ files from two conditions (treated vs control, 4 replicates each). Help me draft a plan to identify differentially expressed genes. Don't execute anything yet.",
+    "Yes, those assumptions all look right. Use hg38 as the reference. Go ahead and draft the formal plan now."
   ],
-  "timeoutMs": 90000,
+  "timeoutMs": 150000,
   "assertions": {
     "events": {
       "mustInclude": ["agent_start", "turn_end"]

--- a/evals/scenarios/plan-creation-rnaseq/scenario.json
+++ b/evals/scenarios/plan-creation-rnaseq/scenario.json
@@ -1,0 +1,25 @@
+{
+  "name": "plan creation: agent drafts an RNA-seq plan in notebook.md",
+  "description": "User asks Loom to draft a bulk RNA-seq differential-expression plan. Tests the SHELL CONTRACT for plan creation -- did the agent honor the notebook conventions (`## Plan X: <title> [<routing>]` heading, step list with `- [ ] N. **Title** -- description`, acceptance criteria of reasonable length)? Content quality (right tools, right ordering, biological correctness) is intentionally NOT scored here -- that lives in the galaxy harness with LLMJudge. We're answering 'does Loom-the-shell get a usable plan into the notebook?', not 'is this a *good* RNA-seq plan?'.",
+  "tier": 2,
+  "requiresModel": true,
+  "loomArgs": ["--tools", "read,write,edit", "--no-skills", "--no-context-files"],
+  "inputs": [
+    "I have paired-end RNA-seq FASTQ files from two conditions (treated vs control, 4 replicates each). Help me draft a plan in notebook.md to identify differentially expressed genes. Use the Loom notebook conventions: a `## Plan A: <title> [<routing>]` heading where routing is one of [local|galaxy|hybrid|remote], followed by a `### Steps` section with steps like `- [ ] 1. **Step title** -- description with acceptance criteria`. At least 4 pending steps. Do NOT execute anything -- just write the plan into notebook.md."
+  ],
+  "timeoutMs": 90000,
+  "assertions": {
+    "events": {
+      "mustInclude": ["agent_start", "turn_end"]
+    },
+    "notebook": {
+      "exists": true,
+      "plan": {
+        "exists": true,
+        "routingIn": ["galaxy", "hybrid", "local", "remote"],
+        "minPendingSteps": 4,
+        "eachStepHasDescription": true
+      }
+    }
+  }
+}

--- a/evals/scenarios/plan-creation-scrna-celltypes/scenario.json
+++ b/evals/scenarios/plan-creation-scrna-celltypes/scenario.json
@@ -3,9 +3,9 @@
   "description": "Researcher persona, single-cell RNA-seq cell-type ID. Phrasing adapted from the galaxy harness's bioinformatics_workflows.scrna_cell_type_identification case + claw's scrna-orchestrator skill. Tests SHELL CONTRACT: did the agent draft a properly-shaped plan in notebook.md? Content-quality scoring (right normalization choice, right marker DB, etc.) stays in the galaxy harness with LLMJudge.",
   "tier": 2,
   "requiresModel": true,
-  "loomArgs": ["--tools", "read,write,edit", "--no-skills", "--no-context-files"],
+  "loomArgs": ["--tools", "read,write,edit"],
   "inputs": [
-    "I just got my single-cell RNA-seq count matrix back. Help me figure out what cell types are present. Draft a plan in notebook.md following the Loom conventions: a `## Plan A: <title> [<routing>]` heading where routing is one of [local|galaxy|hybrid|remote], followed by a `### Steps` section with steps like `- [ ] 1. **Step title** -- description with acceptance criteria`. At least 4 pending steps. Do NOT execute -- just draft the plan."
+    "I just got my single-cell RNA-seq count matrix back. Help me draft a plan to figure out what cell types are present. Don't execute anything yet."
   ],
   "timeoutMs": 90000,
   "assertions": {

--- a/evals/scenarios/plan-creation-scrna-celltypes/scenario.json
+++ b/evals/scenarios/plan-creation-scrna-celltypes/scenario.json
@@ -1,0 +1,23 @@
+{
+  "name": "plan creation: scRNA-seq cell type identification",
+  "description": "Researcher persona, single-cell RNA-seq cell-type ID. Phrasing adapted from the galaxy harness's bioinformatics_workflows.scrna_cell_type_identification case + claw's scrna-orchestrator skill. Tests SHELL CONTRACT: did the agent draft a properly-shaped plan in notebook.md? Content-quality scoring (right normalization choice, right marker DB, etc.) stays in the galaxy harness with LLMJudge.",
+  "tier": 2,
+  "requiresModel": true,
+  "loomArgs": ["--tools", "read,write,edit", "--no-skills", "--no-context-files"],
+  "inputs": [
+    "I just got my single-cell RNA-seq count matrix back. Help me figure out what cell types are present. Draft a plan in notebook.md following the Loom conventions: a `## Plan A: <title> [<routing>]` heading where routing is one of [local|galaxy|hybrid|remote], followed by a `### Steps` section with steps like `- [ ] 1. **Step title** -- description with acceptance criteria`. At least 4 pending steps. Do NOT execute -- just draft the plan."
+  ],
+  "timeoutMs": 90000,
+  "assertions": {
+    "events": { "mustInclude": ["agent_start", "turn_end"] },
+    "notebook": {
+      "exists": true,
+      "plan": {
+        "exists": true,
+        "routingIn": ["galaxy", "hybrid", "local", "remote"],
+        "minPendingSteps": 4,
+        "eachStepHasDescription": true
+      }
+    }
+  }
+}

--- a/evals/scenarios/plan-creation-scrna-celltypes/scenario.json
+++ b/evals/scenarios/plan-creation-scrna-celltypes/scenario.json
@@ -5,9 +5,10 @@
   "requiresModel": true,
   "loomArgs": ["--tools", "read,write,edit"],
   "inputs": [
-    "I just got my single-cell RNA-seq count matrix back. Help me draft a plan to figure out what cell types are present. Don't execute anything yet."
+    "I just got my single-cell RNA-seq count matrix back. Help me draft a plan to figure out what cell types are present. Don't execute anything yet.",
+    "Yes, those assumptions are fine. It's 10x Chromium data, human PBMCs, around 8000 cells. Go ahead and draft the formal plan now."
   ],
-  "timeoutMs": 90000,
+  "timeoutMs": 150000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
     "chatPlan": {

--- a/evals/scenarios/plan-creation-scrna-celltypes/scenario.json
+++ b/evals/scenarios/plan-creation-scrna-celltypes/scenario.json
@@ -11,12 +11,14 @@
   "timeoutMs": 150000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
-    "chatPlan": {
+    "notebook": {
       "exists": true,
-      "routingIn": ["galaxy", "hybrid", "local", "remote"],
-      "minPendingSteps": 4,
-      "eachStepHasDescription": true
-    },
-    "notebook": { "plan": { "exists": false } }
+      "plan": {
+        "exists": true,
+        "routingIn": ["galaxy", "hybrid", "local", "remote"],
+        "minPendingSteps": 4,
+        "eachStepHasDescription": true
+      }
+    }
   }
 }

--- a/evals/scenarios/plan-creation-scrna-celltypes/scenario.json
+++ b/evals/scenarios/plan-creation-scrna-celltypes/scenario.json
@@ -10,14 +10,12 @@
   "timeoutMs": 90000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
-    "notebook": {
+    "chatPlan": {
       "exists": true,
-      "plan": {
-        "exists": true,
-        "routingIn": ["galaxy", "hybrid", "local", "remote"],
-        "minPendingSteps": 4,
-        "eachStepHasDescription": true
-      }
-    }
+      "routingIn": ["galaxy", "hybrid", "local", "remote"],
+      "minPendingSteps": 4,
+      "eachStepHasDescription": true
+    },
+    "notebook": { "plan": { "exists": false } }
   }
 }

--- a/evals/scenarios/plan-creation-somatic-variants/scenario.json
+++ b/evals/scenarios/plan-creation-somatic-variants/scenario.json
@@ -11,12 +11,14 @@
   "timeoutMs": 150000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
-    "chatPlan": {
+    "notebook": {
       "exists": true,
-      "routingIn": ["galaxy", "hybrid", "local", "remote"],
-      "minPendingSteps": 5,
-      "eachStepHasDescription": true
-    },
-    "notebook": { "plan": { "exists": false } }
+      "plan": {
+        "exists": true,
+        "routingIn": ["galaxy", "hybrid", "local", "remote"],
+        "minPendingSteps": 5,
+        "eachStepHasDescription": true
+      }
+    }
   }
 }

--- a/evals/scenarios/plan-creation-somatic-variants/scenario.json
+++ b/evals/scenarios/plan-creation-somatic-variants/scenario.json
@@ -10,14 +10,12 @@
   "timeoutMs": 90000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
-    "notebook": {
+    "chatPlan": {
       "exists": true,
-      "plan": {
-        "exists": true,
-        "routingIn": ["galaxy", "hybrid", "local", "remote"],
-        "minPendingSteps": 5,
-        "eachStepHasDescription": true
-      }
-    }
+      "routingIn": ["galaxy", "hybrid", "local", "remote"],
+      "minPendingSteps": 5,
+      "eachStepHasDescription": true
+    },
+    "notebook": { "plan": { "exists": false } }
   }
 }

--- a/evals/scenarios/plan-creation-somatic-variants/scenario.json
+++ b/evals/scenarios/plan-creation-somatic-variants/scenario.json
@@ -3,9 +3,9 @@
   "description": "Clinical/researcher persona. Phrasing adapted from the galaxy harness's bioinformatics_workflows.somatic_variant_calling case + claw's clinical-variant-reporter skill. Tests SHELL CONTRACT: did the agent draft a properly-shaped plan? The actual pipeline shape (BWA vs Bowtie, MuTect2 vs Strelka, annotation with VEP vs SnpEff) is content quality, deliberately out of scope here.",
   "tier": 2,
   "requiresModel": true,
-  "loomArgs": ["--tools", "read,write,edit", "--no-skills", "--no-context-files"],
+  "loomArgs": ["--tools", "read,write,edit"],
   "inputs": [
-    "I have matched tumor and normal whole-exome sequencing data. Help me draft a plan in notebook.md to call somatic variants. Follow Loom conventions: `## Plan A: <title> [<routing>]` heading where routing is one of [local|galaxy|hybrid|remote], `### Steps` section, steps as `- [ ] 1. **Step title** -- description with acceptance criteria`. At least 5 pending steps (this is a multi-stage pipeline). Don't execute -- just draft."
+    "I have matched tumor and normal whole-exome sequencing data. Help me draft a plan to call somatic variants. Don't execute anything yet."
   ],
   "timeoutMs": 90000,
   "assertions": {

--- a/evals/scenarios/plan-creation-somatic-variants/scenario.json
+++ b/evals/scenarios/plan-creation-somatic-variants/scenario.json
@@ -1,0 +1,23 @@
+{
+  "name": "plan creation: somatic variant calling from tumor/normal WES",
+  "description": "Clinical/researcher persona. Phrasing adapted from the galaxy harness's bioinformatics_workflows.somatic_variant_calling case + claw's clinical-variant-reporter skill. Tests SHELL CONTRACT: did the agent draft a properly-shaped plan? The actual pipeline shape (BWA vs Bowtie, MuTect2 vs Strelka, annotation with VEP vs SnpEff) is content quality, deliberately out of scope here.",
+  "tier": 2,
+  "requiresModel": true,
+  "loomArgs": ["--tools", "read,write,edit", "--no-skills", "--no-context-files"],
+  "inputs": [
+    "I have matched tumor and normal whole-exome sequencing data. Help me draft a plan in notebook.md to call somatic variants. Follow Loom conventions: `## Plan A: <title> [<routing>]` heading where routing is one of [local|galaxy|hybrid|remote], `### Steps` section, steps as `- [ ] 1. **Step title** -- description with acceptance criteria`. At least 5 pending steps (this is a multi-stage pipeline). Don't execute -- just draft."
+  ],
+  "timeoutMs": 90000,
+  "assertions": {
+    "events": { "mustInclude": ["agent_start", "turn_end"] },
+    "notebook": {
+      "exists": true,
+      "plan": {
+        "exists": true,
+        "routingIn": ["galaxy", "hybrid", "local", "remote"],
+        "minPendingSteps": 5,
+        "eachStepHasDescription": true
+      }
+    }
+  }
+}

--- a/evals/scenarios/plan-creation-somatic-variants/scenario.json
+++ b/evals/scenarios/plan-creation-somatic-variants/scenario.json
@@ -5,9 +5,10 @@
   "requiresModel": true,
   "loomArgs": ["--tools", "read,write,edit"],
   "inputs": [
-    "I have matched tumor and normal whole-exome sequencing data. Help me draft a plan to call somatic variants. Don't execute anything yet."
+    "I have matched tumor and normal whole-exome sequencing data. Help me draft a plan to call somatic variants. Don't execute anything yet.",
+    "Yes, those assumptions are fine. Human, GRCh38, around 100x tumor / 50x normal coverage, illumina paired-end 150bp. Go ahead and draft the formal plan now."
   ],
-  "timeoutMs": 90000,
+  "timeoutMs": 150000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
     "chatPlan": {

--- a/evals/scenarios/smoke-echo/scenario.json
+++ b/evals/scenarios/smoke-echo/scenario.json
@@ -1,6 +1,6 @@
 {
   "name": "smoke: model echoes a fixed token",
-  "description": "Tier 2 sanity check that the matrix runner can spawn loom against each curated model and capture the assistant turn. The prompt asks for a single agreed-upon word; we assert the model says it. No tools, no MCP, no plan -- just verify the model is actually wired in. Cheap and fast on TACC.",
+  "description": "Tier 2 sanity check that the matrix runner can spawn loom against each curated model and capture the assistant turn. The prompt asks for a single agreed-upon word; we assert the model says it. No tools, no MCP, no plan -- just verify the model is actually wired in. Cheap and fast on TACC. The `--no-skills --no-context-files` strip flags are intentional here (they are NOT used on plan-creation scenarios): smoke-echo's job is to verify matrix wiring, so we want the smallest possible system prompt -- removing Loom's hard-constraint block and skills discovery isolates spawn-success from prompt-following. Loom-as-shipped behavior is tested by plan-creation scenarios with the full prompt stack in play.",
   "tier": 2,
   "requiresModel": true,
   "loomArgs": ["--no-tools", "--no-skills", "--no-context-files"],

--- a/evals/scenarios/smoke-echo/scenario.json
+++ b/evals/scenarios/smoke-echo/scenario.json
@@ -1,0 +1,17 @@
+{
+  "name": "smoke: model echoes a fixed token",
+  "description": "Tier 2 sanity check that the matrix runner can spawn loom against each curated model and capture the assistant turn. The prompt asks for a single agreed-upon word; we assert the model says it. No tools, no MCP, no plan -- just verify the model is actually wired in. Cheap and fast on TACC.",
+  "tier": 2,
+  "requiresModel": true,
+  "loomArgs": ["--no-tools", "--no-skills", "--no-context-files"],
+  "inputs": ["Reply with exactly one word: ALPHATAU. Do not say anything else."],
+  "timeoutMs": 60000,
+  "assertions": {
+    "events": {
+      "mustInclude": ["agent_start", "turn_start"]
+    },
+    "chatText": {
+      "mustInclude": ["ALPHATAU"]
+    }
+  }
+}

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -515,7 +515,7 @@ on **indented sub-bullets**. Markdown collapses continuation-indent
 text into the parent line; sub-bullets render as a real nested list.
 
 \`\`\`markdown
-## Plan A: <Title> [local|hybrid|remote]
+## Plan A: <Title> [galaxy|hybrid|local|remote]
 
 <one or two sentences of rationale + research question>
 
@@ -541,8 +541,11 @@ Conventions:
 
 - Use \`{#plan-X-step-N}\` anchors so invocation YAML blocks can reference
   individual steps unambiguously.
-- Routing tag in the section header: \`[local]\`, \`[hybrid]\`, or
-  \`[remote]\`. Tag literal so future tooling can grep.
+- Routing tag in the section header is one of \`[galaxy]\`, \`[hybrid]\`,
+  \`[local]\`, or \`[remote]\`. Default to \`[galaxy]\` when the work has a
+  matching Galaxy workflow/tool; \`[hybrid]\` when some steps are local
+  and some Galaxy; \`[local]\` only for personal-scale or ad-hoc work.
+  Tag literal (lowercase, in square brackets) so tooling can grep.
 - Step routing/tool details go on **sub-bullets**, not on the same line
   as the step heading. Markdown will collapse same-line continuation
   text and the rendered notebook becomes unreadable.

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -529,15 +529,15 @@ the IWC \`bwa-mem-chrM\` workflow. Output: chrM VCF + per-sample QC.
 
 ### Steps
 
-- [ ] 1. **QC FASTQs** {#plan-a-step-1} — fastp adapter trim + per-base QC
+- [ ] 1. **QC FASTQs** — fastp adapter trim + per-base QC
   - Routing: galaxy
   - Tool: fastp
   - Verification: confirm fastp HTML/JSON report exists and includes per-base quality metrics
-- [ ] 2. **Align to chrM reference** {#plan-a-step-2} — BWA-MEM, sorted BAM out
+- [ ] 2. **Align to chrM reference** — BWA-MEM, sorted BAM out
   - Routing: galaxy
   - Tool: bwa_mem
   - Verification: poll Galaxy invocation to `ok` and inspect BAM outputs
-- [ ] 3. **Call variants** {#plan-a-step-3} — bcftools call, filter Q>=30
+- [ ] 3. **Call variants** — bcftools call, filter Q>=30
   - Routing: galaxy
   - Tool: bcftools_call
   - Verification: confirm VCF exists and has variants passing the Q>=30 filter
@@ -565,8 +565,11 @@ Conventions (please re-read the heading line above before drafting):
   and some Galaxy; \`[local]\` only for personal-scale or ad-hoc work.
   Tag literal, lowercase, square brackets, no spaces inside the
   brackets so tooling can grep.
-- Use \`{#plan-X-step-N}\` anchors so invocation YAML blocks can reference
-  individual steps unambiguously.
+- Step anchors (\`{#plan-X-step-N}\` syntax) are supported by the
+  parser but **do not write them**. The litellm proxy in front of some
+  Llama-4 deployments mistakes the curly-brace anchor for a tool-call
+  marker and rejects the response. Reference steps by their step number
+  + plan letter instead (e.g. "Plan A step 2").
 - Step routing/tool details go on **sub-bullets**, not on the same line
   as the step heading. Markdown will collapse same-line continuation
   text and the rendered notebook becomes unreadable.

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -465,7 +465,8 @@ otherwise leave it pending and record the blocker.
 `;
 }
 
-function buildPlanConventionBlock(): string {
+function buildPlanConventionBlock(opts: { omitAnchors?: boolean } = {}): string {
+  const omitAnchors = opts.omitAnchors === true;
   return `## Project model and plan sections
 
 The project is the directory you're working in. \`notebook.md\` is its
@@ -529,15 +530,15 @@ the IWC \`bwa-mem-chrM\` workflow. Output: chrM VCF + per-sample QC.
 
 ### Steps
 
-- [ ] 1. **QC FASTQs** — fastp adapter trim + per-base QC
+- [ ] 1. **QC FASTQs**${anchorOrEmpty("plan-a-step-1", omitAnchors)} — fastp adapter trim + per-base QC
   - Routing: galaxy
   - Tool: fastp
   - Verification: confirm fastp HTML/JSON report exists and includes per-base quality metrics
-- [ ] 2. **Align to chrM reference** — BWA-MEM, sorted BAM out
+- [ ] 2. **Align to chrM reference**${anchorOrEmpty("plan-a-step-2", omitAnchors)} — BWA-MEM, sorted BAM out
   - Routing: galaxy
   - Tool: bwa_mem
   - Verification: poll Galaxy invocation to `ok` and inspect BAM outputs
-- [ ] 3. **Call variants** — bcftools call, filter Q>=30
+- [ ] 3. **Call variants**${anchorOrEmpty("plan-a-step-3", omitAnchors)} — bcftools call, filter Q>=30
   - Routing: galaxy
   - Tool: bcftools_call
   - Verification: confirm VCF exists and has variants passing the Q>=30 filter
@@ -565,11 +566,7 @@ Conventions (please re-read the heading line above before drafting):
   and some Galaxy; \`[local]\` only for personal-scale or ad-hoc work.
   Tag literal, lowercase, square brackets, no spaces inside the
   brackets so tooling can grep.
-- Step anchors (\`{#plan-X-step-N}\` syntax) are supported by the
-  parser but **do not write them**. The litellm proxy in front of some
-  Llama-4 deployments mistakes the curly-brace anchor for a tool-call
-  marker and rejects the response. Reference steps by their step number
-  + plan letter instead (e.g. "Plan A step 2").
+${anchorGuidance(omitAnchors)}
 - Step routing/tool details go on **sub-bullets**, not on the same line
   as the step heading. Markdown will collapse same-line continuation
   text and the rendered notebook becomes unreadable.
@@ -582,6 +579,35 @@ Conventions (please re-read the heading line above before drafting):
 - Multiple plans coexist; append new plan sections at the bottom of the
   notebook. Don't delete old plans.
 `;
+}
+
+/** Render a step anchor only when anchors are safe for the active provider. */
+function anchorOrEmpty(id: string, omit: boolean): string {
+  return omit ? "" : ` {#${id}}`;
+}
+
+/**
+ * Inline guidance about anchors. Two versions:
+ * - Safe providers (Anthropic, OpenAI, Google, etc.): teach anchors so
+ *   invocation YAML blocks can reference steps unambiguously.
+ * - Llama-4 family on litellm-routed proxies: don't write anchors --
+ *   the proxy mistakes the curly-brace `{...}` for a tool-call boundary
+ *   and rejects the whole response as "Invalid function calling output."
+ *   The parser still accepts anchors when present, so existing notebooks
+ *   keep working; we just don't ask the model to produce them.
+ */
+function anchorGuidance(omit: boolean): string {
+  if (omit) {
+    return `- Step anchors (\`{#plan-X-step-N}\` syntax) are supported by the
+  parser but **do not write them**. The litellm proxy in front of this
+  Llama-4 deployment mistakes the curly-brace anchor for a tool-call
+  marker and rejects the response. Reference steps by their step number
+  + plan letter instead (e.g. "Plan A step 2").`;
+  }
+  return `- Use \`{#plan-X-step-N}\` anchors so invocation YAML blocks can
+  reference individual steps unambiguously. Place the anchor after the
+  bold step title and before the description em-dash:
+  \`- [ ] 1. **Step name** {#plan-a-step-1} — description\`.`;
 }
 
 /**
@@ -851,12 +877,29 @@ asks what was said.
 `;
 }
 
+/**
+ * The litellm Llama-4 adapter (used by the SambaNova-on-TACC proxy and
+ * some other Llama-4 deployments) misinterprets `{...}` patterns in
+ * model output as tool-call boundaries and tries to JSON-parse the
+ * contents. Notebook-anchor syntax (`{#plan-a-step-1}`) trips this, so
+ * we suppress anchor guidance for Llama-4 models. Anthropic / OpenAI /
+ * Google / Llama-3 et al. don't have this issue and keep full anchor
+ * support. The init-gate parser accepts anchors when present regardless,
+ * so suppression is fail-soft.
+ */
+function isLlama4ViaLitellm(model: { id?: string; provider?: string } | undefined): boolean {
+  if (!model) return false;
+  const id = (model.id ?? "").toLowerCase();
+  return /llama-?4|maverick|scout/.test(id);
+}
+
 export function setupContextInjection(pi: ExtensionAPI): void {
   pi.on("before_agent_start", async (_event, ctx) => {
+    const omitAnchors = isLlama4ViaLitellm(ctx.model);
     const systemPrompt = [
       buildOperatingDisciplineBlock(),
       buildVerificationDisciplineBlock(),
-      buildPlanConventionBlock(),
+      buildPlanConventionBlock({ omitAnchors }),
       buildParameterReviewBlock(),
       buildChatFormattingBlock(),
       buildNotebookWriteBlock(),

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -537,7 +537,7 @@ the IWC \`bwa-mem-chrM\` workflow. Output: chrM VCF + per-sample QC.
 - [ ] 2. **Align to chrM reference**${anchorOrEmpty("plan-a-step-2", omitAnchors)} — BWA-MEM, sorted BAM out
   - Routing: galaxy
   - Tool: bwa_mem
-  - Verification: poll Galaxy invocation to `ok` and inspect BAM outputs
+  - Verification: poll Galaxy invocation to \`ok\` and inspect BAM outputs
 - [ ] 3. **Call variants**${anchorOrEmpty("plan-a-step-3", omitAnchors)} — bcftools call, filter Q>=30
   - Routing: galaxy
   - Tool: bcftools_call

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -510,42 +510,63 @@ honor it and skip the remaining gates.
 
 ### Plan section template (used in the chat draft AND the notebook write)
 
-Each step is a top-level checklist item with its routing and tool(s)
-on **indented sub-bullets**. Markdown collapses continuation-indent
-text into the parent line; sub-bullets render as a real nested list.
+The heading line is rigid: \`## Plan <Letter>: <Title> [<routing>]\`,
+with a literal letter (\`A\`, \`B\`, \`C\` -- pick the next free one),
+a colon, the human-readable title, and a routing tag in literal
+square brackets. Each step is a top-level checklist item with routing
+and tool(s) on **indented sub-bullets**. Markdown collapses
+continuation-indent text into the parent line; sub-bullets render as
+a real nested list.
+
+Worked example -- copy this shape exactly, just substitute domain
+content:
 
 \`\`\`markdown
-## Plan A: <Title> [galaxy|hybrid|local|remote]
+## Plan A: chrM Variant Calling [galaxy]
 
-<one or two sentences of rationale + research question>
+Identify mitochondrial variants from 4 paired-end WGS samples using
+the IWC \`bwa-mem-chrM\` workflow. Output: chrM VCF + per-sample QC.
 
 ### Steps
 
-- [ ] 1. **<Step name>** {#plan-a-step-1} — <one-line purpose>
-  - Routing: local
-  - Tool: <tool-name-or-galaxy-id>
-  - Verification: <concrete check before this step can be marked complete>
-- [ ] 2. **<Step name>** {#plan-a-step-2} — <one-line purpose>
-  - Routing: Galaxy
-  - Tool: <galaxy-tool-id>
-  - Verification: <Galaxy status/output inspection that proves it worked>
+- [ ] 1. **QC FASTQs** {#plan-a-step-1} — fastp adapter trim + per-base QC
+  - Routing: galaxy
+  - Tool: fastp
+  - Verification: confirm fastp HTML/JSON report exists and includes per-base quality metrics
+- [ ] 2. **Align to chrM reference** {#plan-a-step-2} — BWA-MEM, sorted BAM out
+  - Routing: galaxy
+  - Tool: bwa_mem
+  - Verification: poll Galaxy invocation to `ok` and inspect BAM outputs
+- [ ] 3. **Call variants** {#plan-a-step-3} — bcftools call, filter Q>=30
+  - Routing: galaxy
+  - Tool: bcftools_call
+  - Verification: confirm VCF exists and has variants passing the Q>=30 filter
 
 ### Parameters
 
 | Step | Tool | Parameter | Default | Value | Description |
 | --- | --- | --- | --- | --- | --- |
-| 1   | ... | ...       | ...     | ...   | ...         |
+| 1   | fastp     | --qualified_quality_phred | 15 | 20 | min Phred to keep |
+| 2   | bwa_mem   | --threads                 | 4  | 8  | parallel threads  |
+| 3   | bcftools_call | -p                    | 0.5 | 0.01 | call threshold  |
 \`\`\`
 
-Conventions:
+Conventions (please re-read the heading line above before drafting):
 
-- Use \`{#plan-X-step-N}\` anchors so invocation YAML blocks can reference
-  individual steps unambiguously.
+- Heading **must** be \`## Plan <Letter>: <Title> [<routing>]\`.
+  Examples that pass: \`## Plan A: RNA-seq DE [galaxy]\`,
+  \`## Plan B: Quick local QC [local]\`. Examples that **fail** and
+  must be avoided: \`## Plan: ...\` (missing letter),
+  \`## Plan A: ...\` (missing routing tag),
+  \`## Plan A - Title [galaxy]\` (dash instead of colon).
 - Routing tag in the section header is one of \`[galaxy]\`, \`[hybrid]\`,
   \`[local]\`, or \`[remote]\`. Default to \`[galaxy]\` when the work has a
   matching Galaxy workflow/tool; \`[hybrid]\` when some steps are local
   and some Galaxy; \`[local]\` only for personal-scale or ad-hoc work.
-  Tag literal (lowercase, in square brackets) so tooling can grep.
+  Tag literal, lowercase, square brackets, no spaces inside the
+  brackets so tooling can grep.
+- Use \`{#plan-X-step-N}\` anchors so invocation YAML blocks can reference
+  individual steps unambiguously.
 - Step routing/tool details go on **sub-bullets**, not on the same line
   as the step heading. Markdown will collapse same-line continuation
   text and the rendered notebook becomes unreadable.

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -878,16 +878,26 @@ asks what was said.
 }
 
 /**
- * The litellm Llama-4 adapter (used by the SambaNova-on-TACC proxy and
- * some other Llama-4 deployments) misinterprets `{...}` patterns in
- * model output as tool-call boundaries and tries to JSON-parse the
- * contents. Notebook-anchor syntax (`{#plan-a-step-1}`) trips this, so
- * we suppress anchor guidance for Llama-4 models. Anthropic / OpenAI /
- * Google / Llama-3 et al. don't have this issue and keep full anchor
- * support. The init-gate parser accepts anchors when present regardless,
- * so suppression is fail-soft.
+ * Heuristic id-based detector for Llama-4 family models. The actual bug
+ * we're working around lives in the litellm Llama-4 adapter (used by the
+ * SambaNova-on-TACC proxy and some other Llama-4 deployments): it
+ * misinterprets `{...}` patterns in model output as tool-call boundaries
+ * and tries to JSON-parse the contents, so notebook-anchor syntax
+ * (`{#plan-a-step-1}`) trips it and gets rejected as "Invalid function
+ * calling output." We don't have a clean signal for "is this model
+ * behind a buggy litellm adapter," so we approximate it by detecting
+ * Llama-4 in the model id and suppressing anchor guidance for the whole
+ * family. Trade-offs:
+ *   - False positive (Llama-4 on a non-buggy adapter): the model loses
+ *     anchor guidance and references steps by "Plan A step 2" instead;
+ *     no functional regression.
+ *   - False negative (some other model behind the same buggy proxy):
+ *     would re-surface "Invalid function calling output" -- not seen in
+ *     the matrix today.
+ *   - Init-gate parser accepts anchors when present regardless of which
+ *     prompt path ran, so swapping providers mid-project is fail-soft.
  */
-function isLlama4ViaLitellm(model: { id?: string; provider?: string } | undefined): boolean {
+function isLlama4Family(model: { id?: string; provider?: string } | undefined): boolean {
   if (!model) return false;
   const id = (model.id ?? "").toLowerCase();
   return /llama-?4|maverick|scout/.test(id);
@@ -895,7 +905,7 @@ function isLlama4ViaLitellm(model: { id?: string; provider?: string } | undefine
 
 export function setupContextInjection(pi: ExtensionAPI): void {
   pi.on("before_agent_start", async (_event, ctx) => {
-    const omitAnchors = isLlama4ViaLitellm(ctx.model);
+    const omitAnchors = isLlama4Family(ctx.model);
     const systemPrompt = [
       buildOperatingDisciplineBlock(),
       buildVerificationDisciplineBlock(),

--- a/extensions/loom/sync-command.ts
+++ b/extensions/loom/sync-command.ts
@@ -7,162 +7,151 @@
  * them from the chat without going through the agent.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getNotebookPath } from "./state";
 import { readNotebook } from "./notebook-writer";
 import { findGalaxyPageBlocks } from "./galaxy-page-binding";
 import {
-    pushNotebookToGalaxy,
-    pullNotebookFromGalaxy,
-    linkGalaxyPage,
-    resumeGalaxyPage,
+  pushNotebookToGalaxy,
+  pullNotebookFromGalaxy,
+  linkGalaxyPage,
+  resumeGalaxyPage,
 } from "./galaxy-pages-sync";
 
 interface ParsedFlags {
-    positional: string[];
-    flags: Record<string, string | undefined>;
+  positional: string[];
+  flags: Record<string, string | undefined>;
 }
 
 function parseFlags(input: string): ParsedFlags {
-    const tokens =
-        input.match(/(?:--[a-z-]+(?:=(?:"[^"]*"|\S+))?|"[^"]*"|\S+)/gi) ?? [];
-    const positional: string[] = [];
-    const flags: Record<string, string | undefined> = {};
-    for (let i = 0; i < tokens.length; i++) {
-        const t = tokens[i];
-        if (t.startsWith("--")) {
-            const eq = t.indexOf("=");
-            if (eq >= 0) {
-                const k = t.slice(2, eq);
-                const v = t.slice(eq + 1).replace(/^"|"$/g, "");
-                flags[k] = v;
-            } else {
-                const k = t.slice(2);
-                const next = tokens[i + 1];
-                if (next && !next.startsWith("--")) {
-                    flags[k] = next.replace(/^"|"$/g, "");
-                    i++;
-                } else {
-                    flags[k] = "";
-                }
-            }
+  const tokens = input.match(/(?:--[a-z-]+(?:=(?:"[^"]*"|\S+))?|"[^"]*"|\S+)/gi) ?? [];
+  const positional: string[] = [];
+  const flags: Record<string, string | undefined> = {};
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t.startsWith("--")) {
+      const eq = t.indexOf("=");
+      if (eq >= 0) {
+        const k = t.slice(2, eq);
+        const v = t.slice(eq + 1).replace(/^"|"$/g, "");
+        flags[k] = v;
+      } else {
+        const k = t.slice(2);
+        const next = tokens[i + 1];
+        if (next && !next.startsWith("--")) {
+          flags[k] = next.replace(/^"|"$/g, "");
+          i++;
         } else {
-            positional.push(t.replace(/^"|"$/g, ""));
+          flags[k] = "";
         }
+      }
+    } else {
+      positional.push(t.replace(/^"|"$/g, ""));
     }
-    return { positional, flags };
+  }
+  return { positional, flags };
 }
 
 export function registerSyncCommand(pi: ExtensionAPI): void {
-    pi.registerCommand("sync", {
-        description:
-            "Sync notebook.md with a Galaxy page. Subcommands: status | push [--history H --title T --slug S --annotation A] | pull | link <page_id> [--history H] | resume <page_id> [--history H]",
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        handler: async (args: string, ctx: any) => {
-            const trimmed = (args ?? "").trim();
-            const firstSpace = trimmed.indexOf(" ");
-            const subcommand =
-                firstSpace === -1 ? trimmed || "status" : trimmed.slice(0, firstSpace);
-            const tail = firstSpace === -1 ? "" : trimmed.slice(firstSpace + 1);
-            const { positional, flags } = parseFlags(tail);
+  pi.registerCommand("sync", {
+    description:
+      "Sync notebook.md with a Galaxy page. Subcommands: status | push [--history H --title T --slug S --annotation A] | pull | link <page_id> [--history H] | resume <page_id> [--history H]",
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    handler: async (args: string, ctx: any) => {
+      const trimmed = (args ?? "").trim();
+      const firstSpace = trimmed.indexOf(" ");
+      const subcommand = firstSpace === -1 ? trimmed || "status" : trimmed.slice(0, firstSpace);
+      const tail = firstSpace === -1 ? "" : trimmed.slice(firstSpace + 1);
+      const { positional, flags } = parseFlags(tail);
 
-            try {
-                if (subcommand === "status") {
-                    const nbPath = getNotebookPath();
-                    if (!nbPath) {
-                        ctx.ui.notify(
-                            "No active loom session; nothing to sync.",
-                            "warning",
-                        );
-                        return;
-                    }
-                    const content = await readNotebook(nbPath);
-                    const binding = findGalaxyPageBlocks(content)[0];
-                    if (!binding) {
-                        ctx.ui.notify(
-                            "Notebook is not bound to a Galaxy page. Use `/sync push --history <id>` to create one, or `/sync link <page_id>` to link an existing page.",
-                            "info",
-                        );
-                        return;
-                    }
-                    ctx.ui.notify(
-                        `Bound to ${binding.galaxyServerUrl} (page_id=${binding.pageId}, slug=${binding.pageSlug ?? "<none>"}, last_synced_revision=${binding.lastSyncedRevision ?? "<none>"})`,
-                        "info",
-                    );
-                    return;
-                }
+      try {
+        if (subcommand === "status") {
+          const nbPath = getNotebookPath();
+          if (!nbPath) {
+            ctx.ui.notify("No active loom session; nothing to sync.", "warning");
+            return;
+          }
+          const content = await readNotebook(nbPath);
+          const binding = findGalaxyPageBlocks(content)[0];
+          if (!binding) {
+            ctx.ui.notify(
+              "Notebook is not bound to a Galaxy page. Use `/sync push --history <id>` to create one, or `/sync link <page_id>` to link an existing page.",
+              "info",
+            );
+            return;
+          }
+          ctx.ui.notify(
+            `Bound to ${binding.galaxyServerUrl} (page_id=${binding.pageId}, slug=${binding.pageSlug ?? "<none>"}, last_synced_revision=${binding.lastSyncedRevision ?? "<none>"})`,
+            "info",
+          );
+          return;
+        }
 
-                if (subcommand === "push") {
-                    const result = await pushNotebookToGalaxy({
-                        historyId: flags.history,
-                        title: flags.title,
-                        slug: flags.slug,
-                        annotation: flags.annotation,
-                    });
-                    ctx.ui.notify(
-                        `Pushed: ${result.action} page ${result.pageId} (revision ${result.latestRevisionId}).`,
-                        "info",
-                    );
-                    return;
-                }
+        if (subcommand === "push") {
+          const result = await pushNotebookToGalaxy({
+            historyId: flags.history,
+            title: flags.title,
+            slug: flags.slug,
+            annotation: flags.annotation,
+          });
+          ctx.ui.notify(
+            `Pushed: ${result.action} page ${result.pageId} (revision ${result.latestRevisionId}).`,
+            "info",
+          );
+          return;
+        }
 
-                if (subcommand === "pull") {
-                    const result = await pullNotebookFromGalaxy();
-                    ctx.ui.notify(
-                        `Pulled page ${result.pageId} (revision ${result.latestRevisionId}). Notebook updated.`,
-                        "info",
-                    );
-                    return;
-                }
+        if (subcommand === "pull") {
+          const result = await pullNotebookFromGalaxy();
+          ctx.ui.notify(
+            `Pulled page ${result.pageId} (revision ${result.latestRevisionId}). Notebook updated.`,
+            "info",
+          );
+          return;
+        }
 
-                if (subcommand === "link") {
-                    const pageId = positional[0];
-                    if (!pageId) {
-                        ctx.ui.notify(
-                            "Usage: /sync link <page_id> [--history <id>]",
-                            "warning",
-                        );
-                        return;
-                    }
-                    const result = await linkGalaxyPage(pageId, {
-                        historyId: flags.history,
-                    });
-                    ctx.ui.notify(
-                        `Linked to page ${result.pageId} (revision ${result.latestRevisionId}).`,
-                        "info",
-                    );
-                    return;
-                }
+        if (subcommand === "link") {
+          const pageId = positional[0];
+          if (!pageId) {
+            ctx.ui.notify("Usage: /sync link <page_id> [--history <id>]", "warning");
+            return;
+          }
+          const result = await linkGalaxyPage(pageId, {
+            historyId: flags.history,
+          });
+          ctx.ui.notify(
+            `Linked to page ${result.pageId} (revision ${result.latestRevisionId}).`,
+            "info",
+          );
+          return;
+        }
 
-                if (subcommand === "resume") {
-                    const pageId = positional[0];
-                    if (!pageId) {
-                        ctx.ui.notify(
-                            "Usage: /sync resume <page_id> [--history <id>]",
-                            "warning",
-                        );
-                        return;
-                    }
-                    const result = await resumeGalaxyPage(pageId, {
-                        historyId: flags.history,
-                    });
-                    ctx.ui.notify(
-                        `Resumed page ${result.pageId} (${result.action}, revision ${result.latestRevisionId}). Notebook updated.`,
-                        "info",
-                    );
-                    return;
-                }
+        if (subcommand === "resume") {
+          const pageId = positional[0];
+          if (!pageId) {
+            ctx.ui.notify("Usage: /sync resume <page_id> [--history <id>]", "warning");
+            return;
+          }
+          const result = await resumeGalaxyPage(pageId, {
+            historyId: flags.history,
+          });
+          ctx.ui.notify(
+            `Resumed page ${result.pageId} (${result.action}, revision ${result.latestRevisionId}). Notebook updated.`,
+            "info",
+          );
+          return;
+        }
 
-                ctx.ui.notify(
-                    `Unknown /sync subcommand: ${subcommand}. Use status, push, pull, link, or resume.`,
-                    "warning",
-                );
-            } catch (e) {
-                ctx.ui.notify(
-                    `/sync ${subcommand}: ${e instanceof Error ? e.message : String(e)}`,
-                    "error",
-                );
-            }
-        },
-    });
+        ctx.ui.notify(
+          `Unknown /sync subcommand: ${subcommand}. Use status, push, pull, link, or resume.`,
+          "warning",
+        );
+      } catch (e) {
+        ctx.ui.notify(
+          `/sync ${subcommand}: ${e instanceof Error ? e.message : String(e)}`,
+          "error",
+        );
+      }
+    },
+  });
 }

--- a/extensions/loom/tools-sync.ts
+++ b/extensions/loom/tools-sync.ts
@@ -7,134 +7,132 @@
  * response for the agent.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import {
-    pushNotebookToGalaxy,
-    pullNotebookFromGalaxy,
-    linkGalaxyPage,
-    resumeGalaxyPage,
+  pushNotebookToGalaxy,
+  pullNotebookFromGalaxy,
+  linkGalaxyPage,
+  resumeGalaxyPage,
 } from "./galaxy-pages-sync";
 
 function errorContent(e: unknown) {
-    return {
-        content: [
-            {
-                type: "text" as const,
-                text: `Error: ${e instanceof Error ? e.message : String(e)}`,
-            },
-        ],
-        details: { error: true },
-    };
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Error: ${e instanceof Error ? e.message : String(e)}`,
+      },
+    ],
+    details: { error: true },
+  };
 }
 
 export function registerNotebookSyncTools(pi: ExtensionAPI): void {
-    pi.registerTool({
-        name: "notebook_push_to_galaxy",
-        label: "Push notebook to Galaxy page",
-        description: `Push the local notebook.md to a Galaxy page. If the notebook already
+  pi.registerTool({
+    name: "notebook_push_to_galaxy",
+    label: "Push notebook to Galaxy page",
+    description: `Push the local notebook.md to a Galaxy page. If the notebook already
 has a loom-galaxy-page binding block, updates that page in place (creates a
 new revision). If there's no binding yet, pass history_id (and optionally title,
 slug, annotation) to create a new page attached to that history and bind it.
 Strips loom-galaxy-page blocks from the body sent to Galaxy, but keeps
 loom-invocation blocks (they're analysis content). Unconditional local-wins:
 any concurrent Galaxy-UI edits since the last sync are overwritten.`,
-        parameters: Type.Object({
-            history_id: Type.Optional(
-                Type.String({
-                    description:
-                        "History ID to attach the page to (required when creating a new page).",
-                }),
-            ),
-            title: Type.Optional(
-                Type.String({
-                    description:
-                        "Page title for create. Defaults to 'Untitled notebook' if omitted.",
-                }),
-            ),
-            slug: Type.Optional(
-                Type.String({
-                    description:
-                        "URL slug for create. Lowercase letters, digits, and hyphens. Auto-generated if omitted.",
-                }),
-            ),
-            annotation: Type.Optional(
-                Type.String({
-                    description: "Optional annotation attached to the page.",
-                }),
-            ),
+    parameters: Type.Object({
+      history_id: Type.Optional(
+        Type.String({
+          description: "History ID to attach the page to (required when creating a new page).",
         }),
-        async execute(_callId, params, _signal, _onUpdate, _ctx) {
-            try {
-                const result = await pushNotebookToGalaxy({
-                    historyId: params.history_id,
-                    title: params.title,
-                    slug: params.slug,
-                    annotation: params.annotation,
-                });
-                return {
-                    content: [
-                        {
-                            type: "text" as const,
-                            text: JSON.stringify(
-                                {
-                                    page_id: result.pageId,
-                                    page_slug: result.pageSlug,
-                                    latest_revision_id: result.latestRevisionId,
-                                    action: result.action,
-                                },
-                                null,
-                                2,
-                            ),
-                        },
-                    ],
-                    details: { pageId: result.pageId, action: result.action },
-                };
-            } catch (e) {
-                return errorContent(e);
-            }
-        },
-    });
+      ),
+      title: Type.Optional(
+        Type.String({
+          description: "Page title for create. Defaults to 'Untitled notebook' if omitted.",
+        }),
+      ),
+      slug: Type.Optional(
+        Type.String({
+          description:
+            "URL slug for create. Lowercase letters, digits, and hyphens. Auto-generated if omitted.",
+        }),
+      ),
+      annotation: Type.Optional(
+        Type.String({
+          description: "Optional annotation attached to the page.",
+        }),
+      ),
+    }),
+    async execute(_callId, params, _signal, _onUpdate, _ctx) {
+      try {
+        const result = await pushNotebookToGalaxy({
+          historyId: params.history_id,
+          title: params.title,
+          slug: params.slug,
+          annotation: params.annotation,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  page_id: result.pageId,
+                  page_slug: result.pageSlug,
+                  latest_revision_id: result.latestRevisionId,
+                  action: result.action,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          details: { pageId: result.pageId, action: result.action },
+        };
+      } catch (e) {
+        return errorContent(e);
+      }
+    },
+  });
 
-    pi.registerTool({
-        name: "notebook_pull_from_galaxy",
-        label: "Pull notebook from Galaxy page",
-        description: `Replace the local notebook.md with the body of the linked Galaxy page,
+  pi.registerTool({
+    name: "notebook_pull_from_galaxy",
+    label: "Pull notebook from Galaxy page",
+    description: `Replace the local notebook.md with the body of the linked Galaxy page,
 then re-apply the loom-galaxy-page binding block on top. Requires the
 notebook to already have a binding (use notebook_link_galaxy_page or
 notebook_push_to_galaxy first). Unconditional remote-wins: any local edits
 since the last sync are overwritten, including loom-invocation blocks
 that weren't pushed yet.`,
-        parameters: Type.Object({}),
-        async execute(_callId, _params, _signal, _onUpdate, _ctx) {
-            try {
-                const result = await pullNotebookFromGalaxy();
-                return {
-                    content: [
-                        {
-                            type: "text" as const,
-                            text: JSON.stringify(
-                                {
-                                    page_id: result.pageId,
-                                    latest_revision_id: result.latestRevisionId,
-                                },
-                                null,
-                                2,
-                            ),
-                        },
-                    ],
-                    details: { pageId: result.pageId },
-                };
-            } catch (e) {
-                return errorContent(e);
-            }
-        },
-    });
+    parameters: Type.Object({}),
+    async execute(_callId, _params, _signal, _onUpdate, _ctx) {
+      try {
+        const result = await pullNotebookFromGalaxy();
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  page_id: result.pageId,
+                  latest_revision_id: result.latestRevisionId,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          details: { pageId: result.pageId },
+        };
+      } catch (e) {
+        return errorContent(e);
+      }
+    },
+  });
 
-    pi.registerTool({
-        name: "notebook_resume_from_galaxy",
-        label: "Resume notebook from Galaxy page",
-        description: `One-shot resume of a Galaxy page into the local notebook: writes the
+  pi.registerTool({
+    name: "notebook_resume_from_galaxy",
+    label: "Resume notebook from Galaxy page",
+    description: `One-shot resume of a Galaxy page into the local notebook: writes the
 loom-galaxy-page binding block and replaces local content with the remote
 page body in a single locked operation. Use this when starting a fresh
 Loom session against a page that was created or last edited in the Galaxy
@@ -142,87 +140,85 @@ UI -- it saves the user from having to do notebook_link_galaxy_page then
 notebook_pull_from_galaxy. Refuses to clobber when the notebook is already
 bound to a different page on the same server (use notebook_link_galaxy_page
 to switch explicitly). Idempotent when re-resuming the same page.`,
-        parameters: Type.Object({
-            page_id: Type.String({
-                description: "Encoded page id (or slug) to resume from.",
-            }),
-            history_id: Type.Optional(
-                Type.String({
-                    description:
-                        "History id; only needed if Galaxy's page response doesn't include one.",
-                }),
-            ),
+    parameters: Type.Object({
+      page_id: Type.String({
+        description: "Encoded page id (or slug) to resume from.",
+      }),
+      history_id: Type.Optional(
+        Type.String({
+          description: "History id; only needed if Galaxy's page response doesn't include one.",
         }),
-        async execute(_callId, params, _signal, _onUpdate, _ctx) {
-            try {
-                const result = await resumeGalaxyPage(params.page_id, {
-                    historyId: params.history_id,
-                });
-                return {
-                    content: [
-                        {
-                            type: "text" as const,
-                            text: JSON.stringify(
-                                {
-                                    page_id: result.pageId,
-                                    latest_revision_id: result.latestRevisionId,
-                                    action: result.action,
-                                },
-                                null,
-                                2,
-                            ),
-                        },
-                    ],
-                    details: { pageId: result.pageId, action: result.action },
-                };
-            } catch (e) {
-                return errorContent(e);
-            }
-        },
-    });
+      ),
+    }),
+    async execute(_callId, params, _signal, _onUpdate, _ctx) {
+      try {
+        const result = await resumeGalaxyPage(params.page_id, {
+          historyId: params.history_id,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  page_id: result.pageId,
+                  latest_revision_id: result.latestRevisionId,
+                  action: result.action,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          details: { pageId: result.pageId, action: result.action },
+        };
+      } catch (e) {
+        return errorContent(e);
+      }
+    },
+  });
 
-    pi.registerTool({
-        name: "notebook_link_galaxy_page",
-        label: "Link notebook to existing Galaxy page",
-        description: `Bind the local notebook.md to an existing Galaxy page without pushing
+  pi.registerTool({
+    name: "notebook_link_galaxy_page",
+    label: "Link notebook to existing Galaxy page",
+    description: `Bind the local notebook.md to an existing Galaxy page without pushing
 or pulling content. Inserts a loom-galaxy-page block with the page's id,
 slug, server URL, and latest revision id. Use this when an analysis was
 started in the Galaxy UI and the user wants Loom to take over editing.`,
-        parameters: Type.Object({
-            page_id: Type.String({
-                description: "Encoded page id (or slug) to link to.",
-            }),
-            history_id: Type.Optional(
-                Type.String({
-                    description:
-                        "History id; only needed if Galaxy's page response doesn't include one.",
-                }),
-            ),
+    parameters: Type.Object({
+      page_id: Type.String({
+        description: "Encoded page id (or slug) to link to.",
+      }),
+      history_id: Type.Optional(
+        Type.String({
+          description: "History id; only needed if Galaxy's page response doesn't include one.",
         }),
-        async execute(_callId, params, _signal, _onUpdate, _ctx) {
-            try {
-                const result = await linkGalaxyPage(params.page_id, {
-                    historyId: params.history_id,
-                });
-                return {
-                    content: [
-                        {
-                            type: "text" as const,
-                            text: JSON.stringify(
-                                {
-                                    page_id: result.pageId,
-                                    latest_revision_id: result.latestRevisionId,
-                                },
-                                null,
-                                2,
-                            ),
-                        },
-                    ],
-                    details: { pageId: result.pageId },
-                };
-            } catch (e) {
-                return errorContent(e);
-            }
-        },
-    });
+      ),
+    }),
+    async execute(_callId, params, _signal, _onUpdate, _ctx) {
+      try {
+        const result = await linkGalaxyPage(params.page_id, {
+          historyId: params.history_id,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  page_id: result.pageId,
+                  latest_revision_id: result.latestRevisionId,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          details: { pageId: result.pageId },
+        };
+      } catch (e) {
+        return errorContent(e);
+      }
+    },
+  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "prettier": "^3.8.3",
+        "tsx": "^4.21.0",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.59.1",
         "vitest": "^4.1.4"
@@ -2662,6 +2663,448 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -5042,6 +5485,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escalade": {
@@ -8509,6 +8994,25 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prepare": "husky",
     "test": "vitest run",
     "test:watch": "vitest",
+    "evals": "tsx evals/run.ts",
     "typecheck": "tsc --noEmit",
     "smoke:pack": "node scripts/smoke-pack.mjs",
     "prepublishOnly": "npm run typecheck && npm test && npm run smoke:pack"
@@ -75,6 +76,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.3",
+    "tsx": "^4.21.0",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.59.1",
     "vitest": "^4.1.4"

--- a/tests/evals-notebook-parser.test.ts
+++ b/tests/evals-notebook-parser.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import { parseLatestPlan } from "../evals/lib/notebook-parser";
+
+describe("evals notebook-parser: parseLatestPlan", () => {
+  it("returns null when no `## Plan X:` heading is present", () => {
+    expect(parseLatestPlan("just some prose, no plan here")).toBeNull();
+    expect(parseLatestPlan("## Notes\n\nstuff")).toBeNull();
+  });
+
+  it("parses the heading line and routing tag", () => {
+    const plan = parseLatestPlan(
+      ["## Plan A: RNA-seq DE [galaxy]", "", "### Steps", "- [ ] 1. **Align** -- bwa step"].join(
+        "\n",
+      ),
+    );
+    expect(plan).not.toBeNull();
+    expect(plan!.title).toBe("A: RNA-seq DE");
+    expect(plan!.routing).toBe("galaxy");
+    expect(plan!.pendingSteps).toHaveLength(1);
+  });
+
+  it("returns the LATEST plan when the doc has multiple", () => {
+    const content = [
+      "## Plan A: Old plan [local]",
+      "- [ ] 1. **Old step** -- old description",
+      "",
+      "## Plan B: New plan [hybrid]",
+      "- [ ] 1. **New step** -- new description",
+    ].join("\n");
+    const plan = parseLatestPlan(content);
+    expect(plan!.title).toBe("B: New plan");
+    expect(plan!.routing).toBe("hybrid");
+  });
+
+  it("returns routing='unknown' when the heading has no routing tag", () => {
+    const plan = parseLatestPlan("## Plan A: Untagged\n- [ ] 1. **Step** -- desc");
+    expect(plan).not.toBeNull();
+    expect(plan!.routing).toBe("unknown");
+  });
+
+  it("ignores completed steps and only collects `- [ ]` pending ones", () => {
+    const content = [
+      "## Plan A: Mixed [galaxy]",
+      "- [x] 1. **Done step** -- already finished",
+      "- [ ] 2. **Pending step** -- still to do",
+      "- [x] 3. **Also done** -- finished too",
+    ].join("\n");
+    const plan = parseLatestPlan(content);
+    expect(plan!.pendingSteps).toHaveLength(1);
+    expect(plan!.pendingSteps[0].raw).toContain("Pending step");
+  });
+
+  it("folds sub-bullet text into the description length", () => {
+    // Same step rendered two ways: title-only main line, content lives on sub-bullets.
+    // Some models (Qwen3, Maverick) write plans this way; the parser must count it
+    // as a real description rather than flagging the step as skinny.
+    const content = [
+      "## Plan A: Galaxy work [galaxy]",
+      "- [ ] 1. **Trim adapters**",
+      "  - Routing: galaxy",
+      "  - Tool: fastp",
+    ].join("\n");
+    const plan = parseLatestPlan(content);
+    expect(plan!.pendingSteps).toHaveLength(1);
+    // sub-bullet text is "Routing: galaxy Tool: fastp" -> well above the 8-char gate
+    expect(plan!.pendingSteps[0].descriptionLength).toBeGreaterThanOrEqual(8);
+  });
+
+  it("flags genuinely skinny steps (title only, no sub-bullets) below the 8-char gate", () => {
+    const content = ["## Plan A: Skinny [galaxy]", "- [ ] 1. **X**"].join("\n");
+    const plan = parseLatestPlan(content);
+    expect(plan!.pendingSteps[0].descriptionLength).toBeLessThan(8);
+  });
+
+  it("strips `{#plan-X-step-N}` anchors from the description measurement", () => {
+    // Anchors are syntactic scaffolding for invocation YAML refs, not content.
+    // Two steps with identical descriptions but one anchored should measure the same.
+    const anchored = parseLatestPlan(
+      "## Plan A: Anchored [galaxy]\n- [ ] 1. **Step** {#plan-a-step-1} -- align reads",
+    );
+    const plain = parseLatestPlan("## Plan A: Plain [galaxy]\n- [ ] 1. **Step** -- align reads");
+    expect(anchored!.pendingSteps[0].descriptionLength).toBe(
+      plain!.pendingSteps[0].descriptionLength,
+    );
+  });
+
+  it("stops collecting sub-bullets at the next top-level step", () => {
+    // The sub-bullet between steps 1 and 2 belongs to step 1, not step 2.
+    const content = [
+      "## Plan A: Two steps [galaxy]",
+      "- [ ] 1. **First**",
+      "  - sub-bullet for first",
+      "- [ ] 2. **Second** -- on the same line",
+    ].join("\n");
+    const plan = parseLatestPlan(content);
+    expect(plan!.pendingSteps).toHaveLength(2);
+    expect(plan!.pendingSteps[0].descriptionLength).toBeGreaterThanOrEqual(8);
+    expect(plan!.pendingSteps[1].descriptionLength).toBeGreaterThanOrEqual(8);
+  });
+
+  it("stops collecting sub-bullets at the next `##` section", () => {
+    const content = [
+      "## Plan A: One step [galaxy]",
+      "- [ ] 1. **Step**",
+      "  - sub belongs to step",
+      "## Parameters",
+      "  - this paragraph is NOT a sub-bullet of the step",
+    ].join("\n");
+    const plan = parseLatestPlan(content);
+    expect(plan!.pendingSteps).toHaveLength(1);
+    // "sub belongs to step" -> 19 chars; the next-section paragraph must not bleed in.
+    expect(plan!.pendingSteps[0].descriptionLength).toBe("sub belongs to step".length);
+  });
+
+  it("treats `[Galaxy]` (capitalized) as the galaxy routing tag", () => {
+    const plan = parseLatestPlan("## Plan A: Caps [Galaxy]\n- [ ] 1. **Step** -- desc");
+    expect(plan!.routing).toBe("galaxy");
+  });
+});


### PR DESCRIPTION
Phase 1+2 of the eval plan: scenario-driven runner that spawns
`loom --mode json` non-interactively against a fixture cwd, captures the
JSON event stream, and asserts on tool calls / chat text / final
notebook state. Tier 2 scenarios cross-product against a curated model
matrix (`evals/models.json`); first-class Pi providers (anthropic,
openai, google) need only their API key set, OpenAI-compatible custom
providers (TACC SambaNova proxy, litellm) declare a `providerConfig`
block and the runner synthesizes a Pi `models.json` into the temp agent
dir before spawning. Models with missing env vars are skipped (not
failed), so contributors without every credential can still exercise
the subset they have. Run: `npm run evals` (filter with
`-- <scenario>` and/or `-- --model <id>`).

Seven scenarios in this PR:

- `init-gate-galaxy-no-connection` (Tier 1) -- `/execute` must hard-fail
  before any LLM call when the latest plan is `[galaxy]` but no Galaxy
  connection is active. Exercises the slash-command preflight without
  needing model auth.
- `smoke-echo` (Tier 2) -- "reply with this token, nothing else,"
  `--no-skills --no-context-files` to isolate matrix wiring from
  prompt-following. Passes on all three TACC models.
- `plan-creation-{rnaseq, scrna-celltypes, somatic-variants,
  pharmacogenomics, metagenomics}` (Tier 2) -- two-turn naturalistic
  asks across bioinformatics domains and registers; structural
  assertion is "by end of run, a `## Plan X: <title> [<routing>]` block
  with N+ pending steps lives in notebook.md."

Running the matrix surfaced three Loom-side prompt regressions that the
suite is now wired to catch. Each landed as its own atomic commit; the
full play-by-play is in `evals/findings.md`:

1. The plan-section template's routing-tag enum listed
   `[local|hybrid|remote]` but every other piece of Loom (init-gate
   parser, AGENTS.md hard constraints, `execution-commands.ts`) treats
   `[galaxy]` as a first-class option and the default. Result: every
   model picked `[local]` regardless of how Galaxy-flavored the request
   was. Fix lists `[galaxy]` first and spells out when each tag applies.

2. The plan-section template used abstract `<Title>` / `<routing>` /
   `<Step name>` placeholders. Llama-3.3-70B kept dropping the letter
   and the routing tag and emitting `## Plan: <title>`. Replaced with a
   concrete worked example (`## Plan A: chrM Variant Calling [galaxy]`
   with three real steps and a populated parameter table) plus an
   explicit pass/fail list of what the heading line must look like.
   Llama-3.3 went from 0% heading-correct to ~100%.

3. The template taught models to write `{#plan-a-step-N}` step anchors.
   The litellm Llama-4 adapter on the SambaNova-on-TACC proxy mistakes
   any `{...}` pattern in the model's chat output for a tool-call
   boundary, fails to JSON-parse the contents, and rejects the whole
   response as "Invalid function calling output." Conditional fix: a
   small `isLlama4Family` detector reads `ctx.model.id` in
   `setupContextInjection` and passes `omitAnchors: true` to
   `buildPlanConventionBlock` only for Llama-4 model ids
   (`/llama-?4|maverick|scout/i`). Anthropic / OpenAI / Google /
   Llama-3 / Qwen3 keep full anchor guidance, so Opus/Sonnet production
   behavior is unchanged. Init-gate parser accepts anchors when present
   regardless of which prompt path ran, so suppression is fail-soft.

Verified on the TACC matrix after the conditional fix: zero "Invalid
function calling" errors (Maverick suppression works), 40+
`{#plan-...}` occurrences in Llama-3.3 + Qwen3 output (anchors fully
restored for safe providers), pass rate stable within nondeterminism
range.

Per-model behavioral observations (single-run snapshot, will be replaced
by n=3 median scoring in Phase 6):

|                  | Plan-creation | Notes                                                |
|------------------|---------------|------------------------------------------------------|
| Qwen3-32B        | 4-5 / 5       | Most consistent; rich parameter tables               |
| Llama-3.3-70B    | 2 / 5         | Writes to notebook on turn 1; `[local]` default      |
| Llama-4-Maverick | 3 / 5         | Highest variance run-to-run; not a fundamental limit |

What the eval is good at: catching Loom-side prompt regressions (any of
the three above would have shown up immediately), per-model
shell-contract leaderboard, spotting upstream proxy/model issues. What
it's deliberately not: content quality scoring (no LLMJudge; that's the
galaxy harness's job), single-run reliability (Phase 6 adds n=3
median), or testing pi-coding-agent itself.

Includes the in-progress Orbit-web remote-only design spec (commit
`f3e9fb9`) that rode along on this branch from another session. It's
narrative work, doesn't touch shipped code, fine to land separately if
preferred -- happy to split out.

## Test plan

- [x] `npm test` (165 passing, +11 from new notebook-parser suite)
- [x] `npm run typecheck`
- [x] `npm run evals -- --model tacc:llama-3.3-70b,tacc:llama-4-maverick,tacc:qwen3-32b` (13/19 on last run, within nondeterminism range; smoke-echo green on all three)
- [ ] Reviewer running with `ANTHROPIC_API_KEY` set -- the eval suite will discover Anthropic models from `evals/models.json` once entries are added (intentionally not committed; TACC-only on this PR)