### PR TITLE
Humanize agent API errors and dedupe duplicates in chat

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -1,4 +1,5 @@
 import { ChatPanel } from "./chat/chat-panel.js";
+import { humanizeAgentError } from "./chat/error-humanizer.js";
 import { ShellPanel } from "./chat/shell-panel.js";
 import { ArtifactPanel } from "./artifacts/artifact-panel.js";
 import { FilesPanel } from "./files/files-panel.js";
@@ -1789,7 +1790,7 @@ window.orbit.onAgentEvent((event) => {
         // isn't staring at a silent UI after a failed call.
         if (msg.stopReason === "error" && msg.errorMessage) {
           chat.hideThinking();
-          chat.addErrorMessage(msg.errorMessage);
+          chat.addErrorMessage(humanizeAgentError(msg.errorMessage).text);
           setStatusBadge("error");
         }
       }
@@ -1853,9 +1854,9 @@ window.orbit.onAgentEvent((event) => {
       break;
 
     case "error": {
-      const msg = (event as { message?: string }).message || "Unknown error";
+      const rawMsg = (event as { message?: string }).message || "Unknown error";
       chat.hideThinking();
-      chat.addErrorMessage(msg);
+      chat.addErrorMessage(humanizeAgentError(rawMsg).text);
       streaming = false;
       stopTurnTimer();
       setStatusBadge("error");

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -322,7 +322,7 @@ export class ChatPanel {
   addErrorMessage(text: string): void {
     if (this.lastErrorEl && this.lastErrorText === text) {
       this.lastErrorCount += 1;
-      this.lastErrorEl.textContent = `${text}  (×${this.lastErrorCount})`;
+      this.lastErrorEl.textContent = `${text}  (x${this.lastErrorCount})`;
       this.scrollToBottom();
       return;
     }

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -18,6 +18,11 @@ export class ChatPanel {
   private thinkingEl: HTMLElement | null = null;
   private cwd = "";
   private promptCounter = 0;
+  // Track the most recent error message so consecutive duplicates (e.g. the
+  // brain auto-retrying through an overloaded API) collapse to one card.
+  private lastErrorEl: HTMLElement | null = null;
+  private lastErrorText = "";
+  private lastErrorCount = 0;
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -80,6 +85,7 @@ export class ChatPanel {
   }
 
   addUserMessage(text: string): void {
+    this.resetErrorDedup();
     const n = ++this.promptCounter;
     const turn = document.createElement("div");
     turn.className = "user-turn";
@@ -111,6 +117,7 @@ export class ChatPanel {
    * counter equals the replay's count. Live numbers continue from there.
    */
   addReplayUserMessage(text: string, promptNum: number): void {
+    this.resetErrorDedup();
     this.promptCounter = promptNum;
     const turn = document.createElement("div");
     turn.className = "user-turn";
@@ -306,12 +313,27 @@ export class ChatPanel {
     }
   }
 
+  private resetErrorDedup(): void {
+    this.lastErrorEl = null;
+    this.lastErrorText = "";
+    this.lastErrorCount = 0;
+  }
+
   addErrorMessage(text: string): void {
+    if (this.lastErrorEl && this.lastErrorText === text) {
+      this.lastErrorCount += 1;
+      this.lastErrorEl.textContent = `${text}  (×${this.lastErrorCount})`;
+      this.scrollToBottom();
+      return;
+    }
     const el = document.createElement("div");
     el.className = "message assistant";
     el.style.color = "var(--error)";
     el.textContent = text;
     this.container.appendChild(el);
+    this.lastErrorEl = el;
+    this.lastErrorText = text;
+    this.lastErrorCount = 1;
     this.scrollToBottom();
   }
 

--- a/app/src/renderer/chat/error-humanizer.ts
+++ b/app/src/renderer/chat/error-humanizer.ts
@@ -1,0 +1,92 @@
+// Translate the raw error strings the brain forwards in `errorMessage` into
+// something a user can act on. pi-ai's providers fall back to
+// `JSON.stringify(error)` when the upstream throws a non-Error (which is what
+// the Anthropic SDK does for HTTP errors), so we end up showing the wire
+// payload verbatim in chat unless we unwrap it here.
+
+export interface HumanizedError {
+  text: string;
+  retriable: boolean;
+}
+
+interface AnthropicLikeError {
+  type?: string;
+  error?: { type?: string; message?: string };
+  message?: string;
+}
+
+const RETRIABLE_TYPES = new Set(["overloaded_error", "rate_limit_error", "api_error"]);
+
+export function humanizeAgentError(raw: string | undefined | null): HumanizedError {
+  if (!raw) return { text: "Unknown error", retriable: false };
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    return { text: raw, retriable: false };
+  }
+
+  let parsed: AnthropicLikeError;
+  try {
+    parsed = JSON.parse(trimmed) as AnthropicLikeError;
+  } catch {
+    return { text: raw, retriable: false };
+  }
+
+  const inner = parsed.error;
+  const errType = inner?.type;
+  const errMsg = inner?.message ?? parsed.message ?? "";
+
+  switch (errType) {
+    case "overloaded_error":
+      return {
+        text: "Anthropic is overloaded right now -- give it a moment and resend.",
+        retriable: true,
+      };
+    case "rate_limit_error":
+      return {
+        text: errMsg
+          ? `Rate limited by the API: ${errMsg}. Try again shortly.`
+          : "Rate limited by the API. Try again shortly.",
+        retriable: true,
+      };
+    case "api_error":
+      return {
+        text: errMsg
+          ? `Upstream API error: ${errMsg}. Try again.`
+          : "Upstream API error. Try again.",
+        retriable: true,
+      };
+    case "authentication_error":
+      return {
+        text: "Authentication failed -- check your API key in Preferences.",
+        retriable: false,
+      };
+    case "permission_error":
+      return {
+        text: errMsg ? `Permission denied: ${errMsg}` : "Permission denied.",
+        retriable: false,
+      };
+    case "not_found_error":
+      return {
+        text: errMsg ? `Model or resource not found: ${errMsg}` : "Model or resource not found.",
+        retriable: false,
+      };
+    case "request_too_large":
+      return {
+        text: "Request is too large for the model. Shorten the prompt or start a fresh session.",
+        retriable: false,
+      };
+    case "invalid_request_error":
+      return {
+        text: errMsg ? `Invalid request: ${errMsg}` : "Invalid request.",
+        retriable: false,
+      };
+  }
+
+  if (errMsg) {
+    return {
+      text: errType ? `${errType}: ${errMsg}` : errMsg,
+      retriable: errType ? RETRIABLE_TYPES.has(errType) : false,
+    };
+  }
+  return { text: raw, retriable: false };
+}

--- a/tests/error-humanizer.test.ts
+++ b/tests/error-humanizer.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { humanizeAgentError } from "../app/src/renderer/chat/error-humanizer.js";
+
+describe("humanizeAgentError", () => {
+  it("unwraps Anthropic overloaded_error into a friendly message", () => {
+    const raw = JSON.stringify({
+      type: "error",
+      error: { type: "overloaded_error", message: "Overloaded" },
+      request_id: "req_test",
+    });
+    const result = humanizeAgentError(raw);
+    expect(result.text).toMatch(/overloaded/i);
+    expect(result.text).not.toContain("request_id");
+    expect(result.text).not.toContain("{");
+    expect(result.retriable).toBe(true);
+  });
+
+  it("flags authentication_error as non-retriable with a key-reminder", () => {
+    const raw = JSON.stringify({
+      type: "error",
+      error: { type: "authentication_error", message: "invalid x-api-key" },
+    });
+    const result = humanizeAgentError(raw);
+    expect(result.retriable).toBe(false);
+    expect(result.text.toLowerCase()).toContain("api key");
+  });
+
+  it("includes the upstream message for invalid_request_error", () => {
+    const raw = JSON.stringify({
+      type: "error",
+      error: { type: "invalid_request_error", message: "max_tokens too big" },
+    });
+    const result = humanizeAgentError(raw);
+    expect(result.text).toContain("max_tokens too big");
+    expect(result.retriable).toBe(false);
+  });
+
+  it("falls back to the raw string when JSON is unparseable", () => {
+    const raw = "Connection reset by peer";
+    expect(humanizeAgentError(raw).text).toBe(raw);
+  });
+
+  it("handles empty input", () => {
+    expect(humanizeAgentError("").text).toBe("Unknown error");
+    expect(humanizeAgentError(null).text).toBe("Unknown error");
+    expect(humanizeAgentError(undefined).text).toBe("Unknown error");
+  });
+
+  it("handles unknown error types by stitching type + message", () => {
+    const raw = JSON.stringify({
+      type: "error",
+      error: { type: "weird_new_error", message: "something broke" },
+    });
+    const result = humanizeAgentError(raw);
+    expect(result.text).toContain("weird_new_error");
+    expect(result.text).toContain("something broke");
+    expect(result.retriable).toBe(false);
+  });
+
+  it("does not try to parse strings that don't look like JSON", () => {
+    const raw = "Just a plain error string {not really json";
+    expect(humanizeAgentError(raw).text).toBe(raw);
+  });
+});


### PR DESCRIPTION
## Summary
- Raw Anthropic error JSON (e.g. `{"type":"error","error":{"type":"overloaded_error",...}}`) was showing up verbatim in chat because pi-ai falls back to `JSON.stringify(error)` for non-Error throwables; on retry storms the same payload stacked four-deep.
- Added a small humanizer that maps known Anthropic error types (overloaded, rate-limit, auth, permission, not-found, request-too-large, invalid-request) to short user-facing strings and exposes a `retriable` flag for future use.
- `ChatPanel.addErrorMessage` now collapses consecutive identical errors into one card with a `(xN)` counter that resets at each new user turn.

## Test plan
- [x] `npx vitest run` -- 27 files / 185 tests pass, including 7 new cases in `tests/error-humanizer.test.ts` covering overload, auth, invalid-request, unknown types, empty input, and the non-JSON fallback path.
- [x] `npm run typecheck` (root) and `npx tsc --noEmit` (app) clean.
- [ ] Reproduce an overloaded run in dev (`cd app && npm start`) and confirm the chat shows a single humanized line instead of stacked JSON.