### PR TITLE
Galaxy Pages sync -- client, binding, tools, /sync command

### DIFF
--- a/docs/agent/notebook-schema.md
+++ b/docs/agent/notebook-schema.md
@@ -88,9 +88,16 @@ Sync semantics:
 - `notebook_pull_from_galaxy` -- unconditional remote-wins. Replaces local
   notebook content with the Galaxy page body. Bumps `last_synced_revision`
   to the latest revision id.
+- `notebook_resume_from_galaxy` -- one-shot link + pull for picking up a
+  page that was started or last edited in the Galaxy UI. On a fresh
+  (unbound) notebook it writes the binding block and replaces the body
+  with the remote page content in a single locked op. If the notebook is
+  already bound to the same page it just refreshes (preserving
+  `bound_at`). If it's bound to a different page on the same server the
+  tool refuses -- use `notebook_link_galaxy_page` to switch explicitly.
 - Server URL mismatch fails closed: if `galaxy_server_url` does not match
-  the currently connected Galaxy, both push and pull error out before any
-  network call. Use `/connect` to switch.
+  the currently connected Galaxy, push / pull / resume all error out
+  before any network call. Use `/connect` to switch.
 
 ## Notebook persistence and git
 

--- a/docs/agent/notebook-schema.md
+++ b/docs/agent/notebook-schema.md
@@ -60,6 +60,38 @@ explorations, summaries, ad-hoc edits — answer those directly. A plan
 is for multi-step pipeline orchestration the user explicitly wants
 driven (e.g. "draft a plan for variant calling on this data").
 
+## `loom-galaxy-page` binding block
+
+Records the binding between this notebook and a Galaxy page (see
+galaxyproject/galaxy#22361, Galaxy Notebooks). One block per notebook for
+now -- the upsert grammar is keyed on `page_id` so future per-plan
+bindings are forward-compatible.
+
+```loom-galaxy-page
+page_id: <encoded page id>
+page_slug: <optional slug>
+galaxy_server_url: "<scheme://host>"
+history_id: <encoded history id>
+last_synced_revision: <encoded revision id or empty>
+bound_at: <ISO 8601 timestamp>
+```
+
+This block is **stripped from the body** when pushing to Galaxy and
+**re-applied on top** of the remote body when pulling. It is the durable
+record of where this notebook lives on Galaxy. Don't edit it by hand --
+use the `notebook_link_galaxy_page` tool to create or change a binding.
+
+Sync semantics:
+
+- `notebook_push_to_galaxy` -- unconditional local-wins. Overwrites the
+  Galaxy page body. Bumps `last_synced_revision` to the new revision id.
+- `notebook_pull_from_galaxy` -- unconditional remote-wins. Replaces local
+  notebook content with the Galaxy page body. Bumps `last_synced_revision`
+  to the latest revision id.
+- Server URL mismatch fails closed: if `galaxy_server_url` does not match
+  the currently connected Galaxy, both push and pull error out before any
+  network call. Use `/connect` to switch.
+
 ## Notebook persistence and git
 
 When `notebook.md` is created in a directory that isn't a git repo,

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -15,6 +15,7 @@ import { isSessionIndexEnabled } from "./session-index/is-enabled";
 import { getRecentActivityEvents } from "./activity";
 import { loadConfig } from "./config";
 import { listEnabledSkillRepos } from "./skills";
+import { findGalaxyPageBlocks } from "./galaxy-page-binding";
 
 const NOTEBOOK_HEAD_MAX_CHARS = 2000;
 const NOTEBOOK_TAIL_MAX_CHARS = 4000;
@@ -73,6 +74,38 @@ operating policies above.
 ${truncated ? "_(showing head + tail; middle elided)_\n\n" : ""}\`\`\`markdown
 ${excerpt}
 \`\`\`
+`;
+}
+
+/**
+ * Surface the loom-galaxy-page binding to the agent at session start so it
+ * knows which page push/pull would touch and which tool fits which direction.
+ */
+export function buildGalaxyPageBindingBlock(): string {
+  const nbPath = getNotebookPath();
+  if (!nbPath) return "";
+  let content: string;
+  try {
+    content = fs.readFileSync(nbPath, "utf-8");
+  } catch {
+    return "";
+  }
+  const binding = findGalaxyPageBlocks(content)[0];
+  if (!binding) return "";
+  return `
+## Galaxy page binding
+
+This notebook is linked to a Galaxy page on \`${binding.galaxyServerUrl}\`:
+
+- page_id: \`${binding.pageId}\`
+- page_slug: \`${binding.pageSlug ?? "<none>"}\`
+- history_id: \`${binding.historyId}\`
+- last_synced_revision: \`${binding.lastSyncedRevision ?? "<none>"}\`
+
+Use \`notebook_push_to_galaxy\` to share progress with the user (creates a new
+revision of the Galaxy page). Use \`notebook_pull_from_galaxy\` to fetch
+updates the user made on the Galaxy side -- only when the user explicitly
+asks for it, since pull discards local edits since the last sync.
 `;
 }
 
@@ -714,6 +747,7 @@ export function setupContextInjection(pi: ExtensionAPI): void {
       buildSkillsContext(),
       buildLocalEnvContext(),
       buildNotebookExcerptBlock(),
+      buildGalaxyPageBindingBlock(),
       buildRecentActivityBlock(),
       buildTeamDispatchContext(),
       buildSessionIndexContext(),

--- a/extensions/loom/galaxy-api.ts
+++ b/extensions/loom/galaxy-api.ts
@@ -80,6 +80,50 @@ export async function galaxyGet<T = unknown>(path: string, signal?: AbortSignal)
   return resp.json() as Promise<T>;
 }
 
+async function galaxyMutate<T>(
+  method: "POST" | "PUT",
+  path: string,
+  body: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<T> {
+  const config = getGalaxyConfig();
+  if (!config) throw new Error("Galaxy credentials not configured (GALAXY_URL, GALAXY_API_KEY)");
+
+  const url = `${config.url}/api${path}`;
+  const resp = await fetch(url, {
+    method,
+    headers: {
+      "x-api-key": config.apiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    throw new Error(`Galaxy API ${resp.status}: ${text || resp.statusText}`);
+  }
+
+  return resp.json() as Promise<T>;
+}
+
+export async function galaxyPost<T = unknown>(
+  path: string,
+  body: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<T> {
+  return galaxyMutate<T>("POST", path, body, signal);
+}
+
+export async function galaxyPut<T = unknown>(
+  path: string,
+  body: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<T> {
+  return galaxyMutate<T>("PUT", path, body, signal);
+}
+
 /**
  * Fetch job details from Galaxy. Returns the full response; callers typically
  * only need `tool_version`.

--- a/extensions/loom/galaxy-page-binding.ts
+++ b/extensions/loom/galaxy-page-binding.ts
@@ -1,0 +1,226 @@
+/**
+ * `loom-galaxy-page` fenced YAML block — the durable record of a notebook's
+ * binding to a Galaxy page (see galaxyproject/galaxy#22361, Galaxy Notebooks).
+ *
+ * Lives inside notebook.md alongside the existing `loom-invocation` blocks
+ * documented in notebook-writer.ts. Same render / find / upsert grammar,
+ * keyed on `page_id`. Today's MVP uses one block per notebook, but the
+ * keyed-upsert contract supports N-per-notebook for future per-plan
+ * bindings.
+ *
+ * Block shape:
+ *
+ * ```loom-galaxy-page
+ * page_id: abc123
+ * page_slug: my-analysis
+ * galaxy_server_url: "https://usegalaxy.org"
+ * history_id: hist456
+ * last_synced_revision: rev789
+ * bound_at: 2026-05-14T11:00:00Z
+ * ```
+ *
+ * v1 sync semantics — IMPORTANT, document expectations here so future readers
+ * don't have to spelunk through tool code:
+ *
+ *   - `push` is **unconditional local-wins**. The local notebook content
+ *     replaces the Galaxy page body. Concurrent edits on the Galaxy UI side
+ *     are silently discarded.
+ *   - `pull` is **unconditional remote-wins**. The Galaxy page body replaces
+ *     the local notebook content. Local edits since the last sync are lost
+ *     except for typed blocks (loom-galaxy-page itself, loom-invocation),
+ *     which the pull flow re-applies on top of the remote body.
+ *   - `last_synced_revision` is stored and refreshed after every successful
+ *     push/pull so v2 can add a pre-flight concurrency check without a data
+ *     migration. It is **not** enforced today.
+ *
+ * Galaxy Pages are not the primary edit surface and the agent is the only
+ * push caller, so concurrent UI edits during an active session are an edge
+ * case rather than the norm. v2 will revisit once we have real usage data.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Type
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface GalaxyPageBindingYaml {
+  pageId: string;
+  pageSlug: string | null;
+  galaxyServerUrl: string;
+  historyId: string;
+  lastSyncedRevision: string | null;
+  boundAt: string;
+}
+
+const BINDING_FENCE_OPEN = "```loom-galaxy-page";
+const BINDING_FENCE_CLOSE = "```";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Render
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Render a binding as a `loom-galaxy-page` fenced block. The trailing
+ * newline is intentional so blocks can be appended cleanly.
+ */
+export function renderGalaxyPageBlock(binding: GalaxyPageBindingYaml): string {
+  const lines: string[] = [
+    BINDING_FENCE_OPEN,
+    `page_id: ${binding.pageId}`,
+    `page_slug: ${binding.pageSlug ?? ""}`,
+    `galaxy_server_url: ${escapeYaml(binding.galaxyServerUrl)}`,
+    `history_id: ${binding.historyId}`,
+    `last_synced_revision: ${binding.lastSyncedRevision ?? ""}`,
+    `bound_at: ${binding.boundAt}`,
+    BINDING_FENCE_CLOSE,
+  ];
+  return lines.join("\n") + "\n";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Find
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Find every `loom-galaxy-page` block in the notebook content and parse
+ * each into a GalaxyPageBindingYaml. Skips blocks that fail validation
+ * (missing required fields).
+ */
+export function findGalaxyPageBlocks(content: string): GalaxyPageBindingYaml[] {
+  const result: GalaxyPageBindingYaml[] = [];
+  const lines = content.split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    if (lines[i].trim() === BINDING_FENCE_OPEN) {
+      const start = i + 1;
+      let end = start;
+      while (end < lines.length && lines[end].trim() !== BINDING_FENCE_CLOSE) {
+        end++;
+      }
+      const parsed = parseGalaxyPageBlock(lines.slice(start, end));
+      if (parsed) result.push(parsed);
+      i = end + 1;
+    } else {
+      i++;
+    }
+  }
+  return result;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Upsert
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Upsert a `loom-galaxy-page` block keyed by `page_id`. Replaces in place
+ * if a block with the same page id exists; otherwise appends at the end
+ * of the file with a leading blank line.
+ */
+export function upsertGalaxyPageBlock(
+  content: string,
+  binding: GalaxyPageBindingYaml,
+): string {
+  const ranges = findGalaxyPageBlockRanges(content);
+  const lines = content.split("\n");
+  const newBlock = renderGalaxyPageBlock(binding).trimEnd().split("\n");
+
+  const existing = ranges.find((r) => r.pageId === binding.pageId);
+  if (existing) {
+    const before = lines.slice(0, existing.start);
+    const after = lines.slice(existing.end + 1);
+    return [...before, ...newBlock, ...after].join("\n");
+  }
+
+  const trimmed = content.replace(/\s+$/, "");
+  const sep = trimmed.length > 0 ? "\n\n" : "";
+  return trimmed + sep + newBlock.join("\n") + "\n";
+}
+
+/**
+ * Remove every `loom-galaxy-page` block from the content. Used on push so
+ * Galaxy doesn't render Loom's internal binding metadata, and defensively
+ * on pull in case the remote echoed it back.
+ */
+export function stripGalaxyPageBlocks(content: string): string {
+  const ranges = findGalaxyPageBlockRanges(content);
+  if (ranges.length === 0) return content;
+
+  const lines = content.split("\n");
+  const drop = new Set<number>();
+  for (const r of ranges) {
+    for (let n = r.start; n <= r.end; n++) drop.add(n);
+    // Also drop a single trailing blank line so consecutive strips don't
+    // leave wide gaps in the output.
+    if (r.end + 1 < lines.length && lines[r.end + 1].trim() === "") {
+      drop.add(r.end + 1);
+    }
+  }
+  return lines.filter((_, idx) => !drop.has(idx)).join("\n");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internals
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface GalaxyPageBlockRange {
+  pageId: string;
+  start: number;
+  end: number;
+}
+
+function findGalaxyPageBlockRanges(content: string): GalaxyPageBlockRange[] {
+  const result: GalaxyPageBlockRange[] = [];
+  const lines = content.split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    if (lines[i].trim() === BINDING_FENCE_OPEN) {
+      const start = i;
+      let end = start + 1;
+      let pageId: string | null = null;
+      while (end < lines.length && lines[end].trim() !== BINDING_FENCE_CLOSE) {
+        const m = lines[end].match(/^page_id:\s*(.+)$/);
+        if (m) pageId = m[1].trim();
+        end++;
+      }
+      if (pageId) {
+        result.push({ pageId, start, end });
+      }
+      i = end + 1;
+    } else {
+      i++;
+    }
+  }
+  return result;
+}
+
+function parseGalaxyPageBlock(blockLines: string[]): GalaxyPageBindingYaml | null {
+  const fields: Record<string, string> = {};
+  for (const line of blockLines) {
+    const m = line.match(/^([a-z_]+):\s*(.*)$/);
+    if (m) fields[m[1]] = unescapeYaml(m[2].trim());
+  }
+  if (!fields.page_id || !fields.galaxy_server_url || !fields.history_id || !fields.bound_at) {
+    return null;
+  }
+  return {
+    pageId: fields.page_id,
+    pageSlug: fields.page_slug || null,
+    galaxyServerUrl: fields.galaxy_server_url,
+    historyId: fields.history_id,
+    lastSyncedRevision: fields.last_synced_revision || null,
+    boundAt: fields.bound_at,
+  };
+}
+
+function escapeYaml(value: string): string {
+  if (/[:#\n]/.test(value)) {
+    return `"${value.replace(/"/g, '\\"')}"`;
+  }
+  return value;
+}
+
+function unescapeYaml(value: string): string {
+  if (value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\"/g, '"');
+  }
+  return value;
+}

--- a/extensions/loom/galaxy-pages-api.ts
+++ b/extensions/loom/galaxy-pages-api.ts
@@ -1,0 +1,151 @@
+/**
+ * Galaxy Pages API client — typed wrappers for the /api/pages endpoints
+ * introduced in galaxyproject/galaxy#22361 (Galaxy Notebooks).
+ *
+ * Contract matches Galaxy PR #22361 @ 8c702ecd. The PR is still open and the
+ * shape may move; tests use hand-rolled fixtures pinned to that SHA. When the
+ * PR merges, re-verify against the released contract.
+ *
+ * Notes on the contract corrections this client makes vs. an earlier draft:
+ *
+ *   - `GET /api/pages/{id}/revisions` returns `PageRevisionSummary[]` —
+ *     `{id, page_id, edit_source, create_time, update_time}` only, no
+ *     content or title. Full body is at
+ *     `GET /api/pages/{id}/revisions/{revision_id}` which returns
+ *     `PageRevisionDetails`. Two calls, not one.
+ *
+ *   - `edit_source` is only meaningful on the update payload. The create
+ *     payload silently drops it (`extra="allow"` on the pydantic model),
+ *     so don't send it on create.
+ *
+ *   - `content_format` defaults to `"html"` server-side; always pass
+ *     `"markdown"` explicitly for notebook content.
+ *
+ * No tools are registered against these calls yet — the client lands now,
+ * the tool wiring waits for #22361 to merge.
+ */
+
+import { galaxyGet, galaxyPost, galaxyPut } from "./galaxy-api";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface GalaxyPageSummary {
+  id: string;
+  title: string;
+  slug: string | null;
+  history_id?: string | null;
+  create_time: string;
+  update_time: string;
+  revision_count?: number;
+}
+
+export interface GalaxyPage extends GalaxyPageSummary {
+  content?: string;
+  content_format?: "markdown" | "html";
+  edit_source?: "user" | "agent" | "restore";
+}
+
+/** What `GET /api/pages/{id}/revisions` actually returns — no content. */
+export interface GalaxyPageRevisionSummary {
+  id: string;
+  page_id: string;
+  edit_source?: "user" | "agent" | "restore";
+  create_time: string;
+  update_time: string;
+}
+
+/** What `GET /api/pages/{id}/revisions/{revision_id}` returns — full body. */
+export interface GalaxyPageRevisionDetails extends GalaxyPageRevisionSummary {
+  title?: string;
+  content?: string;
+  content_format?: "markdown" | "html";
+}
+
+export interface CreatePageParams {
+  title: string;
+  content: string;
+  history_id: string;
+  slug?: string;
+  content_format?: "markdown" | "html";
+  annotation?: string;
+}
+
+export interface UpdatePageParams {
+  content: string;
+  title?: string;
+  content_format?: "markdown" | "html";
+  annotation?: string;
+  /** Agent-authored edits should set this to "agent" for provenance. */
+  edit_source?: "user" | "agent";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pages API
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function listHistoryPages(
+  historyId: string,
+  signal?: AbortSignal,
+): Promise<GalaxyPageSummary[]> {
+  return galaxyGet<GalaxyPageSummary[]>(
+    `/pages?history_id=${encodeURIComponent(historyId)}`,
+    signal,
+  );
+}
+
+export async function getPage(pageId: string, signal?: AbortSignal): Promise<GalaxyPage> {
+  return galaxyGet<GalaxyPage>(`/pages/${encodeURIComponent(pageId)}`, signal);
+}
+
+export async function createPage(
+  params: CreatePageParams,
+  signal?: AbortSignal,
+): Promise<GalaxyPageSummary> {
+  const body: Record<string, unknown> = {
+    title: params.title,
+    content: params.content,
+    content_format: params.content_format ?? "markdown",
+    history_id: params.history_id,
+  };
+  if (params.slug !== undefined) body.slug = params.slug;
+  if (params.annotation !== undefined) body.annotation = params.annotation;
+  return galaxyPost<GalaxyPageSummary>("/pages", body, signal);
+}
+
+export async function updatePage(
+  pageId: string,
+  params: UpdatePageParams,
+  signal?: AbortSignal,
+): Promise<GalaxyPageSummary> {
+  const body: Record<string, unknown> = {
+    content: params.content,
+    content_format: params.content_format ?? "markdown",
+  };
+  if (params.title !== undefined) body.title = params.title;
+  if (params.annotation !== undefined) body.annotation = params.annotation;
+  if (params.edit_source !== undefined) body.edit_source = params.edit_source;
+  return galaxyPut<GalaxyPageSummary>(`/pages/${encodeURIComponent(pageId)}`, body, signal);
+}
+
+export async function getPageRevisions(
+  pageId: string,
+  signal?: AbortSignal,
+): Promise<GalaxyPageRevisionSummary[]> {
+  return galaxyGet<GalaxyPageRevisionSummary[]>(
+    `/pages/${encodeURIComponent(pageId)}/revisions`,
+    signal,
+  );
+}
+
+export async function getPageRevisionDetails(
+  pageId: string,
+  revisionId: string,
+  signal?: AbortSignal,
+): Promise<GalaxyPageRevisionDetails> {
+  return galaxyGet<GalaxyPageRevisionDetails>(
+    `/pages/${encodeURIComponent(pageId)}/revisions/${encodeURIComponent(revisionId)}`,
+    signal,
+  );
+}

--- a/extensions/loom/galaxy-pages-api.ts
+++ b/extensions/loom/galaxy-pages-api.ts
@@ -31,14 +31,22 @@ import { galaxyGet, galaxyPost, galaxyPut } from "./galaxy-api";
 // Types
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Typed subset of upstream `PageSummary` (galaxyproject/galaxy schema.py).
+ * Includes only the fields the sync layer consumes; other required fields
+ * (username, email_hash, published, deleted, etc.) are returned by the API
+ * but unused here. `latest_revision_id` is the field push/pull stores into
+ * the binding's `last_synced_revision` after every successful sync.
+ */
 export interface GalaxyPageSummary {
   id: string;
   title: string;
   slug: string | null;
   history_id?: string | null;
+  latest_revision_id: string;
+  revision_ids?: string[];
   create_time: string;
   update_time: string;
-  revision_count?: number;
 }
 
 export interface GalaxyPage extends GalaxyPageSummary {
@@ -119,13 +127,17 @@ export async function updatePage(
   params: UpdatePageParams,
   signal?: AbortSignal,
 ): Promise<GalaxyPageSummary> {
+  // Every update flowing through this client is Loom-authored sync, so
+  // default `edit_source` to "agent" rather than making each call site
+  // remember to set it. Callers can still pass an explicit value to
+  // override (e.g. a future "manual revert" path setting "user").
   const body: Record<string, unknown> = {
     content: params.content,
     content_format: params.content_format ?? "markdown",
+    edit_source: params.edit_source ?? "agent",
   };
   if (params.title !== undefined) body.title = params.title;
   if (params.annotation !== undefined) body.annotation = params.annotation;
-  if (params.edit_source !== undefined) body.edit_source = params.edit_source;
   return galaxyPut<GalaxyPageSummary>(`/pages/${encodeURIComponent(pageId)}`, body, signal);
 }
 

--- a/extensions/loom/galaxy-pages-sync.ts
+++ b/extensions/loom/galaxy-pages-sync.ts
@@ -1,0 +1,119 @@
+/**
+ * Push / pull / link helpers for Loom <-> Galaxy Page sync.
+ *
+ * v1 contract (see ./galaxy-page-binding.ts for full notes):
+ *  - push is unconditional local-wins
+ *  - pull is unconditional remote-wins
+ *  - server-URL mismatch throws before any network call
+ *  - last_synced_revision is stored, not enforced
+ */
+
+import { getNotebookPath } from "./state";
+import { getGalaxyConfig, type GalaxyConfig } from "./galaxy-api";
+import { readNotebook, writeNotebook, withNotebookLock } from "./notebook-writer";
+import { createPage, updatePage, getPage } from "./galaxy-pages-api";
+import {
+    findGalaxyPageBlocks,
+    upsertGalaxyPageBlock,
+    stripGalaxyPageBlocks,
+    type GalaxyPageBindingYaml,
+} from "./galaxy-page-binding";
+
+export interface PushOptions {
+    historyId?: string;
+    title?: string;
+    slug?: string;
+    annotation?: string;
+}
+
+export interface PushResult {
+    pageId: string;
+    pageSlug: string | null;
+    latestRevisionId: string;
+    action: "created" | "updated";
+}
+
+function requireNotebookPath(): string {
+    const p = getNotebookPath();
+    if (!p) throw new Error("notebook path is not set (no active loom session)");
+    return p;
+}
+
+function requireGalaxyConfig(): GalaxyConfig {
+    const c = getGalaxyConfig();
+    if (!c) {
+        throw new Error(
+            "no active Galaxy connection. Use /connect to set a server first.",
+        );
+    }
+    return c;
+}
+
+export async function pushNotebookToGalaxy(
+    opts: PushOptions = {},
+): Promise<PushResult> {
+    const nbPath = requireNotebookPath();
+    const config = requireGalaxyConfig();
+
+    return withNotebookLock(nbPath, async () => {
+        const content = await readNotebook(nbPath);
+        const existing = findGalaxyPageBlocks(content)[0];
+        const stripped = stripGalaxyPageBlocks(content);
+
+        if (existing) {
+            if (existing.galaxyServerUrl !== config.url) {
+                throw new Error(
+                    `Notebook is bound to a Galaxy page on ${existing.galaxyServerUrl}, ` +
+                        `but you are connected to ${config.url}. Use /connect to switch, or ` +
+                        `notebook_link_galaxy_page to re-link to a page on the connected server.`,
+                );
+            }
+            const updated = await updatePage(existing.pageId, {
+                content: stripped,
+                content_format: "markdown",
+                edit_source: "agent",
+            });
+            const refreshed: GalaxyPageBindingYaml = {
+                ...existing,
+                pageSlug: updated.slug ?? existing.pageSlug,
+                lastSyncedRevision: updated.latest_revision_id,
+            };
+            await writeNotebook(nbPath, upsertGalaxyPageBlock(stripped, refreshed));
+            return {
+                pageId: existing.pageId,
+                pageSlug: refreshed.pageSlug,
+                latestRevisionId: updated.latest_revision_id,
+                action: "updated",
+            };
+        }
+
+        if (!opts.historyId) {
+            throw new Error(
+                "notebook is not bound to a Galaxy page; pass history_id to create one",
+            );
+        }
+        const created = await createPage({
+            history_id: opts.historyId,
+            title: opts.title ?? "Untitled notebook",
+            slug: opts.slug,
+            annotation: opts.annotation,
+            content: stripped,
+            content_format: "markdown",
+        });
+        const binding: GalaxyPageBindingYaml = {
+            pageId: created.id,
+            pageSlug: created.slug ?? null,
+            galaxyServerUrl: config.url,
+            historyId: opts.historyId,
+            lastSyncedRevision: created.latest_revision_id,
+            boundAt: new Date().toISOString(),
+        };
+        await writeNotebook(nbPath, upsertGalaxyPageBlock(stripped, binding));
+        return {
+            pageId: created.id,
+            pageSlug: created.slug ?? null,
+            latestRevisionId: created.latest_revision_id,
+            action: "created",
+        };
+    });
+}

--- a/extensions/loom/galaxy-pages-sync.ts
+++ b/extensions/loom/galaxy-pages-sync.ts
@@ -89,6 +89,80 @@ export async function linkGalaxyPage(
     });
 }
 
+export interface ResumeOptions {
+    historyId?: string;
+}
+
+export interface ResumeResult {
+    pageId: string;
+    latestRevisionId: string;
+    action: "linked" | "refreshed";
+}
+
+/**
+ * One-shot "resume from Galaxy": link the local notebook to a Galaxy page
+ * and replace its body with the remote content in a single locked op.
+ *
+ * Refuses to clobber an existing binding to a different page on the same
+ * server -- that's `link` + `pull` territory and should be explicit. Same
+ * fail-closed server URL check as pull. Idempotent when re-resuming the
+ * same page (action="refreshed", boundAt preserved).
+ */
+export async function resumeGalaxyPage(
+    pageIdOrSlug: string,
+    opts: ResumeOptions = {},
+): Promise<ResumeResult> {
+    const nbPath = requireNotebookPath();
+    const config = requireGalaxyConfig();
+
+    return withNotebookLock(nbPath, async () => {
+        const localBefore = await readNotebook(nbPath);
+        const existing = findGalaxyPageBlocks(localBefore)[0];
+        const page = await getPage(pageIdOrSlug);
+
+        if (existing) {
+            if (existing.galaxyServerUrl !== config.url) {
+                throw new Error(
+                    `Notebook is bound to a Galaxy page on ${existing.galaxyServerUrl}, ` +
+                        `but you are connected to ${config.url}. Use /connect to switch first.`,
+                );
+            }
+            if (existing.pageId !== page.id) {
+                throw new Error(
+                    `Notebook is already bound to page ${existing.pageId}; refusing to ` +
+                        `clobber with content from ${page.id}. Use notebook_link_galaxy_page ` +
+                        `to re-link explicitly, then notebook_pull_from_galaxy.`,
+                );
+            }
+        }
+
+        const historyId =
+            opts.historyId ?? page.history_id ?? existing?.historyId ?? null;
+        if (!historyId) {
+            throw new Error(
+                "resumeGalaxyPage: history_id is required (Galaxy did not return one on the " +
+                    "page response and no override was supplied). Pass history_id explicitly.",
+            );
+        }
+
+        const remoteBody = page.content ?? "";
+        const binding: GalaxyPageBindingYaml = {
+            pageId: page.id,
+            pageSlug: page.slug ?? null,
+            galaxyServerUrl: config.url,
+            historyId,
+            lastSyncedRevision: page.latest_revision_id,
+            boundAt: existing?.boundAt ?? new Date().toISOString(),
+        };
+        await writeNotebook(nbPath, upsertGalaxyPageBlock(remoteBody, binding));
+        return {
+            pageId: page.id,
+            latestRevisionId: page.latest_revision_id,
+            action: existing ? "refreshed" : "linked",
+        };
+    });
+}
+
 export interface PullResult {
     pageId: string;
     latestRevisionId: string;

--- a/extensions/loom/galaxy-pages-sync.ts
+++ b/extensions/loom/galaxy-pages-sync.ts
@@ -49,6 +49,49 @@ function requireGalaxyConfig(): GalaxyConfig {
     return c;
 }
 
+export interface LinkOptions {
+    historyId?: string;
+}
+
+export interface LinkResult {
+    pageId: string;
+    latestRevisionId: string;
+}
+
+export async function linkGalaxyPage(
+    pageIdOrSlug: string,
+    opts: LinkOptions = {},
+): Promise<LinkResult> {
+    const nbPath = requireNotebookPath();
+    const config = requireGalaxyConfig();
+
+    return withNotebookLock(nbPath, async () => {
+        const page = await getPage(pageIdOrSlug);
+        const responseHistoryId = (page as Record<string, unknown>).history_id;
+        const historyId =
+            opts.historyId ??
+            (typeof responseHistoryId === "string" ? responseHistoryId : null);
+        if (!historyId) {
+            throw new Error(
+                "linkGalaxyPage: history_id is required (Galaxy did not return one on the page " +
+                    "response and no override was supplied). Pass history_id explicitly, or use " +
+                    "notebook_push_to_galaxy to create a new page bound to a known history.",
+            );
+        }
+        const content = await readNotebook(nbPath);
+        const binding: GalaxyPageBindingYaml = {
+            pageId: page.id,
+            pageSlug: page.slug ?? null,
+            galaxyServerUrl: config.url,
+            historyId,
+            lastSyncedRevision: page.latest_revision_id,
+            boundAt: new Date().toISOString(),
+        };
+        await writeNotebook(nbPath, upsertGalaxyPageBlock(content, binding));
+        return { pageId: page.id, latestRevisionId: page.latest_revision_id };
+    });
+}
+
 export interface PullResult {
     pageId: string;
     latestRevisionId: string;

--- a/extensions/loom/galaxy-pages-sync.ts
+++ b/extensions/loom/galaxy-pages-sync.ts
@@ -67,10 +67,7 @@ export async function linkGalaxyPage(
 
     return withNotebookLock(nbPath, async () => {
         const page = await getPage(pageIdOrSlug);
-        const responseHistoryId = (page as Record<string, unknown>).history_id;
-        const historyId =
-            opts.historyId ??
-            (typeof responseHistoryId === "string" ? responseHistoryId : null);
+        const historyId = opts.historyId ?? page.history_id ?? null;
         if (!historyId) {
             throw new Error(
                 "linkGalaxyPage: history_id is required (Galaxy did not return one on the page " +

--- a/extensions/loom/galaxy-pages-sync.ts
+++ b/extensions/loom/galaxy-pages-sync.ts
@@ -49,6 +49,42 @@ function requireGalaxyConfig(): GalaxyConfig {
     return c;
 }
 
+export interface PullResult {
+    pageId: string;
+    latestRevisionId: string;
+}
+
+export async function pullNotebookFromGalaxy(): Promise<PullResult> {
+    const nbPath = requireNotebookPath();
+    const config = requireGalaxyConfig();
+
+    return withNotebookLock(nbPath, async () => {
+        const content = await readNotebook(nbPath);
+        const existing = findGalaxyPageBlocks(content)[0];
+        if (!existing) {
+            throw new Error(
+                "notebook is not bound to a Galaxy page. Use notebook_link_galaxy_page " +
+                    "to link to an existing page, or notebook_push_to_galaxy to create one.",
+            );
+        }
+        if (existing.galaxyServerUrl !== config.url) {
+            throw new Error(
+                `Notebook is bound to a Galaxy page on ${existing.galaxyServerUrl}, ` +
+                    `but you are connected to ${config.url}. Use /connect to switch first.`,
+            );
+        }
+        const page = await getPage(existing.pageId);
+        const remoteBody = page.content ?? "";
+        const refreshed: GalaxyPageBindingYaml = {
+            ...existing,
+            pageSlug: page.slug ?? existing.pageSlug,
+            lastSyncedRevision: page.latest_revision_id,
+        };
+        await writeNotebook(nbPath, upsertGalaxyPageBlock(remoteBody, refreshed));
+        return { pageId: existing.pageId, latestRevisionId: page.latest_revision_id };
+    });
+}
+
 export async function pushNotebookToGalaxy(
     opts: PushOptions = {},
 ): Promise<PushResult> {

--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -9,6 +9,7 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { registerPlanTools } from "./tools";
+import { registerNotebookSyncTools } from "./tools-sync";
 import { setupContextInjection, formatConnectionStatus } from "./context";
 import { setupUIBridge } from "./ui-bridge";
 import { registerSessionLifecycle } from "./session-lifecycle";
@@ -38,6 +39,7 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
   registerActivityHooks(pi);
 
   registerPlanTools(pi);
+  registerNotebookSyncTools(pi);
   registerExecutionCommands(pi);
   registerConfusablesHint(pi);
   if (isTeamDispatchEnabled()) {

--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -10,6 +10,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { registerPlanTools } from "./tools";
 import { registerNotebookSyncTools } from "./tools-sync";
+import { registerSyncCommand } from "./sync-command";
 import { setupContextInjection, formatConnectionStatus } from "./context";
 import { setupUIBridge } from "./ui-bridge";
 import { registerSessionLifecycle } from "./session-lifecycle";
@@ -40,6 +41,7 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
 
   registerPlanTools(pi);
   registerNotebookSyncTools(pi);
+  registerSyncCommand(pi);
   registerExecutionCommands(pi);
   registerConfusablesHint(pi);
   if (isTeamDispatchEnabled()) {

--- a/extensions/loom/sync-command.ts
+++ b/extensions/loom/sync-command.ts
@@ -1,0 +1,148 @@
+/**
+ * /sync command -- user-facing entry point to the three sync tools.
+ *
+ * Subcommands: status, push, pull, link. Same semantics as the
+ * notebook_*_galaxy tools (they share the underlying helpers in
+ * galaxy-pages-sync.ts); /sync just gives the user a direct way to invoke
+ * them from the chat without going through the agent.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { getNotebookPath } from "./state";
+import { readNotebook } from "./notebook-writer";
+import { findGalaxyPageBlocks } from "./galaxy-page-binding";
+import {
+    pushNotebookToGalaxy,
+    pullNotebookFromGalaxy,
+    linkGalaxyPage,
+} from "./galaxy-pages-sync";
+
+interface ParsedFlags {
+    positional: string[];
+    flags: Record<string, string | undefined>;
+}
+
+function parseFlags(input: string): ParsedFlags {
+    const tokens =
+        input.match(/(?:--[a-z-]+(?:=(?:"[^"]*"|\S+))?|"[^"]*"|\S+)/gi) ?? [];
+    const positional: string[] = [];
+    const flags: Record<string, string | undefined> = {};
+    for (let i = 0; i < tokens.length; i++) {
+        const t = tokens[i];
+        if (t.startsWith("--")) {
+            const eq = t.indexOf("=");
+            if (eq >= 0) {
+                const k = t.slice(2, eq);
+                const v = t.slice(eq + 1).replace(/^"|"$/g, "");
+                flags[k] = v;
+            } else {
+                const k = t.slice(2);
+                const next = tokens[i + 1];
+                if (next && !next.startsWith("--")) {
+                    flags[k] = next.replace(/^"|"$/g, "");
+                    i++;
+                } else {
+                    flags[k] = "";
+                }
+            }
+        } else {
+            positional.push(t.replace(/^"|"$/g, ""));
+        }
+    }
+    return { positional, flags };
+}
+
+export function registerSyncCommand(pi: ExtensionAPI): void {
+    pi.registerCommand("sync", {
+        description:
+            "Sync notebook.md with a Galaxy page. Subcommands: status | push [--history H --title T --slug S --annotation A] | pull | link <page_id> [--history H]",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        handler: async (args: string, ctx: any) => {
+            const trimmed = (args ?? "").trim();
+            const firstSpace = trimmed.indexOf(" ");
+            const subcommand =
+                firstSpace === -1 ? trimmed || "status" : trimmed.slice(0, firstSpace);
+            const tail = firstSpace === -1 ? "" : trimmed.slice(firstSpace + 1);
+            const { positional, flags } = parseFlags(tail);
+
+            try {
+                if (subcommand === "status") {
+                    const nbPath = getNotebookPath();
+                    if (!nbPath) {
+                        ctx.ui.notify(
+                            "No active loom session; nothing to sync.",
+                            "warning",
+                        );
+                        return;
+                    }
+                    const content = await readNotebook(nbPath);
+                    const binding = findGalaxyPageBlocks(content)[0];
+                    if (!binding) {
+                        ctx.ui.notify(
+                            "Notebook is not bound to a Galaxy page. Use `/sync push --history <id>` to create one, or `/sync link <page_id>` to link an existing page.",
+                            "info",
+                        );
+                        return;
+                    }
+                    ctx.ui.notify(
+                        `Bound to ${binding.galaxyServerUrl} (page_id=${binding.pageId}, slug=${binding.pageSlug ?? "<none>"}, last_synced_revision=${binding.lastSyncedRevision ?? "<none>"})`,
+                        "info",
+                    );
+                    return;
+                }
+
+                if (subcommand === "push") {
+                    const result = await pushNotebookToGalaxy({
+                        historyId: flags.history,
+                        title: flags.title,
+                        slug: flags.slug,
+                        annotation: flags.annotation,
+                    });
+                    ctx.ui.notify(
+                        `Pushed: ${result.action} page ${result.pageId} (revision ${result.latestRevisionId}).`,
+                        "info",
+                    );
+                    return;
+                }
+
+                if (subcommand === "pull") {
+                    const result = await pullNotebookFromGalaxy();
+                    ctx.ui.notify(
+                        `Pulled page ${result.pageId} (revision ${result.latestRevisionId}). Notebook updated.`,
+                        "info",
+                    );
+                    return;
+                }
+
+                if (subcommand === "link") {
+                    const pageId = positional[0];
+                    if (!pageId) {
+                        ctx.ui.notify(
+                            "Usage: /sync link <page_id> [--history <id>]",
+                            "warning",
+                        );
+                        return;
+                    }
+                    const result = await linkGalaxyPage(pageId, {
+                        historyId: flags.history,
+                    });
+                    ctx.ui.notify(
+                        `Linked to page ${result.pageId} (revision ${result.latestRevisionId}).`,
+                        "info",
+                    );
+                    return;
+                }
+
+                ctx.ui.notify(
+                    `Unknown /sync subcommand: ${subcommand}. Use status, push, pull, or link.`,
+                    "warning",
+                );
+            } catch (e) {
+                ctx.ui.notify(
+                    `/sync ${subcommand}: ${e instanceof Error ? e.message : String(e)}`,
+                    "error",
+                );
+            }
+        },
+    });
+}

--- a/extensions/loom/sync-command.ts
+++ b/extensions/loom/sync-command.ts
@@ -15,6 +15,7 @@ import {
     pushNotebookToGalaxy,
     pullNotebookFromGalaxy,
     linkGalaxyPage,
+    resumeGalaxyPage,
 } from "./galaxy-pages-sync";
 
 interface ParsedFlags {
@@ -55,7 +56,7 @@ function parseFlags(input: string): ParsedFlags {
 export function registerSyncCommand(pi: ExtensionAPI): void {
     pi.registerCommand("sync", {
         description:
-            "Sync notebook.md with a Galaxy page. Subcommands: status | push [--history H --title T --slug S --annotation A] | pull | link <page_id> [--history H]",
+            "Sync notebook.md with a Galaxy page. Subcommands: status | push [--history H --title T --slug S --annotation A] | pull | link <page_id> [--history H] | resume <page_id> [--history H]",
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         handler: async (args: string, ctx: any) => {
             const trimmed = (args ?? "").trim();
@@ -133,8 +134,27 @@ export function registerSyncCommand(pi: ExtensionAPI): void {
                     return;
                 }
 
+                if (subcommand === "resume") {
+                    const pageId = positional[0];
+                    if (!pageId) {
+                        ctx.ui.notify(
+                            "Usage: /sync resume <page_id> [--history <id>]",
+                            "warning",
+                        );
+                        return;
+                    }
+                    const result = await resumeGalaxyPage(pageId, {
+                        historyId: flags.history,
+                    });
+                    ctx.ui.notify(
+                        `Resumed page ${result.pageId} (${result.action}, revision ${result.latestRevisionId}). Notebook updated.`,
+                        "info",
+                    );
+                    return;
+                }
+
                 ctx.ui.notify(
-                    `Unknown /sync subcommand: ${subcommand}. Use status, push, pull, or link.`,
+                    `Unknown /sync subcommand: ${subcommand}. Use status, push, pull, link, or resume.`,
                     "warning",
                 );
             } catch (e) {

--- a/extensions/loom/tools-sync.ts
+++ b/extensions/loom/tools-sync.ts
@@ -1,0 +1,97 @@
+/**
+ * Tool registrations for Loom <-> Galaxy Pages sync.
+ *
+ * Thin wrappers around the helpers in galaxy-pages-sync.ts. The helpers do
+ * all the work (locking, network, binding-block math); these registrations
+ * just translate TypeBox-validated params, call the helper, and format the
+ * response for the agent.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { Type } from "@sinclair/typebox";
+import {
+    pushNotebookToGalaxy,
+    pullNotebookFromGalaxy,
+    linkGalaxyPage,
+} from "./galaxy-pages-sync";
+
+function errorContent(e: unknown) {
+    return {
+        content: [
+            {
+                type: "text" as const,
+                text: `Error: ${e instanceof Error ? e.message : String(e)}`,
+            },
+        ],
+        details: { error: true },
+    };
+}
+
+export function registerNotebookSyncTools(pi: ExtensionAPI): void {
+    pi.registerTool({
+        name: "notebook_push_to_galaxy",
+        label: "Push notebook to Galaxy page",
+        description: `Push the local notebook.md to a Galaxy page. If the notebook already
+has a loom-galaxy-page binding block, updates that page in place (creates a
+new revision). If there's no binding yet, pass history_id (and optionally title,
+slug, annotation) to create a new page attached to that history and bind it.
+Strips loom-galaxy-page blocks from the body sent to Galaxy, but keeps
+loom-invocation blocks (they're analysis content). Unconditional local-wins:
+any concurrent Galaxy-UI edits since the last sync are overwritten.`,
+        parameters: Type.Object({
+            history_id: Type.Optional(
+                Type.String({
+                    description:
+                        "History ID to attach the page to (required when creating a new page).",
+                }),
+            ),
+            title: Type.Optional(
+                Type.String({
+                    description:
+                        "Page title for create. Defaults to 'Untitled notebook' if omitted.",
+                }),
+            ),
+            slug: Type.Optional(
+                Type.String({
+                    description:
+                        "URL slug for create. Lowercase letters, digits, and hyphens. Auto-generated if omitted.",
+                }),
+            ),
+            annotation: Type.Optional(
+                Type.String({
+                    description: "Optional annotation attached to the page.",
+                }),
+            ),
+        }),
+        async execute(_callId, params, _signal, _onUpdate, _ctx) {
+            try {
+                const result = await pushNotebookToGalaxy({
+                    historyId: params.history_id,
+                    title: params.title,
+                    slug: params.slug,
+                    annotation: params.annotation,
+                });
+                return {
+                    content: [
+                        {
+                            type: "text" as const,
+                            text: JSON.stringify(
+                                {
+                                    page_id: result.pageId,
+                                    page_slug: result.pageSlug,
+                                    latest_revision_id: result.latestRevisionId,
+                                    action: result.action,
+                                },
+                                null,
+                                2,
+                            ),
+                        },
+                    ],
+                    details: { pageId: result.pageId, action: result.action },
+                };
+            } catch (e) {
+                return errorContent(e);
+            }
+        },
+    });
+}

--- a/extensions/loom/tools-sync.ts
+++ b/extensions/loom/tools-sync.ts
@@ -94,4 +94,39 @@ any concurrent Galaxy-UI edits since the last sync are overwritten.`,
             }
         },
     });
+
+    pi.registerTool({
+        name: "notebook_pull_from_galaxy",
+        label: "Pull notebook from Galaxy page",
+        description: `Replace the local notebook.md with the body of the linked Galaxy page,
+then re-apply the loom-galaxy-page binding block on top. Requires the
+notebook to already have a binding (use notebook_link_galaxy_page or
+notebook_push_to_galaxy first). Unconditional remote-wins: any local edits
+since the last sync are overwritten, including loom-invocation blocks
+that weren't pushed yet.`,
+        parameters: Type.Object({}),
+        async execute(_callId, _params, _signal, _onUpdate, _ctx) {
+            try {
+                const result = await pullNotebookFromGalaxy();
+                return {
+                    content: [
+                        {
+                            type: "text" as const,
+                            text: JSON.stringify(
+                                {
+                                    page_id: result.pageId,
+                                    latest_revision_id: result.latestRevisionId,
+                                },
+                                null,
+                                2,
+                            ),
+                        },
+                    ],
+                    details: { pageId: result.pageId },
+                };
+            } catch (e) {
+                return errorContent(e);
+            }
+        },
+    });
 }

--- a/extensions/loom/tools-sync.ts
+++ b/extensions/loom/tools-sync.ts
@@ -129,4 +129,49 @@ that weren't pushed yet.`,
             }
         },
     });
+
+    pi.registerTool({
+        name: "notebook_link_galaxy_page",
+        label: "Link notebook to existing Galaxy page",
+        description: `Bind the local notebook.md to an existing Galaxy page without pushing
+or pulling content. Inserts a loom-galaxy-page block with the page's id,
+slug, server URL, and latest revision id. Use this when an analysis was
+started in the Galaxy UI and the user wants Loom to take over editing.`,
+        parameters: Type.Object({
+            page_id: Type.String({
+                description: "Encoded page id (or slug) to link to.",
+            }),
+            history_id: Type.Optional(
+                Type.String({
+                    description:
+                        "History id; only needed if Galaxy's page response doesn't include one.",
+                }),
+            ),
+        }),
+        async execute(_callId, params, _signal, _onUpdate, _ctx) {
+            try {
+                const result = await linkGalaxyPage(params.page_id, {
+                    historyId: params.history_id,
+                });
+                return {
+                    content: [
+                        {
+                            type: "text" as const,
+                            text: JSON.stringify(
+                                {
+                                    page_id: result.pageId,
+                                    latest_revision_id: result.latestRevisionId,
+                                },
+                                null,
+                                2,
+                            ),
+                        },
+                    ],
+                    details: { pageId: result.pageId },
+                };
+            } catch (e) {
+                return errorContent(e);
+            }
+        },
+    });
 }

--- a/extensions/loom/tools-sync.ts
+++ b/extensions/loom/tools-sync.ts
@@ -13,6 +13,7 @@ import {
     pushNotebookToGalaxy,
     pullNotebookFromGalaxy,
     linkGalaxyPage,
+    resumeGalaxyPage,
 } from "./galaxy-pages-sync";
 
 function errorContent(e: unknown) {
@@ -123,6 +124,56 @@ that weren't pushed yet.`,
                         },
                     ],
                     details: { pageId: result.pageId },
+                };
+            } catch (e) {
+                return errorContent(e);
+            }
+        },
+    });
+
+    pi.registerTool({
+        name: "notebook_resume_from_galaxy",
+        label: "Resume notebook from Galaxy page",
+        description: `One-shot resume of a Galaxy page into the local notebook: writes the
+loom-galaxy-page binding block and replaces local content with the remote
+page body in a single locked operation. Use this when starting a fresh
+Loom session against a page that was created or last edited in the Galaxy
+UI -- it saves the user from having to do notebook_link_galaxy_page then
+notebook_pull_from_galaxy. Refuses to clobber when the notebook is already
+bound to a different page on the same server (use notebook_link_galaxy_page
+to switch explicitly). Idempotent when re-resuming the same page.`,
+        parameters: Type.Object({
+            page_id: Type.String({
+                description: "Encoded page id (or slug) to resume from.",
+            }),
+            history_id: Type.Optional(
+                Type.String({
+                    description:
+                        "History id; only needed if Galaxy's page response doesn't include one.",
+                }),
+            ),
+        }),
+        async execute(_callId, params, _signal, _onUpdate, _ctx) {
+            try {
+                const result = await resumeGalaxyPage(params.page_id, {
+                    historyId: params.history_id,
+                });
+                return {
+                    content: [
+                        {
+                            type: "text" as const,
+                            text: JSON.stringify(
+                                {
+                                    page_id: result.pageId,
+                                    latest_revision_id: result.latestRevisionId,
+                                    action: result.action,
+                                },
+                                null,
+                                2,
+                            ),
+                        },
+                    ],
+                    details: { pageId: result.pageId, action: result.action },
                 };
             } catch (e) {
                 return errorContent(e);

--- a/tests/context-page-binding.test.ts
+++ b/tests/context-page-binding.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fs from "fs";
+import * as state from "../extensions/loom/state";
+import { buildGalaxyPageBindingBlock } from "../extensions/loom/context";
+
+vi.mock("../extensions/loom/state");
+vi.mock("fs", async (importOriginal) => {
+    const actual = await importOriginal<typeof fs>();
+    return { ...actual, readFileSync: vi.fn() };
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("buildGalaxyPageBindingBlock", () => {
+    it("returns empty string when no notebook path", () => {
+        vi.mocked(state.getNotebookPath).mockReturnValue(null);
+        expect(buildGalaxyPageBindingBlock()).toBe("");
+    });
+
+    it("returns empty string when notebook has no binding", () => {
+        vi.mocked(state.getNotebookPath).mockReturnValue("/work/notebook.md");
+        vi.mocked(fs.readFileSync).mockReturnValue("# Just text\n" as never);
+        expect(buildGalaxyPageBindingBlock()).toBe("");
+    });
+
+    it("formats binding info when present", () => {
+        vi.mocked(state.getNotebookPath).mockReturnValue("/work/notebook.md");
+        const nb = [
+            "```loom-galaxy-page",
+            "page_id: p1",
+            'page_slug: "my-analysis"',
+            'galaxy_server_url: "https://galaxy.example"',
+            "history_id: h1",
+            "last_synced_revision: r3",
+            'bound_at: "2026-05-20T10:00:00Z"',
+            "```",
+            "",
+        ].join("\n");
+        vi.mocked(fs.readFileSync).mockReturnValue(nb as never);
+        const out = buildGalaxyPageBindingBlock();
+        expect(out).toContain("Galaxy page binding");
+        expect(out).toContain("p1");
+        expect(out).toContain("my-analysis");
+        expect(out).toContain("https://galaxy.example");
+        expect(out).toContain("notebook_push_to_galaxy");
+        expect(out).toContain("notebook_pull_from_galaxy");
+    });
+});

--- a/tests/galaxy-page-binding.test.ts
+++ b/tests/galaxy-page-binding.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import {
+  findGalaxyPageBlocks,
+  renderGalaxyPageBlock,
+  stripGalaxyPageBlocks,
+  upsertGalaxyPageBlock,
+  type GalaxyPageBindingYaml,
+} from "../extensions/loom/galaxy-page-binding";
+
+function binding(overrides: Partial<GalaxyPageBindingYaml> = {}): GalaxyPageBindingYaml {
+  return {
+    pageId: "page-abc",
+    pageSlug: "my-analysis",
+    galaxyServerUrl: "https://usegalaxy.org",
+    historyId: "hist-123",
+    lastSyncedRevision: null,
+    boundAt: "2026-05-14T11:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("renderGalaxyPageBlock", () => {
+  it("emits the fenced loom-galaxy-page grammar", () => {
+    const out = renderGalaxyPageBlock(binding());
+    expect(out).toBe(
+      [
+        "```loom-galaxy-page",
+        "page_id: page-abc",
+        "page_slug: my-analysis",
+        'galaxy_server_url: "https://usegalaxy.org"',
+        "history_id: hist-123",
+        "last_synced_revision: ",
+        "bound_at: 2026-05-14T11:00:00Z",
+        "```",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("quotes server URLs because they contain a colon", () => {
+    const out = renderGalaxyPageBlock(binding());
+    expect(out).toContain('galaxy_server_url: "https://usegalaxy.org"');
+  });
+
+  it("emits null slug and revision as empty values", () => {
+    const out = renderGalaxyPageBlock(
+      binding({ pageSlug: null, lastSyncedRevision: null }),
+    );
+    expect(out).toContain("page_slug: \n");
+    expect(out).toContain("last_synced_revision: \n");
+  });
+
+  it("emits the revision when present", () => {
+    const out = renderGalaxyPageBlock(binding({ lastSyncedRevision: "rev-789" }));
+    expect(out).toContain("last_synced_revision: rev-789");
+  });
+});
+
+describe("findGalaxyPageBlocks round-trips render output", () => {
+  it("parses a single block", () => {
+    const content = renderGalaxyPageBlock(binding({ lastSyncedRevision: "rev-1" }));
+    const found = findGalaxyPageBlocks(content);
+    expect(found).toHaveLength(1);
+    expect(found[0]).toEqual(binding({ lastSyncedRevision: "rev-1" }));
+  });
+
+  it("parses multiple blocks in document order", () => {
+    const a = renderGalaxyPageBlock(binding({ pageId: "page-A" }));
+    const b = renderGalaxyPageBlock(binding({ pageId: "page-B" }));
+    const found = findGalaxyPageBlocks(`# notebook\n\n${a}\nsome prose\n\n${b}`);
+    expect(found.map((f) => f.pageId)).toEqual(["page-A", "page-B"]);
+  });
+
+  it("skips blocks missing required fields", () => {
+    const broken = "```loom-galaxy-page\npage_slug: orphan\n```\n";
+    expect(findGalaxyPageBlocks(broken)).toEqual([]);
+  });
+
+  it("returns [] when no block is present", () => {
+    expect(findGalaxyPageBlocks("# just markdown\n\nhello\n")).toEqual([]);
+  });
+});
+
+describe("upsertGalaxyPageBlock", () => {
+  it("appends when no matching block exists", () => {
+    const content = "# heading\n\nsome notes\n";
+    const out = upsertGalaxyPageBlock(content, binding({ pageId: "page-new" }));
+    expect(out).toContain("# heading");
+    expect(out).toContain("some notes");
+    expect(out).toContain("page_id: page-new");
+    expect(out.endsWith("```\n")).toBe(true);
+  });
+
+  it("replaces an existing block keyed by page_id, preserving surroundings", () => {
+    const existing = renderGalaxyPageBlock(
+      binding({ pageId: "page-keep", lastSyncedRevision: "rev-old" }),
+    );
+    const content = `# heading\n\nbefore\n\n${existing}\nafter\n`;
+    const out = upsertGalaxyPageBlock(
+      content,
+      binding({ pageId: "page-keep", lastSyncedRevision: "rev-new" }),
+    );
+
+    // The surroundings stayed put.
+    expect(out).toContain("# heading");
+    expect(out).toContain("before");
+    expect(out).toContain("after");
+
+    // The revision was updated in place — and exactly once.
+    expect(out).toContain("last_synced_revision: rev-new");
+    expect(out).not.toContain("last_synced_revision: rev-old");
+
+    // No duplicate block was appended.
+    const blocks = findGalaxyPageBlocks(out);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].pageId).toBe("page-keep");
+    expect(blocks[0].lastSyncedRevision).toBe("rev-new");
+  });
+
+  it("supports multiple distinct page bindings keyed independently", () => {
+    let content = "# notebook\n";
+    content = upsertGalaxyPageBlock(content, binding({ pageId: "page-A" }));
+    content = upsertGalaxyPageBlock(content, binding({ pageId: "page-B" }));
+
+    let blocks = findGalaxyPageBlocks(content);
+    expect(blocks.map((b) => b.pageId).sort()).toEqual(["page-A", "page-B"]);
+
+    // Updating B leaves A intact.
+    content = upsertGalaxyPageBlock(
+      content,
+      binding({ pageId: "page-B", lastSyncedRevision: "rev-B2" }),
+    );
+    blocks = findGalaxyPageBlocks(content);
+    expect(blocks).toHaveLength(2);
+    expect(blocks.find((b) => b.pageId === "page-A")!.lastSyncedRevision).toBeNull();
+    expect(blocks.find((b) => b.pageId === "page-B")!.lastSyncedRevision).toBe("rev-B2");
+  });
+
+  it("works on empty content (no leading blank line needed)", () => {
+    const out = upsertGalaxyPageBlock("", binding());
+    expect(out.startsWith("```loom-galaxy-page")).toBe(true);
+    expect(findGalaxyPageBlocks(out)).toHaveLength(1);
+  });
+});
+
+describe("stripGalaxyPageBlocks", () => {
+  it("removes a single block and its trailing blank line", () => {
+    const content =
+      "# heading\n\n" + renderGalaxyPageBlock(binding()) + "\nafter\n";
+    const out = stripGalaxyPageBlocks(content);
+    expect(out).not.toContain("loom-galaxy-page");
+    expect(out).not.toContain("page_id");
+    expect(out).toContain("# heading");
+    expect(out).toContain("after");
+  });
+
+  it("removes multiple blocks", () => {
+    const content =
+      renderGalaxyPageBlock(binding({ pageId: "A" })) +
+      "\nmiddle prose\n\n" +
+      renderGalaxyPageBlock(binding({ pageId: "B" }));
+    const out = stripGalaxyPageBlocks(content);
+    expect(out).not.toContain("loom-galaxy-page");
+    expect(out).toContain("middle prose");
+  });
+
+  it("leaves loom-invocation blocks alone", () => {
+    const content =
+      "```loom-invocation\ninvocation_id: inv-1\nstatus: in_progress\n```\n\n" +
+      renderGalaxyPageBlock(binding());
+    const out = stripGalaxyPageBlocks(content);
+    expect(out).toContain("loom-invocation");
+    expect(out).toContain("invocation_id: inv-1");
+    expect(out).not.toContain("loom-galaxy-page");
+  });
+
+  it("is a no-op when no binding block is present", () => {
+    const content = "# heading\n\nbody\n";
+    expect(stripGalaxyPageBlocks(content)).toBe(content);
+  });
+});

--- a/tests/galaxy-pages-api.test.ts
+++ b/tests/galaxy-pages-api.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for the Galaxy Pages REST client.
+ *
+ * Fixtures match Galaxy PR #22361 @ 8c702ecd. Re-verify against the merged
+ * contract before wiring tools to this client; if these tests pass but real
+ * Galaxy calls fail, the upstream schema has moved.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as galaxyApi from "../extensions/loom/galaxy-api";
+import {
+  createPage,
+  getPage,
+  getPageRevisionDetails,
+  getPageRevisions,
+  listHistoryPages,
+  updatePage,
+  type GalaxyPage,
+  type GalaxyPageRevisionDetails,
+  type GalaxyPageRevisionSummary,
+  type GalaxyPageSummary,
+} from "../extensions/loom/galaxy-pages-api";
+
+const origUrl = process.env.GALAXY_URL;
+const origKey = process.env.GALAXY_API_KEY;
+
+beforeEach(() => {
+  process.env.GALAXY_URL = "https://usegalaxy.org";
+  process.env.GALAXY_API_KEY = "test-key";
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (origUrl !== undefined) process.env.GALAXY_URL = origUrl;
+  else delete process.env.GALAXY_URL;
+  if (origKey !== undefined) process.env.GALAXY_API_KEY = origKey;
+  else delete process.env.GALAXY_API_KEY;
+});
+
+describe("listHistoryPages", () => {
+  it("hits /pages with the history_id query param", async () => {
+    const get = vi.spyOn(galaxyApi, "galaxyGet").mockResolvedValue([] as GalaxyPageSummary[]);
+    await listHistoryPages("hist-123");
+    expect(get).toHaveBeenCalledWith("/pages?history_id=hist-123", undefined);
+  });
+
+  it("url-encodes the history id", async () => {
+    const get = vi.spyOn(galaxyApi, "galaxyGet").mockResolvedValue([] as GalaxyPageSummary[]);
+    await listHistoryPages("hist with spaces/and slashes");
+    expect(get).toHaveBeenCalledWith(
+      "/pages?history_id=hist%20with%20spaces%2Fand%20slashes",
+      undefined,
+    );
+  });
+});
+
+describe("getPage", () => {
+  it("returns the page with content + content_format", async () => {
+    const fixture: GalaxyPage = {
+      id: "page-abc",
+      title: "My Analysis",
+      slug: "my-analysis",
+      history_id: "hist-1",
+      content: "# Hello\n",
+      content_format: "markdown",
+      edit_source: "agent",
+      create_time: "2026-04-01T00:00:00Z",
+      update_time: "2026-05-14T00:00:00Z",
+      revision_count: 3,
+    };
+    vi.spyOn(galaxyApi, "galaxyGet").mockResolvedValue(fixture);
+    const got = await getPage("page-abc");
+    expect(got).toEqual(fixture);
+  });
+});
+
+describe("createPage", () => {
+  it("posts /pages with markdown content_format and no edit_source", async () => {
+    const post = vi.spyOn(galaxyApi, "galaxyPost").mockResolvedValue({
+      id: "page-new",
+      title: "T",
+      slug: "t",
+      history_id: "h",
+      create_time: "2026-05-14T00:00:00Z",
+      update_time: "2026-05-14T00:00:00Z",
+    } as GalaxyPageSummary);
+
+    await createPage({
+      title: "My Analysis",
+      content: "# heading",
+      history_id: "hist-1",
+    });
+
+    expect(post).toHaveBeenCalledWith(
+      "/pages",
+      {
+        title: "My Analysis",
+        content: "# heading",
+        content_format: "markdown",
+        history_id: "hist-1",
+      },
+      undefined,
+    );
+    // edit_source must NOT appear in the create body — upstream CreatePagePayload
+    // doesn't expose it and would silently drop it (extra="allow").
+    expect(post.mock.calls[0][1]).not.toHaveProperty("edit_source");
+  });
+
+  it("passes optional slug + annotation through when provided", async () => {
+    const post = vi.spyOn(galaxyApi, "galaxyPost").mockResolvedValue({
+      id: "page-new",
+      title: "T",
+      slug: "custom",
+      history_id: "h",
+      create_time: "x",
+      update_time: "x",
+    } as GalaxyPageSummary);
+
+    await createPage({
+      title: "T",
+      content: "c",
+      history_id: "h",
+      slug: "custom",
+      annotation: "for review",
+    });
+
+    expect(post.mock.calls[0][1]).toMatchObject({
+      slug: "custom",
+      annotation: "for review",
+    });
+  });
+});
+
+describe("updatePage", () => {
+  it("puts /pages/{id} with content + content_format and edit_source when given", async () => {
+    const put = vi.spyOn(galaxyApi, "galaxyPut").mockResolvedValue({
+      id: "page-1",
+      title: "T",
+      slug: "t",
+      history_id: "h",
+      create_time: "x",
+      update_time: "y",
+    } as GalaxyPageSummary);
+
+    await updatePage("page-1", {
+      content: "new body",
+      title: "Updated Title",
+      edit_source: "agent",
+    });
+
+    expect(put).toHaveBeenCalledWith(
+      "/pages/page-1",
+      {
+        content: "new body",
+        content_format: "markdown",
+        title: "Updated Title",
+        edit_source: "agent",
+      },
+      undefined,
+    );
+  });
+
+  it("omits title/annotation/edit_source when unset", async () => {
+    const put = vi.spyOn(galaxyApi, "galaxyPut").mockResolvedValue({
+      id: "page-1",
+      title: "T",
+      slug: "t",
+      history_id: "h",
+      create_time: "x",
+      update_time: "y",
+    } as GalaxyPageSummary);
+
+    await updatePage("page-1", { content: "x" });
+
+    expect(put.mock.calls[0][1]).toEqual({
+      content: "x",
+      content_format: "markdown",
+    });
+  });
+});
+
+describe("getPageRevisions vs getPageRevisionDetails — the revision split", () => {
+  // The main contract correction in this client. The list endpoint returns
+  // PageRevisionSummary[] — id, page_id, edit_source, create_time,
+  // update_time — and *not* content or title. To get the body you must
+  // call the per-revision details endpoint. The summary type and details
+  // type are intentionally distinct so a misuse (reading rev.content from
+  // the list) is a compile-time error, not a runtime undefined.
+
+  it("getPageRevisions returns summaries without content", async () => {
+    const summary: GalaxyPageRevisionSummary = {
+      id: "rev-1",
+      page_id: "page-1",
+      edit_source: "agent",
+      create_time: "2026-05-14T00:00:00Z",
+      update_time: "2026-05-14T00:00:00Z",
+    };
+    vi.spyOn(galaxyApi, "galaxyGet").mockResolvedValue([summary]);
+
+    const got = await getPageRevisions("page-1");
+    expect(got).toEqual([summary]);
+    // Belt-and-suspenders: the summary fixture has no content field.
+    expect((got[0] as Record<string, unknown>).content).toBeUndefined();
+  });
+
+  it("getPageRevisionDetails returns content + title", async () => {
+    const details: GalaxyPageRevisionDetails = {
+      id: "rev-1",
+      page_id: "page-1",
+      edit_source: "agent",
+      create_time: "2026-05-14T00:00:00Z",
+      update_time: "2026-05-14T00:00:00Z",
+      title: "My Analysis (rev 1)",
+      content: "# heading\n",
+      content_format: "markdown",
+    };
+    vi.spyOn(galaxyApi, "galaxyGet").mockResolvedValue(details);
+
+    const got = await getPageRevisionDetails("page-1", "rev-1");
+    expect(got.content).toBe("# heading\n");
+    expect(got.title).toBe("My Analysis (rev 1)");
+  });
+
+  it("getPageRevisionDetails url-encodes both ids", async () => {
+    const get = vi.spyOn(galaxyApi, "galaxyGet").mockResolvedValue({
+      id: "r",
+      page_id: "p",
+      create_time: "x",
+      update_time: "x",
+    } as GalaxyPageRevisionDetails);
+
+    await getPageRevisionDetails("page/with/slashes", "rev:with:colons");
+    expect(get).toHaveBeenCalledWith(
+      "/pages/page%2Fwith%2Fslashes/revisions/rev%3Awith%3Acolons",
+      undefined,
+    );
+  });
+});

--- a/tests/galaxy-pages-api.test.ts
+++ b/tests/galaxy-pages-api.test.ts
@@ -66,7 +66,8 @@ describe("getPage", () => {
       edit_source: "agent",
       create_time: "2026-04-01T00:00:00Z",
       update_time: "2026-05-14T00:00:00Z",
-      revision_count: 3,
+      latest_revision_id: "rev-3",
+      revision_ids: ["rev-1", "rev-2", "rev-3"],
     };
     vi.spyOn(galaxyApi, "galaxyGet").mockResolvedValue(fixture);
     const got = await getPage("page-abc");
@@ -81,6 +82,7 @@ describe("createPage", () => {
       title: "T",
       slug: "t",
       history_id: "h",
+      latest_revision_id: "rev-1",
       create_time: "2026-05-14T00:00:00Z",
       update_time: "2026-05-14T00:00:00Z",
     } as GalaxyPageSummary);
@@ -112,6 +114,7 @@ describe("createPage", () => {
       title: "T",
       slug: "custom",
       history_id: "h",
+      latest_revision_id: "rev-1",
       create_time: "x",
       update_time: "x",
     } as GalaxyPageSummary);
@@ -132,16 +135,20 @@ describe("createPage", () => {
 });
 
 describe("updatePage", () => {
-  it("puts /pages/{id} with content + content_format and edit_source when given", async () => {
-    const put = vi.spyOn(galaxyApi, "galaxyPut").mockResolvedValue({
+  function mockPutOk() {
+    return vi.spyOn(galaxyApi, "galaxyPut").mockResolvedValue({
       id: "page-1",
       title: "T",
       slug: "t",
       history_id: "h",
+      latest_revision_id: "rev-2",
       create_time: "x",
       update_time: "y",
     } as GalaxyPageSummary);
+  }
 
+  it("puts /pages/{id} with markdown content_format and the given edit_source", async () => {
+    const put = mockPutOk();
     await updatePage("page-1", {
       content: "new body",
       title: "Updated Title",
@@ -153,29 +160,41 @@ describe("updatePage", () => {
       {
         content: "new body",
         content_format: "markdown",
-        title: "Updated Title",
         edit_source: "agent",
+        title: "Updated Title",
       },
       undefined,
     );
   });
 
-  it("omits title/annotation/edit_source when unset", async () => {
-    const put = vi.spyOn(galaxyApi, "galaxyPut").mockResolvedValue({
-      id: "page-1",
-      title: "T",
-      slug: "t",
-      history_id: "h",
-      create_time: "x",
-      update_time: "y",
-    } as GalaxyPageSummary);
-
+  it("defaults edit_source to \"agent\" when the caller doesn't supply one", async () => {
+    // This client only sees Loom-authored sync writes, so making each
+    // call site remember `edit_source: "agent"` is a footgun. Default it
+    // here; callers can override with an explicit value if needed.
+    const put = mockPutOk();
     await updatePage("page-1", { content: "x" });
 
     expect(put.mock.calls[0][1]).toEqual({
       content: "x",
       content_format: "markdown",
+      edit_source: "agent",
     });
+  });
+
+  it("honors an explicit edit_source override", async () => {
+    const put = mockPutOk();
+    await updatePage("page-1", { content: "x", edit_source: "user" });
+
+    expect(put.mock.calls[0][1]).toMatchObject({ edit_source: "user" });
+  });
+
+  it("omits title and annotation when unset", async () => {
+    const put = mockPutOk();
+    await updatePage("page-1", { content: "x" });
+
+    const body = put.mock.calls[0][1];
+    expect(body).not.toHaveProperty("title");
+    expect(body).not.toHaveProperty("annotation");
   });
 });
 

--- a/tests/galaxy-pages-sync.test.ts
+++ b/tests/galaxy-pages-sync.test.ts
@@ -6,6 +6,7 @@ import * as state from "../extensions/loom/state";
 import {
     pushNotebookToGalaxy,
     pullNotebookFromGalaxy,
+    linkGalaxyPage,
 } from "../extensions/loom/galaxy-pages-sync";
 
 vi.mock("../extensions/loom/galaxy-pages-api");
@@ -214,5 +215,77 @@ describe("pullNotebookFromGalaxy", () => {
         expect(written).not.toContain("Some local edits.");
         expect(written).toContain("```loom-galaxy-page");
         expect(written).toContain("last_synced_revision: r2");
+    });
+});
+
+describe("linkGalaxyPage", () => {
+    it("inserts a binding block from a getPage response", async () => {
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(
+            "# Notebook\n\nNo binding yet.\n",
+        );
+        vi.mocked(pagesApi.getPage).mockResolvedValue({
+            id: "p7",
+            slug: "linked-page",
+            latest_revision_id: "r3",
+            revision_ids: ["r3"],
+            title: "Linked",
+            content: "ignored",
+            content_format: "markdown",
+            history_id: "h7",
+            create_time: "2026-05-20T00:00:00Z",
+            update_time: "2026-05-20T00:00:00Z",
+        });
+
+        const result = await linkGalaxyPage("p7");
+
+        expect(pagesApi.getPage).toHaveBeenCalledWith("p7");
+        expect(result).toEqual({ pageId: "p7", latestRevisionId: "r3" });
+        const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(
+            -1,
+        )![1];
+        expect(written).toContain("page_id: p7");
+        expect(written).toContain("page_slug: linked-page");
+        expect(written).toContain("history_id: h7");
+        expect(written).toContain("# Notebook");
+    });
+
+    it("requires explicit history_id when the page response doesn't carry one", async () => {
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue("# Notebook\n");
+        vi.mocked(pagesApi.getPage).mockResolvedValue({
+            id: "p8",
+            slug: "no-hist",
+            latest_revision_id: "r4",
+            revision_ids: ["r4"],
+            title: "NoHist",
+            content: "",
+            content_format: "markdown",
+            create_time: "2026-05-20T00:00:00Z",
+            update_time: "2026-05-20T00:00:00Z",
+        });
+
+        await expect(linkGalaxyPage("p8")).rejects.toThrow(/history_id/);
+    });
+
+    it("uses provided history_id when caller supplies one", async () => {
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue("# Notebook\n");
+        vi.mocked(pagesApi.getPage).mockResolvedValue({
+            id: "p9",
+            slug: "x",
+            latest_revision_id: "r5",
+            revision_ids: ["r5"],
+            title: "X",
+            content: "",
+            content_format: "markdown",
+            create_time: "2026-05-20T00:00:00Z",
+            update_time: "2026-05-20T00:00:00Z",
+        });
+
+        const result = await linkGalaxyPage("p9", { historyId: "h9-explicit" });
+
+        expect(result.pageId).toBe("p9");
+        const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(
+            -1,
+        )![1];
+        expect(written).toContain("history_id: h9-explicit");
     });
 });

--- a/tests/galaxy-pages-sync.test.ts
+++ b/tests/galaxy-pages-sync.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as pagesApi from "../extensions/loom/galaxy-pages-api";
+import * as galaxyApi from "../extensions/loom/galaxy-api";
+import * as notebookWriter from "../extensions/loom/notebook-writer";
+import * as state from "../extensions/loom/state";
+import { pushNotebookToGalaxy } from "../extensions/loom/galaxy-pages-sync";
+
+vi.mock("../extensions/loom/galaxy-pages-api");
+vi.mock("../extensions/loom/galaxy-api");
+vi.mock("../extensions/loom/notebook-writer", async (importOriginal) => {
+    const actual = await importOriginal<typeof notebookWriter>();
+    return {
+        ...actual,
+        readNotebook: vi.fn(),
+        writeNotebook: vi.fn(),
+        withNotebookLock: vi.fn(async (_p: string, fn: () => Promise<unknown>) => fn()),
+    };
+});
+vi.mock("../extensions/loom/state");
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(state.getNotebookPath).mockReturnValue("/work/notebook.md");
+    vi.mocked(galaxyApi.getGalaxyConfig).mockReturnValue({
+        url: "https://galaxy.example",
+        apiKey: "k",
+    });
+    vi.mocked(notebookWriter.withNotebookLock).mockImplementation(
+        async (_p: string, fn: () => Promise<unknown>) => fn() as Promise<never>,
+    );
+});
+
+describe("pushNotebookToGalaxy", () => {
+    it("creates a new page when notebook has no binding", async () => {
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(
+            "# Analysis\n\nBody content.\n",
+        );
+        vi.mocked(pagesApi.createPage).mockResolvedValue({
+            id: "p1",
+            slug: "analysis",
+            latest_revision_id: "r1",
+            revision_ids: ["r1"],
+            title: "Analysis",
+            create_time: "2026-05-20T00:00:00Z",
+            update_time: "2026-05-20T00:00:00Z",
+        });
+
+        const result = await pushNotebookToGalaxy({
+            historyId: "h1",
+            title: "Analysis",
+        });
+
+        expect(pagesApi.createPage).toHaveBeenCalledWith({
+            history_id: "h1",
+            title: "Analysis",
+            slug: undefined,
+            annotation: undefined,
+            content: "# Analysis\n\nBody content.\n",
+            content_format: "markdown",
+        });
+        expect(result).toEqual({
+            pageId: "p1",
+            pageSlug: "analysis",
+            latestRevisionId: "r1",
+            action: "created",
+        });
+        expect(notebookWriter.writeNotebook).toHaveBeenCalledOnce();
+        const written = vi.mocked(notebookWriter.writeNotebook).mock
+            .calls[0][1];
+        expect(written).toContain("```loom-galaxy-page");
+        expect(written).toContain("page_id: p1");
+        expect(written).toContain("last_synced_revision: r1");
+    });
+
+    it("updates the existing page when a binding is present", async () => {
+        const initial = [
+            "# Analysis",
+            "",
+            "Body content.",
+            "",
+            "```loom-galaxy-page",
+            "page_id: p1",
+            "page_slug: analysis",
+            'galaxy_server_url: "https://galaxy.example"',
+            "history_id: h1",
+            "last_synced_revision: r1",
+            "bound_at: 2026-05-20T10:00:00Z",
+            "```",
+            "",
+        ].join("\n");
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(initial);
+        vi.mocked(pagesApi.updatePage).mockResolvedValue({
+            id: "p1",
+            slug: "analysis",
+            latest_revision_id: "r2",
+            revision_ids: ["r1", "r2"],
+            title: "Analysis",
+            create_time: "2026-05-20T00:00:00Z",
+            update_time: "2026-05-21T00:00:00Z",
+        });
+
+        const result = await pushNotebookToGalaxy();
+
+        expect(pagesApi.updatePage).toHaveBeenCalledWith(
+            "p1",
+            expect.objectContaining({
+                content: expect.not.stringContaining("loom-galaxy-page"),
+                content_format: "markdown",
+                edit_source: "agent",
+            }),
+        );
+        expect(result).toEqual({
+            pageId: "p1",
+            pageSlug: "analysis",
+            latestRevisionId: "r2",
+            action: "updated",
+        });
+        const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(
+            -1,
+        )![1];
+        expect(written).toContain("last_synced_revision: r2");
+    });
+
+    it("throws on server-URL mismatch before calling Galaxy", async () => {
+        const initial = [
+            "```loom-galaxy-page",
+            "page_id: p1",
+            "page_slug: a",
+            'galaxy_server_url: "https://other.example"',
+            "history_id: h1",
+            "last_synced_revision: r1",
+            "bound_at: 2026-05-20T10:00:00Z",
+            "```",
+            "",
+        ].join("\n");
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(initial);
+
+        await expect(pushNotebookToGalaxy()).rejects.toThrow(
+            /bound to.*other\.example.*connected to.*galaxy\.example/,
+        );
+        expect(pagesApi.updatePage).not.toHaveBeenCalled();
+    });
+});

--- a/tests/galaxy-pages-sync.test.ts
+++ b/tests/galaxy-pages-sync.test.ts
@@ -7,6 +7,7 @@ import {
     pushNotebookToGalaxy,
     pullNotebookFromGalaxy,
     linkGalaxyPage,
+    resumeGalaxyPage,
 } from "../extensions/loom/galaxy-pages-sync";
 
 vi.mock("../extensions/loom/galaxy-pages-api");
@@ -287,5 +288,163 @@ describe("linkGalaxyPage", () => {
             -1,
         )![1];
         expect(written).toContain("history_id: h9-explicit");
+    });
+});
+
+describe("resumeGalaxyPage", () => {
+    it("links and pulls when notebook has no binding", async () => {
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(
+            "# Template\n\nNothing here yet.\n",
+        );
+        vi.mocked(pagesApi.getPage).mockResolvedValue({
+            id: "p10",
+            slug: "resumed",
+            latest_revision_id: "r10",
+            revision_ids: ["r10"],
+            title: "Resumed",
+            content: "# Remote analysis\n\nReal work happened here.\n",
+            content_format: "markdown",
+            history_id: "h10",
+            create_time: "2026-05-20T00:00:00Z",
+            update_time: "2026-05-20T00:00:00Z",
+        });
+
+        const result = await resumeGalaxyPage("p10");
+
+        expect(pagesApi.getPage).toHaveBeenCalledWith("p10");
+        expect(result).toEqual({
+            pageId: "p10",
+            latestRevisionId: "r10",
+            action: "linked",
+        });
+        const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(
+            -1,
+        )![1];
+        expect(written).toContain("# Remote analysis");
+        expect(written).toContain("Real work happened here.");
+        expect(written).not.toContain("Template");
+        expect(written).toContain("page_id: p10");
+        expect(written).toContain("history_id: h10");
+        expect(written).toContain("last_synced_revision: r10");
+    });
+
+    it("refreshes when already bound to the same page (preserves bound_at)", async () => {
+        const bound = [
+            "Local stale content.",
+            "",
+            "```loom-galaxy-page",
+            "page_id: p11",
+            "page_slug: same",
+            'galaxy_server_url: "https://galaxy.example"',
+            "history_id: h11",
+            "last_synced_revision: r11",
+            "bound_at: 2026-05-20T10:00:00Z",
+            "```",
+            "",
+        ].join("\n");
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
+        vi.mocked(pagesApi.getPage).mockResolvedValue({
+            id: "p11",
+            slug: "same",
+            latest_revision_id: "r12",
+            revision_ids: ["r11", "r12"],
+            title: "Same",
+            content: "# Fresh from server\n",
+            content_format: "markdown",
+            history_id: "h11",
+            create_time: "2026-05-20T00:00:00Z",
+            update_time: "2026-05-21T00:00:00Z",
+        });
+
+        const result = await resumeGalaxyPage("p11");
+
+        expect(result.action).toBe("refreshed");
+        const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(
+            -1,
+        )![1];
+        expect(written).toContain("# Fresh from server");
+        expect(written).not.toContain("Local stale content.");
+        expect(written).toContain("last_synced_revision: r12");
+        expect(written).toContain("bound_at: 2026-05-20T10:00:00Z");
+    });
+
+    it("refuses to clobber when bound to a different page on the same server", async () => {
+        const bound = [
+            "```loom-galaxy-page",
+            "page_id: p-mine",
+            "page_slug: mine",
+            'galaxy_server_url: "https://galaxy.example"',
+            "history_id: h1",
+            "last_synced_revision: r1",
+            "bound_at: 2026-05-20T10:00:00Z",
+            "```",
+            "",
+        ].join("\n");
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
+        vi.mocked(pagesApi.getPage).mockResolvedValue({
+            id: "p-other",
+            slug: "other",
+            latest_revision_id: "r2",
+            revision_ids: ["r2"],
+            title: "Other",
+            content: "should not land",
+            content_format: "markdown",
+            history_id: "h1",
+            create_time: "2026-05-20T00:00:00Z",
+            update_time: "2026-05-20T00:00:00Z",
+        });
+
+        await expect(resumeGalaxyPage("p-other")).rejects.toThrow(
+            /already bound to page p-mine/,
+        );
+        expect(notebookWriter.writeNotebook).not.toHaveBeenCalled();
+    });
+
+    it("throws on server-URL mismatch before writing", async () => {
+        const bound = [
+            "```loom-galaxy-page",
+            "page_id: p1",
+            "page_slug: a",
+            'galaxy_server_url: "https://other.example"',
+            "history_id: h1",
+            "last_synced_revision: r1",
+            "bound_at: 2026-05-20T10:00:00Z",
+            "```",
+            "",
+        ].join("\n");
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
+        vi.mocked(pagesApi.getPage).mockResolvedValue({
+            id: "p1",
+            slug: "a",
+            latest_revision_id: "r1",
+            revision_ids: ["r1"],
+            title: "A",
+            content: "",
+            content_format: "markdown",
+            history_id: "h1",
+            create_time: "2026-05-20T00:00:00Z",
+            update_time: "2026-05-20T00:00:00Z",
+        });
+        await expect(resumeGalaxyPage("p1")).rejects.toThrow(
+            /bound to.*other\.example.*connected to.*galaxy\.example/,
+        );
+        expect(notebookWriter.writeNotebook).not.toHaveBeenCalled();
+    });
+
+    it("requires history_id when the page response doesn't carry one", async () => {
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue("# Template\n");
+        vi.mocked(pagesApi.getPage).mockResolvedValue({
+            id: "p20",
+            slug: "no-hist",
+            latest_revision_id: "r20",
+            revision_ids: ["r20"],
+            title: "NoHist",
+            content: "body",
+            content_format: "markdown",
+            create_time: "2026-05-20T00:00:00Z",
+            update_time: "2026-05-20T00:00:00Z",
+        });
+
+        await expect(resumeGalaxyPage("p20")).rejects.toThrow(/history_id/);
     });
 });

--- a/tests/galaxy-pages-sync.test.ts
+++ b/tests/galaxy-pages-sync.test.ts
@@ -3,7 +3,10 @@ import * as pagesApi from "../extensions/loom/galaxy-pages-api";
 import * as galaxyApi from "../extensions/loom/galaxy-api";
 import * as notebookWriter from "../extensions/loom/notebook-writer";
 import * as state from "../extensions/loom/state";
-import { pushNotebookToGalaxy } from "../extensions/loom/galaxy-pages-sync";
+import {
+    pushNotebookToGalaxy,
+    pullNotebookFromGalaxy,
+} from "../extensions/loom/galaxy-pages-sync";
 
 vi.mock("../extensions/loom/galaxy-pages-api");
 vi.mock("../extensions/loom/galaxy-api");
@@ -139,5 +142,77 @@ describe("pushNotebookToGalaxy", () => {
             /bound to.*other\.example.*connected to.*galaxy\.example/,
         );
         expect(pagesApi.updatePage).not.toHaveBeenCalled();
+    });
+});
+
+describe("pullNotebookFromGalaxy", () => {
+    it("throws when notebook has no binding", async () => {
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(
+            "# No binding here\n",
+        );
+        await expect(pullNotebookFromGalaxy()).rejects.toThrow(
+            /not bound to a Galaxy page/,
+        );
+        expect(pagesApi.getPage).not.toHaveBeenCalled();
+    });
+
+    it("throws on server-URL mismatch", async () => {
+        const bound = [
+            "```loom-galaxy-page",
+            "page_id: p1",
+            "page_slug: a",
+            'galaxy_server_url: "https://other.example"',
+            "history_id: h1",
+            "last_synced_revision: r1",
+            "bound_at: 2026-05-20T10:00:00Z",
+            "```",
+            "",
+        ].join("\n");
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
+        await expect(pullNotebookFromGalaxy()).rejects.toThrow(
+            /bound to.*other\.example.*connected to.*galaxy\.example/,
+        );
+        expect(pagesApi.getPage).not.toHaveBeenCalled();
+    });
+
+    it("replaces notebook with remote body and re-applies binding with new revision", async () => {
+        const bound = [
+            "Some local edits.",
+            "",
+            "```loom-galaxy-page",
+            "page_id: p1",
+            "page_slug: a",
+            'galaxy_server_url: "https://galaxy.example"',
+            "history_id: h1",
+            "last_synced_revision: r1",
+            "bound_at: 2026-05-20T10:00:00Z",
+            "```",
+            "",
+        ].join("\n");
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
+        vi.mocked(pagesApi.getPage).mockResolvedValue({
+            id: "p1",
+            slug: "a",
+            latest_revision_id: "r2",
+            revision_ids: ["r1", "r2"],
+            title: "A",
+            content: "# Remote body\n\nUpdated server-side.\n",
+            content_format: "markdown",
+            create_time: "2026-05-20T00:00:00Z",
+            update_time: "2026-05-21T00:00:00Z",
+        });
+
+        const result = await pullNotebookFromGalaxy();
+
+        expect(pagesApi.getPage).toHaveBeenCalledWith("p1");
+        expect(result).toEqual({ pageId: "p1", latestRevisionId: "r2" });
+        const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(
+            -1,
+        )![1];
+        expect(written).toContain("# Remote body");
+        expect(written).toContain("Updated server-side.");
+        expect(written).not.toContain("Some local edits.");
+        expect(written).toContain("```loom-galaxy-page");
+        expect(written).toContain("last_synced_revision: r2");
     });
 });

--- a/tests/notebook-link-tool.test.ts
+++ b/tests/notebook-link-tool.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+import * as sync from "../extensions/loom/galaxy-pages-sync";
+
+vi.mock("../extensions/loom/galaxy-pages-sync");
+
+interface ToolDef {
+    name: string;
+    execute: (
+        callId: string,
+        params: Record<string, unknown>,
+        signal: AbortSignal,
+        onUpdate: () => void,
+        ctx: Record<string, unknown>,
+    ) => Promise<{ content: { type: string; text: string }[]; details?: unknown }>;
+}
+
+describe("notebook_link_galaxy_page tool", () => {
+    it("forwards page_id and optional history_id to linkGalaxyPage", async () => {
+        const tools: ToolDef[] = [];
+        const api = {
+            registerTool: (d: ToolDef) => tools.push(d),
+            registerCommand: vi.fn(),
+            sendUserMessage: vi.fn(),
+        };
+        const { registerNotebookSyncTools } = await import(
+            "../extensions/loom/tools-sync"
+        );
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        registerNotebookSyncTools(api as any);
+        const tool = tools.find((t) => t.name === "notebook_link_galaxy_page");
+        expect(tool).toBeDefined();
+
+        vi.mocked(sync.linkGalaxyPage).mockResolvedValue({
+            pageId: "p5",
+            latestRevisionId: "r7",
+        });
+        await tool!.execute(
+            "c1",
+            { page_id: "p5", history_id: "h5" },
+            new AbortController().signal,
+            vi.fn(),
+            {},
+        );
+        expect(sync.linkGalaxyPage).toHaveBeenCalledWith("p5", {
+            historyId: "h5",
+        });
+    });
+});

--- a/tests/notebook-pull-tool.test.ts
+++ b/tests/notebook-pull-tool.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+import * as sync from "../extensions/loom/galaxy-pages-sync";
+
+vi.mock("../extensions/loom/galaxy-pages-sync");
+
+interface ToolDef {
+    name: string;
+    execute: (
+        callId: string,
+        params: Record<string, unknown>,
+        signal: AbortSignal,
+        onUpdate: () => void,
+        ctx: Record<string, unknown>,
+    ) => Promise<{ content: { type: string; text: string }[]; details?: unknown }>;
+}
+
+describe("notebook_pull_from_galaxy tool", () => {
+    it("forwards to pullNotebookFromGalaxy", async () => {
+        const tools: ToolDef[] = [];
+        const api = {
+            registerTool: (d: ToolDef) => tools.push(d),
+            registerCommand: vi.fn(),
+            sendUserMessage: vi.fn(),
+        };
+        const { registerNotebookSyncTools } = await import(
+            "../extensions/loom/tools-sync"
+        );
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        registerNotebookSyncTools(api as any);
+        const tool = tools.find((t) => t.name === "notebook_pull_from_galaxy");
+        expect(tool).toBeDefined();
+
+        vi.mocked(sync.pullNotebookFromGalaxy).mockResolvedValue({
+            pageId: "p1",
+            latestRevisionId: "r2",
+        });
+        const result = await tool!.execute(
+            "c1",
+            {},
+            new AbortController().signal,
+            vi.fn(),
+            {},
+        );
+
+        expect(sync.pullNotebookFromGalaxy).toHaveBeenCalledWith();
+        expect(result.content[0].text).toContain("r2");
+    });
+});

--- a/tests/notebook-push-tool.test.ts
+++ b/tests/notebook-push-tool.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import * as sync from "../extensions/loom/galaxy-pages-sync";
+
+vi.mock("../extensions/loom/galaxy-pages-sync");
+
+interface ToolDef {
+    name: string;
+    label?: string;
+    execute: (
+        callId: string,
+        params: Record<string, unknown>,
+        signal: AbortSignal,
+        onUpdate: () => void,
+        ctx: Record<string, unknown>,
+    ) => Promise<{ content: { type: string; text: string }[]; details?: unknown }>;
+}
+
+function makeFakeApi() {
+    const tools: ToolDef[] = [];
+    return {
+        api: {
+            registerTool: (def: ToolDef) => {
+                tools.push(def);
+            },
+            registerCommand: vi.fn(),
+            sendUserMessage: vi.fn(),
+        },
+        tools,
+    };
+}
+
+describe("notebook_push_to_galaxy tool", () => {
+    it("registers with expected label and forwards args to pushNotebookToGalaxy", async () => {
+        const { api, tools } = makeFakeApi();
+        const { registerNotebookSyncTools } = await import(
+            "../extensions/loom/tools-sync"
+        );
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        registerNotebookSyncTools(api as any);
+
+        const tool = tools.find((t) => t.name === "notebook_push_to_galaxy");
+        expect(tool).toBeDefined();
+        expect(tool!.label).toBe("Push notebook to Galaxy page");
+
+        vi.mocked(sync.pushNotebookToGalaxy).mockResolvedValue({
+            pageId: "p1",
+            pageSlug: "a",
+            latestRevisionId: "r1",
+            action: "created",
+        });
+        const result = await tool!.execute(
+            "call-1",
+            { history_id: "h1", title: "A" },
+            new AbortController().signal,
+            vi.fn(),
+            {},
+        );
+
+        expect(sync.pushNotebookToGalaxy).toHaveBeenCalledWith({
+            historyId: "h1",
+            title: "A",
+            slug: undefined,
+            annotation: undefined,
+        });
+        expect(result.content[0].text).toContain("p1");
+        expect(result.content[0].text).toContain("created");
+    });
+});

--- a/tests/notebook-resume-tool.test.ts
+++ b/tests/notebook-resume-tool.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import * as sync from "../extensions/loom/galaxy-pages-sync";
+
+vi.mock("../extensions/loom/galaxy-pages-sync");
+
+interface ToolDef {
+    name: string;
+    execute: (
+        callId: string,
+        params: Record<string, unknown>,
+        signal: AbortSignal,
+        onUpdate: () => void,
+        ctx: Record<string, unknown>,
+    ) => Promise<{ content: { type: string; text: string }[]; details?: unknown }>;
+}
+
+describe("notebook_resume_from_galaxy tool", () => {
+    it("forwards page_id and optional history_id to resumeGalaxyPage", async () => {
+        const tools: ToolDef[] = [];
+        const api = {
+            registerTool: (d: ToolDef) => tools.push(d),
+            registerCommand: vi.fn(),
+            sendUserMessage: vi.fn(),
+        };
+        const { registerNotebookSyncTools } = await import(
+            "../extensions/loom/tools-sync"
+        );
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        registerNotebookSyncTools(api as any);
+        const tool = tools.find((t) => t.name === "notebook_resume_from_galaxy");
+        expect(tool).toBeDefined();
+
+        vi.mocked(sync.resumeGalaxyPage).mockResolvedValue({
+            pageId: "p99",
+            latestRevisionId: "r99",
+            action: "linked",
+        });
+        const result = await tool!.execute(
+            "c1",
+            { page_id: "p99", history_id: "h99" },
+            new AbortController().signal,
+            vi.fn(),
+            {},
+        );
+        expect(sync.resumeGalaxyPage).toHaveBeenCalledWith("p99", {
+            historyId: "h99",
+        });
+        const payload = JSON.parse(result.content[0].text) as {
+            page_id: string;
+            latest_revision_id: string;
+            action: string;
+        };
+        expect(payload).toEqual({
+            page_id: "p99",
+            latest_revision_id: "r99",
+            action: "linked",
+        });
+    });
+});

--- a/tests/sync-command.test.ts
+++ b/tests/sync-command.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as notebookWriter from "../extensions/loom/notebook-writer";
+import * as state from "../extensions/loom/state";
+import * as sync from "../extensions/loom/galaxy-pages-sync";
+
+vi.mock("../extensions/loom/notebook-writer", async (importOriginal) => {
+    const actual = await importOriginal<typeof notebookWriter>();
+    return { ...actual, readNotebook: vi.fn() };
+});
+vi.mock("../extensions/loom/state");
+vi.mock("../extensions/loom/galaxy-pages-sync");
+
+interface CmdDef {
+    description: string;
+    handler: (
+        args: string,
+        ctx: { ui: { notify: ReturnType<typeof vi.fn> } },
+    ) => Promise<void>;
+}
+
+function makeApi() {
+    const commands: Record<string, CmdDef> = {};
+    return {
+        api: {
+            registerCommand: (name: string, def: CmdDef) => {
+                commands[name] = def;
+            },
+            registerTool: vi.fn(),
+            sendUserMessage: vi.fn(),
+        },
+        commands,
+    };
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("/sync command", () => {
+    it("status with no binding reports unbound", async () => {
+        vi.mocked(state.getNotebookPath).mockReturnValue("/work/notebook.md");
+        vi.mocked(notebookWriter.readNotebook).mockResolvedValue("# No binding\n");
+        const { registerSyncCommand } = await import(
+            "../extensions/loom/sync-command"
+        );
+        const { api, commands } = makeApi();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        registerSyncCommand(api as any);
+
+        const ctx = { ui: { notify: vi.fn() } };
+        await commands.sync.handler("status", ctx);
+        expect(ctx.ui.notify).toHaveBeenCalledWith(
+            expect.stringMatching(/not bound/i),
+            expect.any(String),
+        );
+    });
+
+    it("push forwards parsed args to pushNotebookToGalaxy", async () => {
+        vi.mocked(sync.pushNotebookToGalaxy).mockResolvedValue({
+            pageId: "p1",
+            pageSlug: null,
+            latestRevisionId: "r1",
+            action: "created",
+        });
+        const { registerSyncCommand } = await import(
+            "../extensions/loom/sync-command"
+        );
+        const { api, commands } = makeApi();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        registerSyncCommand(api as any);
+
+        const ctx = { ui: { notify: vi.fn() } };
+        await commands.sync.handler(
+            'push --history h1 --title "My Analysis"',
+            ctx,
+        );
+        expect(sync.pushNotebookToGalaxy).toHaveBeenCalledWith({
+            historyId: "h1",
+            title: "My Analysis",
+            slug: undefined,
+            annotation: undefined,
+        });
+    });
+
+    it("pull forwards to pullNotebookFromGalaxy", async () => {
+        vi.mocked(sync.pullNotebookFromGalaxy).mockResolvedValue({
+            pageId: "p1",
+            latestRevisionId: "r2",
+        });
+        const { registerSyncCommand } = await import(
+            "../extensions/loom/sync-command"
+        );
+        const { api, commands } = makeApi();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        registerSyncCommand(api as any);
+
+        const ctx = { ui: { notify: vi.fn() } };
+        await commands.sync.handler("pull", ctx);
+        expect(sync.pullNotebookFromGalaxy).toHaveBeenCalled();
+    });
+
+    it("link parses page id and optional history", async () => {
+        vi.mocked(sync.linkGalaxyPage).mockResolvedValue({
+            pageId: "p2",
+            latestRevisionId: "r3",
+        });
+        const { registerSyncCommand } = await import(
+            "../extensions/loom/sync-command"
+        );
+        const { api, commands } = makeApi();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        registerSyncCommand(api as any);
+
+        const ctx = { ui: { notify: vi.fn() } };
+        await commands.sync.handler("link p2 --history h2", ctx);
+        expect(sync.linkGalaxyPage).toHaveBeenCalledWith("p2", {
+            historyId: "h2",
+        });
+    });
+});

--- a/tests/sync-command.test.ts
+++ b/tests/sync-command.test.ts
@@ -117,4 +117,45 @@ describe("/sync command", () => {
             historyId: "h2",
         });
     });
+
+    it("resume parses page id and optional history, reports action", async () => {
+        vi.mocked(sync.resumeGalaxyPage).mockResolvedValue({
+            pageId: "p7",
+            latestRevisionId: "r7",
+            action: "linked",
+        });
+        const { registerSyncCommand } = await import(
+            "../extensions/loom/sync-command"
+        );
+        const { api, commands } = makeApi();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        registerSyncCommand(api as any);
+
+        const ctx = { ui: { notify: vi.fn() } };
+        await commands.sync.handler("resume p7 --history h7", ctx);
+        expect(sync.resumeGalaxyPage).toHaveBeenCalledWith("p7", {
+            historyId: "h7",
+        });
+        expect(ctx.ui.notify).toHaveBeenCalledWith(
+            expect.stringMatching(/Resumed page p7.*linked.*revision r7/),
+            "info",
+        );
+    });
+
+    it("resume without a page id reports usage", async () => {
+        const { registerSyncCommand } = await import(
+            "../extensions/loom/sync-command"
+        );
+        const { api, commands } = makeApi();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        registerSyncCommand(api as any);
+
+        const ctx = { ui: { notify: vi.fn() } };
+        await commands.sync.handler("resume", ctx);
+        expect(sync.resumeGalaxyPage).not.toHaveBeenCalled();
+        expect(ctx.ui.notify).toHaveBeenCalledWith(
+            expect.stringMatching(/Usage: \/sync resume/),
+            "warning",
+        );
+    });
 });


### PR DESCRIPTION
## Why

galaxyproject/galaxy#22361 ("Galaxy Notebooks") added `/api/pages` endpoints
for persistent narratives bound to a history. That PR merged upstream on
2026-05-20 (commit `45982c8e`), so the contract is now stable and the full
notebook<->page sync slice can land together.

Originally I had this scoped as foundation-only (the REST client + binding
format) with tools/`/sync`/context-injection deferred to a follow-up while
#22361 was still open. With upstream merged, the follow-up rolled forward
into this same PR -- one slice end-to-end is easier to review and rolls
back as a unit if anything in the sync semantics turns out wrong.

## What lands

All under `extensions/loom/`. Commits are kept distinct (no squash, per
project norms) so the foundation layer is reviewable on its own.

**Foundation (3 commits, originally the scope of this PR):**

- **`cb24f51` -- Pages REST client** (`galaxy-pages-api.ts`,
  `galaxy-api.ts` +44, `tests/galaxy-pages-api.test.ts`)
  Typed wrappers for `listHistoryPages` / `getPage` / `createPage` /
  `updatePage` / `getPageRevisions` / `getPageRevisionDetails`. Contract
  notes:
  - Revisions split -- `GET /pages/{id}/revisions` returns
    `PageRevisionSummary[]` (no body); body is at
    `GET /pages/{id}/revisions/{revision_id}` (`PageRevisionDetails`).
    Two distinct TS types so reading `rev.content` from the list is a
    compile-time error, not a runtime undefined.
  - `edit_source` is only on `UpdatePagePayload` upstream;
    `CreatePagePayload` has `extra="allow"` and silently drops it.
  - `content_format` defaults to `"markdown"` client-side (server
    default is `"html"`); notebook content is always markdown.

- **`949c86d` -- `loom-galaxy-page` fenced YAML block**
  (`galaxy-page-binding.ts`, `tests/galaxy-page-binding.test.ts`)
  Mirrors the `loom-invocation` block grammar: `render` / `find` /
  `upsert` (keyed on `page_id`) / `strip`. Keeps `notebook.md` as pure
  markdown plus a small set of typed blocks rather than picking up a
  sidecar dotfile. v1 sync contract documented in the module header:
  push is unconditional local-wins, pull is unconditional remote-wins,
  `last_synced_revision` is stored and refreshed but **not** enforced
  (v2 adds the pre-flight check once we have real usage data).

- **`75d8e0e` -- Review-pass fixes**
  `revision_count` -> `latest_revision_id` + `revision_ids` to match
  upstream. `updatePage()` defaults `edit_source` to `"agent"` so call
  sites don't have to remember it.

**Sync slice (14 commits):**

- **Helpers** (`galaxy-pages-sync.ts`) -- `pushNotebookToGalaxy`,
  `pullNotebookFromGalaxy`, `linkGalaxyPage`, `resumeGalaxyPage`.
  Fail-closed on missing Galaxy server URL before any network call.
  Strips the binding block on push, re-applies it on pull/resume.
  (Commits `743387c`, `29d75e7`, `feaec42`, `b586e5a`, `60db43a`.)
- **Four tools** (`tools-sync.ts`) -- `notebook_push_to_galaxy`,
  `notebook_pull_from_galaxy`, `notebook_link_galaxy_page`,
  `notebook_resume_from_galaxy`. TypeBox param schemas, consistent
  `{content, details}` response shape. The resume tool is the one-shot
  "pick up a Galaxy page in a fresh Loom session" entry point -- saves
  the user from having to do link + pull as two separate calls.
  (Commits `9b1e4f7`, `2585e86`, `99fb388`, `908adf5`.)
- **`/sync` command** (`sync-command.ts`) -- `status` / `push` /
  `pull` / `link <pageId>` / `resume <pageId>` subcommands with a
  minimal `--key value` / `--key="quoted"` flag parser.
  (Commits `6ab5bd7`, `b4fc721`.)
- **Context injection** (`context.ts`) -- adds
  `buildGalaxyPageBindingBlock()` to the agent's system prompt between
  the notebook excerpt and recent-activity blocks, so the agent knows
  which Galaxy page (if any) the current notebook is bound to.
  (Commit `fb835ef`.)
- **Schema doc** (`docs/agent/notebook-schema.md`) -- documents the
  block grammar, the strip-on-push / re-apply-on-pull/resume contract,
  and the fail-closed server URL guard.
  (Commits `041c053`, `d0bd3fd`.)

## Test plan

- [x] `npm run typecheck` -- clean
- [x] `cd app && npx tsc --noEmit` -- clean
- [x] `npm test` -- 209/209 (foundation tests + 26 new across sync,
      tools, command, context-injection, and resume)
