### PR TITLE
Files context menu: select on right-click, surface clipboard failures

### DIFF
--- a/app/src/renderer/files/files-panel.ts
+++ b/app/src/renderer/files/files-panel.ts
@@ -95,6 +95,10 @@ export class FilesPanel {
     row.addEventListener("contextmenu", (e) => {
       e.preventDefault();
       e.stopPropagation();
+      // Right-click on a file selects it, matching the convention of every
+      // editor file tree. Directories have no selection visual (setSelected
+      // only applies the class to type=file rows), so they're a no-op.
+      if (node.type === "file") this.setSelected(node.relPath);
       showFilePathContextMenu(e.clientX, e.clientY, node.relPath);
     });
 
@@ -190,7 +194,12 @@ function showFilePathContextMenu(x: number, y: number, relPath: string): void {
     item.textContent = label;
     item.addEventListener("click", (e) => {
       e.stopPropagation();
-      void Promise.resolve(onClick()).finally(close);
+      // Surface clipboard rejections (no secure context, permission
+      // denied, etc.) instead of swallowing them — a silent copy menu is
+      // the worst kind of broken.
+      Promise.resolve(onClick())
+        .catch((err) => console.warn(`[files-ctx-menu] "${label}" failed:`, err))
+        .finally(close);
     });
     menu.appendChild(item);
   };


### PR DESCRIPTION
Two small follow-ups to #105 from the review.

**Select on right-click.** Right-click on a file row now also selects the
row, matching the convention every editor file tree uses. Previously the
context menu popped without changing selection, so you'd have a menu
floating over a row with no visual indicator of which file the menu was
for. Scoped to `type=file` rows since `setSelected`'s class application
is already file-only; directories pass through as no-op.

**Surface clipboard failures.** The three `addItem` onClicks await
`navigator.clipboard.writeText`. The surrounding wrapper did `void
Promise.resolve(onClick()).finally(close)` -- the `void` swallowed any
rejection silently, so a clipboard failure (no secure context,
permission denied, weird Electron state) would close the menu and leave
the user with empty clipboard and zero feedback. Swap for a `.catch`
that `console.warn`s before the `.finally(close)`. Debug-only signal but
at least the failure becomes inspectable.

Deliberately left for later: ARIA roles + keyboard navigation between
menu items, and a jsdom unit test for the helper. Both worth doing, but
they're new surface area rather than nits, so a separate PR makes more
sense if someone wants to pick them up.

## Test plan

- [x] `npm run typecheck` clean (root + app)
- [x] Manual: right-click a file -> row gains `.selected`; right-click a
      directory -> no selection change; both still pop the menu
- [x] Copy actions still work; clipboard failures (verified by
      temporarily breaking `navigator.clipboard.writeText` to throw) now
      log to console