### PR TITLE
Issue 23 verify artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,10 @@ file -- if anything in the topic docs seems to conflict, these win.
   ad-hoc edits -- answer those directly.
 - **Never proceed past an unverified step.** Examine results before moving
   on. Stop on failure.
+- **Never claim a checkable artifact is done without evidence.** A workflow,
+  tool run, file, config, report, or plan step is complete only after Loom
+  has run the relevant verification and recorded the evidence in the
+  notebook.
 - **Never invent dataset IDs, invocation IDs, history IDs, or workflow
   IDs.** Look them up via the MCP tools.
 - **Update the notebook, not chat, with durable findings.** Chat is for
@@ -78,5 +82,7 @@ re-anchor here:
 - Galaxy invocations live in `loom-invocation` YAML blocks.
 - Don't auto-create plans -- wait for an ask.
 - Never proceed past an unverified step.
+- Never claim a checkable artifact is done without notebook-recorded
+  verification evidence.
 - Never invent dataset / invocation / history / workflow IDs.
 - Update the notebook, not chat, with durable findings.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ Conventions:
 - Anchors `{#plan-X-step-N}` so Galaxy invocation YAML can reference individual steps.
 - Multiple plans coexist; new plan sections append at the bottom. Old plans aren't deleted.
 
+See [docs/agent/notebook-schema.md](docs/agent/notebook-schema.md) for
+verification evidence requirements.
+
 ### Four-stage approval before notebook write
 
 Plans don't land in the notebook on first draft. The agent is instructed to follow this order:

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ frequencies across tissues.
 Conventions:
 
 - Routing tag in the section header: `[local]`, `[hybrid]`, or `[remote]`. Literal so future tooling can grep.
-- Step status by the checkbox: `- [ ]` pending, `- [x]` completed, `- [!]` failed.
+- Step status by the checkbox: `- [ ]` pending, `- [x]` verified completed, `- [!]` failed.
+- If verification is blocked or inconclusive but the step itself has not failed, leave the step pending and record the blocker.
 - Anchors `{#plan-X-step-N}` so Galaxy invocation YAML can reference individual steps.
 - Multiple plans coexist; new plan sections append at the bottom. Old plans aren't deleted.
 

--- a/README.md
+++ b/README.md
@@ -98,12 +98,15 @@ frequencies across tissues.
 - [ ] 1. **QC FASTQ** {#plan-a-step-1} — fastp adapter trim + per-base QC
   - Routing: local
   - Tool: fastp
+  - Verification: confirm fastp HTML/JSON report exists and includes per-base quality metrics
 - [x] 2. **Reference index** {#plan-a-step-2} — bwa index of chrM
   - Routing: local
   - Tool: bwa index, samtools faidx
+  - Verification: confirm BWA index sidecar files and `.fai` exist
 - [ ] 3. **Read alignment** {#plan-a-step-3} — BWA-MEM, paired collection
   - Routing: Galaxy
   - Tool: bwa-mem2/2.2.1
+  - Verification: poll Galaxy invocation to `ok` and inspect BAM outputs
 - ...
 
 ### Parameters

--- a/docs/agent/galaxy-routing.md
+++ b/docs/agent/galaxy-routing.md
@@ -55,6 +55,11 @@ look plausible for the request. Then write that verification evidence to
 the notebook and edit the markdown checkbox: `- [ ]` → `- [x]` (or
 `- [!]` on failure).
 
+Treat invocation YAML status as Galaxy job state. Treat the plan checkbox
+as verified-result state: a YAML `completed` invocation still needs
+output inspection and notebook evidence before the corresponding step is
+marked `- [x]`.
+
 ## Artifact verification
 
 Generated Galaxy artifacts are not complete just because a file exists

--- a/docs/agent/galaxy-routing.md
+++ b/docs/agent/galaxy-routing.md
@@ -50,5 +50,29 @@ tools can find it later.
 Periodically call `galaxy_invocation_check_all` to advance in-flight
 work. The tool auto-transitions YAML status (all-jobs-ok → completed,
 any-error → failed) and writes results back to the notebook. After a
-transition, edit the markdown checkbox: `- [ ]` → `- [x]` (or `- [!]`
-on failure).
+transition, inspect the output datasets enough to confirm they exist and
+look plausible for the request. Then write that verification evidence to
+the notebook and edit the markdown checkbox: `- [ ]` → `- [x]` (or
+`- [!]` on failure).
+
+## Artifact verification
+
+Generated Galaxy artifacts are not complete just because a file exists
+locally. For authored workflows (`.ga` or workflow JSON), import/upload
+the workflow to Galaxy, invoke it on a small appropriate test input, poll
+to a terminal state, and inspect the outputs. If credentials, test data,
+or tool availability block that check, record the blocker and say
+"created but not verified" rather than claiming the artifact is done.
+
+Useful verification examples:
+
+- Galaxy dataset: check state, datatype, size/metadata, and a small
+  preview/peek; for collections, confirm element count and failures.
+- BAM/CRAM: use Galaxy metadata or `samtools quickcheck`; add `flagstat`
+  or `idxstats` when alignment quality or reference coverage matters.
+- VCF/BCF: parse headers, count records, check sample names, and verify
+  compression/index status when downstream tools need it.
+- FASTQ/FASTA: verify gzip/container integrity, read/sequence counts, and
+  expected identifiers in a small preview.
+- CSV/TSV/JSON/YAML/config: parse with a real parser, check required
+  columns/keys, and compare row/object counts to the request.

--- a/docs/agent/notebook-schema.md
+++ b/docs/agent/notebook-schema.md
@@ -32,7 +32,7 @@ Question: how do mtDNA variants distribute across tissues in this dataset?
 
 - [ ] 1. **QC FASTQ** {#plan-a-step-1} — fastp adapter trim + per-base QC
   - Routing: local
-  - Verification: confirm FastQC output exists and includes per-base quality metrics
+  - Verification: confirm fastp HTML/JSON report exists and includes per-base quality metrics
 - [ ] 2. **Reference index** {#plan-a-step-2} — bwa index of chrM
   - Routing: local
   - Verification: confirm BWA index sidecar files and `.fai` exist

--- a/docs/agent/notebook-schema.md
+++ b/docs/agent/notebook-schema.md
@@ -31,11 +31,14 @@ Question: how do mtDNA variants distribute across tissues in this dataset?
 ### Steps
 
 - [ ] 1. **QC FASTQ** {#plan-a-step-1} — fastp adapter trim + per-base QC
-     Routing: local
+  - Routing: local
+  - Verification: confirm FastQC output exists and includes per-base quality metrics
 - [ ] 2. **Reference index** {#plan-a-step-2} — bwa index of chrM
-     Routing: local
+  - Routing: local
+  - Verification: confirm BWA index sidecar files and `.fai` exist
 - [ ] 3. **Read alignment** {#plan-a-step-3} — bwa mem PE 4 samples
-     Routing: Galaxy (bwa-mem2/2.2.1)
+  - Routing: Galaxy (bwa-mem2/2.2.1)
+  - Verification: poll Galaxy jobs to `ok` and inspect BAM outputs
 - ...
 
 ### Parameters
@@ -50,10 +53,21 @@ Conventions:
 - `## Plan X: <Title> [routing]` — routing tag is `[local]`, `[hybrid]`,
   or `[remote]`. Future tooling greps for these literals.
 - `{#plan-x-step-N}` anchors so invocation YAML can reference steps.
+- Every step needs a concrete `Verification:` sub-bullet describing the
+  evidence required before completion.
 - Mark step status by editing the checkbox: `- [ ]` pending, `- [x]`
-  completed, `- [!]` failed.
+  verified completed, `- [!]` failed. Do not mark `- [x]` until the
+  verification evidence is written into the notebook.
+- If a verification check is blocked or inconclusive but the step itself
+  has not failed, leave the checkbox pending and record the blocker.
 - Multiple plans coexist; append new plan sections at the bottom of the
   notebook. Don't delete old plans.
+
+Verification examples should be specific to the artifact: `samtools
+quickcheck` / `flagstat` for BAM, header + record/sample checks for VCF,
+read/sequence counts for FASTQ/FASTA, parser + required keys/columns for
+JSON/YAML/CSV/TSV, and Galaxy state/datatype/metadata/peek checks for
+remote datasets.
 
 **Don't propose a plan unless asked.** Most user requests are questions,
 explorations, summaries, ad-hoc edits — answer those directly. A plan

--- a/docs/agent/role.md
+++ b/docs/agent/role.md
@@ -13,8 +13,9 @@ through the complete research lifecycle.
   documentation in the notebook.
 - **Transparent**: You explain your reasoning and the implications of
   each choice — in chat for dialogue, in the notebook for durable record.
-- **Rigorous**: You enforce QC checkpoints (as items in the markdown plan)
-  and don't skip validation steps.
+- **Rigorous**: You enforce QC checkpoints (as items in the markdown plan),
+  verify checkable artifacts before calling them complete, and don't skip
+  validation steps.
 
 ## Communication style
 

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -370,8 +370,8 @@ Match the verification check to the artifact or action being completed:
   state with \`galaxy_invocation_check_all\` or the relevant Galaxy MCP
   inspection call, then inspect resulting datasets/collections enough to
   confirm they exist and look plausible for the request.
-- **Authored workflow artifact** (\`.ga\`, workflow JSON, generated
-  Galaxy workflow) — upload/import it to Galaxy, invoke it on a small
+- **Authored Galaxy workflow** (\`.ga\` or workflow JSON) —
+  upload/import it to Galaxy, invoke it on a small
   appropriate test input, poll to completion, and inspect outputs.
 - **Galaxy dataset or collection output** — inspect state, datatype,
   metadata, size, preview/peek, expected element count, and failed or

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -364,23 +364,33 @@ or telling the user the work is done.
 
 ### What counts as verification
 
-- **Galaxy workflow/tool run** — poll the invocation/job to a terminal
+Verification is not limited to workflows. Match the check to the
+artifact or action:
+
+- **Galaxy workflow or tool run** — poll the invocation/job to a terminal
   state with \`galaxy_invocation_check_all\` or the relevant Galaxy MCP
-  inspection call, then inspect output datasets enough to confirm they
-  exist and look plausible for the request.
+  inspection call, then inspect resulting datasets/collections enough to
+  confirm they exist and look plausible for the request.
 - **Authored workflow artifact** (\`.ga\`, workflow JSON, generated
   Galaxy workflow) — upload/import it to Galaxy, invoke it on a small
   appropriate test input, poll to completion, and inspect outputs.
-- **Local file/config/report** — read it back and parse, lint, smoke
-  test, or otherwise confirm the state matches the user request.
+- **Galaxy dataset or collection output** — inspect state, datatype,
+  metadata, size, preview/peek, expected element count, and failed or
+  hidden elements when collections are involved.
+- **Local data file** — read or parse the file with an appropriate tool
+  for its format, such as BAM/CRAM, VCF/BCF, FASTQ/FASTA, CSV/TSV,
+  JSON, YAML, or similar project artifacts.
+- **Config, script, or report** — read it back and parse, lint, render,
+  smoke test, or otherwise confirm the state matches the user request.
 - **Plan execution** — each completed step needs notebook evidence:
   command or Galaxy action, observed status/output, and the verification
   result.
 
 ### Verification examples
 
-Use the cheapest check that proves the artifact is usable for the
-request:
+Use a targeted check that proves the artifact is usable for the request.
+Prefer the smallest representative verification that establishes the
+claim, but do not skip required validation just to save time:
 
 - **Workflow \`.ga\` / workflow JSON**: import it into Galaxy, invoke it on
   a tiny representative input, poll jobs to \`ok\`, then inspect expected

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -364,8 +364,7 @@ or telling the user the work is done.
 
 ### What counts as verification
 
-Verification is not limited to workflows. Match the check to the
-artifact or action:
+Match the verification check to the artifact or action being completed:
 
 - **Galaxy workflow or tool run** — poll the invocation/job to a terminal
   state with \`galaxy_invocation_check_all\` or the relevant Galaxy MCP

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -197,8 +197,10 @@ After invoking via Galaxy MCP and getting an \`invocationId\` back:
 2. Periodically call \`galaxy_invocation_check_all\` to advance in-flight
    invocations. The tool auto-transitions YAML status (all-jobs-ok →
    completed, any-error → failed) and writes results back to the
-   notebook. After a transition, edit the markdown checkbox for the step
-   from \`- [ ]\` to \`- [x]\` (or \`- [!]\` for failures).
+   notebook. After a successful transition, inspect the output datasets,
+   record verification evidence in the notebook, then edit the markdown
+   checkbox for the step from \`- [ ]\` to \`- [x]\`. On failure, record
+   the error evidence and use \`- [!]\`.
 `;
 }
 
@@ -348,6 +350,79 @@ should rotate it.
 `;
 }
 
+/**
+ * Verification discipline. This is deliberately brain-side policy:
+ * shells render progress, but Loom decides when evidence is sufficient to
+ * call a research artifact complete.
+ */
+export function buildVerificationDisciplineBlock(): string {
+  return `## Verification before completion
+
+Evidence comes before assertion. For every checkable result, you must
+run an actual verification step before marking a notebook step complete
+or telling the user the work is done.
+
+### What counts as verification
+
+- **Galaxy workflow/tool run** — poll the invocation/job to a terminal
+  state with \`galaxy_invocation_check_all\` or the relevant Galaxy MCP
+  inspection call, then inspect output datasets enough to confirm they
+  exist and look plausible for the request.
+- **Authored workflow artifact** (\`.ga\`, workflow JSON, generated
+  Galaxy workflow) — upload/import it to Galaxy, invoke it on a small
+  appropriate test input, poll to completion, and inspect outputs.
+- **Local file/config/report** — read it back and parse, lint, smoke
+  test, or otherwise confirm the state matches the user request.
+- **Plan execution** — each completed step needs notebook evidence:
+  command or Galaxy action, observed status/output, and the verification
+  result.
+
+### Verification examples
+
+Use the cheapest check that proves the artifact is usable for the
+request:
+
+- **Workflow \`.ga\` / workflow JSON**: import it into Galaxy, invoke it on
+  a tiny representative input, poll jobs to \`ok\`, then inspect expected
+  outputs for datatype, non-empty content when expected, and plausible
+  metadata.
+- **Galaxy dataset output**: inspect dataset state, datatype, name,
+  size/metadata, and a small preview/peek. If the output is a collection,
+  confirm expected element count and failed/hidden elements.
+- **BAM/CRAM**: check file exists and is non-empty; use Galaxy metadata or
+  a Galaxy/local tool such as \`samtools quickcheck\` and, when useful,
+  \`samtools flagstat\` or \`idxstats\` on a small output.
+- **VCF/BCF**: confirm headers parse, record count is plausible for the
+  request, sample names match expectations, and compression/index status
+  is correct when downstream tools need it.
+- **FASTQ/FASTA**: confirm gzip/container integrity if compressed, count
+  reads/sequences, and check a small preview for expected identifiers.
+- **CSV/TSV/JSON/YAML/config**: parse it with the appropriate parser,
+  confirm required keys/columns are present, and check row/object counts
+  against the request.
+- **Markdown/HTML/PDF report**: open or render enough of the artifact to
+  confirm requested sections, figures/tables, and links/references are
+  present.
+
+If verification is blocked by missing credentials, missing test data,
+tool unavailability, or user scope, stop and say exactly what is
+unverified. Do **not** mark the step \`- [x]\` and do **not** say "done"
+or "complete" for that artifact. Say "created but not verified" and ask
+for the missing input or approval to change scope.
+
+### Notebook requirement
+
+Every new plan step should include a concrete \`Verification:\` sub-bullet
+so the expected evidence is clear before work starts. Existing or ad-hoc
+steps may lack that line; in those cases, infer the appropriate check
+from the artifact and execute it after the work runs. Before flipping
+\`- [ ]\` to \`- [x]\`, write the verification evidence under that step
+or in the relevant results section of \`notebook.md\`. For failed or
+inconclusive checks, mark \`- [!]\` only when the step itself failed;
+otherwise leave it pending and record the blocker.
+`;
+}
+
 function buildPlanConventionBlock(): string {
   return `## Project model and plan sections
 
@@ -407,9 +482,11 @@ text into the parent line; sub-bullets render as a real nested list.
 - [ ] 1. **<Step name>** {#plan-a-step-1} — <one-line purpose>
   - Routing: local
   - Tool: <tool-name-or-galaxy-id>
+  - Verification: <concrete check before this step can be marked complete>
 - [ ] 2. **<Step name>** {#plan-a-step-2} — <one-line purpose>
   - Routing: Galaxy
   - Tool: <galaxy-tool-id>
+  - Verification: <Galaxy status/output inspection that proves it worked>
 
 ### Parameters
 
@@ -427,8 +504,12 @@ Conventions:
 - Step routing/tool details go on **sub-bullets**, not on the same line
   as the step heading. Markdown will collapse same-line continuation
   text and the rendered notebook becomes unreadable.
+- Each step needs a **Verification** sub-bullet. It must name a concrete
+  check (poll invocation + inspect dataset, run smoke test, parse file,
+  compare expected rows, etc.), not a vague "looks good".
 - Mark step status by editing the checkbox: \`- [ ]\` (pending),
-  \`- [x]\` (completed), \`- [!]\` (failed).
+  \`- [x]\` (verified completed), \`- [!]\` (failed). Never mark
+  \`- [x]\` until the verification evidence is written to the notebook.
 - Multiple plans coexist; append new plan sections at the bottom of the
   notebook. Don't delete old plans.
 `;
@@ -456,7 +537,7 @@ literal \`**asterisks**\` instead of bold. Two rules:
   Galaxy invocation status updates land in the YAML blocks. Keep chat
   for **dialogue + final status** — open questions, requested
   decisions, and a single end-of-turn summary like
-  *"All 8 steps done. Variant call results in plan-a-step-7. Ready
+  *"All 8 steps verified. Variant call results in plan-a-step-7. Ready
   for interpretation?"*
 
 When you do post a multi-line update, prefer a markdown list or a
@@ -705,6 +786,7 @@ export function setupContextInjection(pi: ExtensionAPI): void {
   pi.on("before_agent_start", async (_event, ctx) => {
     const systemPrompt = [
       buildOperatingDisciplineBlock(),
+      buildVerificationDisciplineBlock(),
       buildPlanConventionBlock(),
       buildParameterReviewBlock(),
       buildChatFormattingBlock(),

--- a/extensions/loom/execution-commands.ts
+++ b/extensions/loom/execution-commands.ts
@@ -41,10 +41,17 @@ export function registerExecutionCommands(pi: ExtensionAPI): void {
         `1. Decide local vs Galaxy per the plan's routing tag (see [local|hybrid|remote] in the section header).\n` +
         `2. For Galaxy steps: invoke via Galaxy MCP, then call galaxy_invocation_record(...).\n` +
         `3. For local steps: run via bash; capture results into the notebook.\n` +
-        `4. After completion, edit the markdown checkbox to \`- [x]\` (or \`- [!]\` on failure).\n` +
-        `5. Periodically call galaxy_invocation_check_all to advance in-flight Galaxy work.\n` +
+        `4. Verify the result using the step's \`Verification:\` sub-bullet when present, ` +
+        `or infer the appropriate check from the artifact just produced. ` +
+        `For Galaxy work, poll to a terminal state and inspect output datasets; ` +
+        `for generated workflows, upload/import and invoke on a small test input; ` +
+        `for local artifacts, read/parse/lint/smoke-test them.\n` +
+        `5. Write the verification evidence into the notebook before changing status.\n` +
+        `6. Only after verification succeeds, edit the markdown checkbox to \`- [x]\` (or \`- [!]\` on failure). If verification is blocked or inconclusive, leave the step pending, record the blocker, and stop.\n` +
+        `7. Periodically call galaxy_invocation_check_all to advance in-flight Galaxy work.\n` +
         `Do NOT narrate progress in chat — the Notebook tab shows it. ` +
-        `Stop on failure; do not auto-advance past errors.`,
+        `Do NOT claim the artifact or step is done in chat unless verification evidence is recorded. ` +
+        `Stop on failure; do not auto-advance past errors or unverified results.`,
     );
   };
 

--- a/extensions/loom/execution-commands.ts
+++ b/extensions/loom/execution-commands.ts
@@ -47,7 +47,8 @@ export function registerExecutionCommands(pi: ExtensionAPI): void {
         `for generated workflows, upload/import and invoke on a small test input; ` +
         `for local artifacts, read/parse/lint/smoke-test them.\n` +
         `5. Write the verification evidence into the notebook before changing status.\n` +
-        `6. Only after verification succeeds, edit the markdown checkbox to \`- [x]\` (or \`- [!]\` on failure). If verification is blocked or inconclusive, leave the step pending, record the blocker, and stop.\n` +
+        `6. Only after verification succeeds, edit the markdown checkbox to \`- [x]\` (or \`- [!]\` on failure). ` +
+        `If verification is blocked or inconclusive, leave the step pending, record the blocker, say "created but not verified" for created artifacts, ask for the missing input or approval to change scope, and stop.\n` +
         `7. Periodically call galaxy_invocation_check_all to advance in-flight Galaxy work.\n` +
         `Do NOT narrate progress in chat — the Notebook tab shows it. ` +
         `Do NOT claim the artifact or step is done in chat unless verification evidence is recorded. ` +

--- a/tests/execution-commands.test.ts
+++ b/tests/execution-commands.test.ts
@@ -58,6 +58,7 @@ describe("registerExecutionCommands", () => {
     expect(prompt).toContain("or infer the appropriate check from the artifact just produced");
     expect(prompt).toContain("Write the verification evidence into the notebook");
     expect(prompt).toContain("Only after verification succeeds");
+    expect(prompt).toContain("created but not verified");
     expect(prompt).toContain("Do NOT claim the artifact or step is done");
   });
 });

--- a/tests/execution-commands.test.ts
+++ b/tests/execution-commands.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { registerExecutionCommands } from "../extensions/loom/execution-commands";
+import { resetState, setNotebookPath } from "../extensions/loom/state";
+
+let tmpDir: string;
+let nbPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "loom-execute-command-"));
+  nbPath = path.join(tmpDir, "notebook.md");
+  resetState();
+});
+
+afterEach(() => {
+  resetState();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeRunnableNotebook() {
+  fs.writeFileSync(
+    nbPath,
+    `
+## Plan A: Smoke [local]
+
+- [ ] 1. **Write config** {#plan-a-step-1} -- create the requested config file
+  - Routing: local
+  - Tool: file write
+  - Verification: read the file back and confirm the requested key is present
+`,
+    "utf-8",
+  );
+  setNotebookPath(nbPath);
+}
+
+describe("registerExecutionCommands", () => {
+  it("instructs the agent to verify before marking a step complete", async () => {
+    writeRunnableNotebook();
+
+    const commands = new Map<string, { handler: (args: string | undefined, ctx: any) => void }>();
+    const sendUserMessage = vi.fn();
+    const pi = {
+      registerCommand: vi.fn(
+        (name: string, command: { handler: (args: string | undefined, ctx: any) => void }) => {
+          commands.set(name, command);
+        },
+      ),
+      sendUserMessage,
+    };
+
+    registerExecutionCommands(pi as any);
+    await commands.get("execute")!.handler(undefined, { ui: { notify: vi.fn() } });
+
+    const prompt = sendUserMessage.mock.calls[0][0] as string;
+    expect(prompt).toContain("Verify the result using the step's `Verification:` sub-bullet");
+    expect(prompt).toContain("or infer the appropriate check from the artifact just produced");
+    expect(prompt).toContain("Write the verification evidence into the notebook");
+    expect(prompt).toContain("Only after verification succeeds");
+    expect(prompt).toContain("Do NOT claim the artifact or step is done");
+  });
+});

--- a/tests/init-gate.test.ts
+++ b/tests/init-gate.test.ts
@@ -43,7 +43,7 @@ describe("parseMostRecentPlan", () => {
 ### Steps
 
 - [ ] 1. **QC FASTQ** {#plan-a-step-1} -- fastp adapter trim + per-base QC
-  - Verification: confirm FastQC output exists and includes per-base quality summary
+  - Verification: confirm fastp HTML/JSON report exists and includes per-base quality summary
 - [ ] 2. **Reference index** {#plan-a-step-2} -- bwa index of chrM
 `);
     expect(plan).not.toBeNull();

--- a/tests/init-gate.test.ts
+++ b/tests/init-gate.test.ts
@@ -284,7 +284,7 @@ describe("checkPreconditions -- happy path", () => {
 ## Plan A: chrM [local]
 
 - [ ] 1. **QC FASTQ** {#plan-a-step-1} -- fastp adapter trim + per-base QC
-  - Verification: confirm FastQC output exists and includes the summary module
+  - Verification: confirm fastp HTML/JSON report exists and includes the summary module
 `);
     const result = checkPreconditions();
     expect(result.ok).toBe(true);

--- a/tests/init-gate.test.ts
+++ b/tests/init-gate.test.ts
@@ -43,12 +43,24 @@ describe("parseMostRecentPlan", () => {
 ### Steps
 
 - [ ] 1. **QC FASTQ** {#plan-a-step-1} -- fastp adapter trim + per-base QC
+  - Verification: confirm FastQC output exists and includes per-base quality summary
 - [ ] 2. **Reference index** {#plan-a-step-2} -- bwa index of chrM
 `);
     expect(plan).not.toBeNull();
     expect(plan!.title).toBe("A: chrM Variant Calling");
     expect(plan!.routing).toBe("hybrid");
     expect(plan!.nextStep).not.toBeNull();
+    expect(plan!.nextStep!.raw).toContain("QC FASTQ");
+  });
+
+  it("still parses legacy continuation-line routing details", () => {
+    const plan = parseMostRecentPlan(`
+## Plan A: Legacy Format [local]
+
+- [ ] 1. **QC FASTQ** {#plan-a-step-1} -- fastp adapter trim + per-base QC
+     Routing: local
+`);
+    expect(plan).not.toBeNull();
     expect(plan!.nextStep!.raw).toContain("QC FASTQ");
   });
 
@@ -187,6 +199,7 @@ describe("checkPreconditions -- hard failures", () => {
 ## Plan A: Local stuff [local]
 
 - [ ] 1. **Parse data** -- awk magic over CSV
+  - Verification: confirm the parsed CSV exists and has the expected header
 `);
     setGalaxyConnection(false);
     const result = checkPreconditions();
@@ -252,6 +265,17 @@ history_id: f5912ab34
     expect(result.failures.find((f) => f.name === "acceptance")).toBeTruthy();
     expect(result.failures.find((f) => f.name === "acceptance")!.severity).toBe("soft");
   });
+
+  it("does not block execution when verification criteria are missing", () => {
+    writeNotebook(`
+## Plan A: Legacy [local]
+
+- [ ] 1. **Write config** {#plan-a-step-1} -- create the requested config file
+`);
+    const result = checkPreconditions();
+    expect(result.ok).toBe(true);
+    expect(result.failures).toEqual([]);
+  });
 });
 
 describe("checkPreconditions -- happy path", () => {
@@ -260,6 +284,7 @@ describe("checkPreconditions -- happy path", () => {
 ## Plan A: chrM [local]
 
 - [ ] 1. **QC FASTQ** {#plan-a-step-1} -- fastp adapter trim + per-base QC
+  - Verification: confirm FastQC output exists and includes the summary module
 `);
     const result = checkPreconditions();
     expect(result.ok).toBe(true);
@@ -273,6 +298,7 @@ describe("checkPreconditions -- happy path", () => {
 ## Plan A: Aligned [galaxy]
 
 - [ ] 1. **bwa-mem PE** {#plan-a-step-1} -- 4 samples on chrM reference
+  - Verification: poll the Galaxy invocation to completion and inspect BAM outputs
 `);
     setGalaxyConnection(true, "abc123");
     const result = checkPreconditions();

--- a/tests/verification-context.test.ts
+++ b/tests/verification-context.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildVerificationDisciplineBlock,
+  setupContextInjection,
+} from "../extensions/loom/context";
+
+describe("buildVerificationDisciplineBlock", () => {
+  it("requires evidence before done claims for checkable artifacts", () => {
+    const ctx = buildVerificationDisciplineBlock();
+
+    expect(ctx).toContain("Evidence comes before assertion");
+    expect(ctx).toContain('do **not** say "done"');
+    expect(ctx).toContain("created but not verified");
+    expect(ctx).toContain("Authored workflow artifact");
+    expect(ctx).toContain("upload/import it to Galaxy");
+    expect(ctx).toContain("Every new plan step should include a concrete `Verification:`");
+    expect(ctx).toContain("infer the appropriate check");
+    expect(ctx).toContain("samtools quickcheck");
+    expect(ctx).toContain("VCF/BCF");
+    expect(ctx).toContain("required keys/columns");
+    expect(ctx).toContain("element count");
+  });
+
+  it("is wired into the assembled system prompt", async () => {
+    const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>();
+    const pi = {
+      on: (event: string, handler: (event: unknown, ctx: unknown) => Promise<unknown>) => {
+        handlers.set(event, handler);
+      },
+    };
+
+    setupContextInjection(pi as any);
+    const result = (await handlers.get("before_agent_start")!({}, {})) as { systemPrompt: string };
+
+    expect(result.systemPrompt).toContain("## Operating discipline");
+    expect(result.systemPrompt).toContain("## Verification before completion");
+    expect(result.systemPrompt).toContain("## Project model and plan sections");
+    expect(result.systemPrompt.indexOf("## Operating discipline")).toBeLessThan(
+      result.systemPrompt.indexOf("## Verification before completion"),
+    );
+    expect(result.systemPrompt.indexOf("## Verification before completion")).toBeLessThan(
+      result.systemPrompt.indexOf("## Project model and plan sections"),
+    );
+  });
+});

--- a/tests/verification-context.test.ts
+++ b/tests/verification-context.test.ts
@@ -12,7 +12,7 @@ describe("buildVerificationDisciplineBlock", () => {
     expect(ctx).toContain('do **not** say "done"');
     expect(ctx).toContain("created but not verified");
     expect(ctx).toContain("Match the verification check to the artifact or action");
-    expect(ctx).toContain("Authored workflow artifact");
+    expect(ctx).toContain("Authored Galaxy workflow");
     expect(ctx).toContain("upload/import it to Galaxy");
     expect(ctx).toContain("Galaxy dataset or collection output");
     expect(ctx).toContain("Local data file");

--- a/tests/verification-context.test.ts
+++ b/tests/verification-context.test.ts
@@ -11,10 +11,16 @@ describe("buildVerificationDisciplineBlock", () => {
     expect(ctx).toContain("Evidence comes before assertion");
     expect(ctx).toContain('do **not** say "done"');
     expect(ctx).toContain("created but not verified");
+    expect(ctx).toContain("Verification is not limited to workflows");
     expect(ctx).toContain("Authored workflow artifact");
     expect(ctx).toContain("upload/import it to Galaxy");
+    expect(ctx).toContain("Galaxy dataset or collection output");
+    expect(ctx).toContain("Local data file");
+    expect(ctx).toContain("Config, script, or report");
     expect(ctx).toContain("Every new plan step should include a concrete `Verification:`");
     expect(ctx).toContain("infer the appropriate check");
+    expect(ctx).toContain("Use a targeted check");
+    expect(ctx).not.toContain("Use the cheapest check");
     expect(ctx).toContain("samtools quickcheck");
     expect(ctx).toContain("VCF/BCF");
     expect(ctx).toContain("required keys/columns");

--- a/tests/verification-context.test.ts
+++ b/tests/verification-context.test.ts
@@ -11,7 +11,7 @@ describe("buildVerificationDisciplineBlock", () => {
     expect(ctx).toContain("Evidence comes before assertion");
     expect(ctx).toContain('do **not** say "done"');
     expect(ctx).toContain("created but not verified");
-    expect(ctx).toContain("Verification is not limited to workflows");
+    expect(ctx).toContain("Match the verification check to the artifact or action");
     expect(ctx).toContain("Authored workflow artifact");
     expect(ctx).toContain("upload/import it to Galaxy");
     expect(ctx).toContain("Galaxy dataset or collection output");


### PR DESCRIPTION
## Summary

- Add verified-completion guidance so checkable work is only marked complete after Loom has inspected evidence and recorded it in the notebook.
- Broaden verification policy beyond workflows to cover Galaxy tool runs, datasets/collections, local data files, configs, scripts, reports, and plan steps.
- Update `/execute` so each step is executed, verified with explicit or inferred checks, documented in the notebook, and only then marked `- [x]`.
- Clarify that Galaxy invocation YAML status is job state, while the plan checkbox represents verified-result state.
- Add tests for verification prompt wiring, `/execute` verification instructions, and backward-compatible plan parsing.

## Scope note

This PR implements broad brain-side verification behavior and command guidance. It does not add a hard runtime lock that intercepts every possible completion claim.

Refs #23

## Test plan

- `npm test`
- `npm run typecheck`