### PR TITLE
Sign in with ChatGPT -- add openai-codex as an Orbit provider

### DIFF
--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -18,14 +18,21 @@ const PROVIDER_ENV_MAP: Record<string, string> = {
   xai: "XAI_API_KEY",
 };
 
+/** Providers that authenticate via OAuth (~/.pi/agent/auth.json), not env vars. */
+const OAUTH_PROVIDERS: ReadonlySet<string> = new Set(["openai-codex"]);
+
 /** Build the secret env vars injected into the brain subprocess. */
 function buildSecretEnv(): Record<string, string> {
   const env: Record<string, string> = {};
   const cfg = loadConfig();
 
+  const provider = cfg.llm?.active || "anthropic";
   const llmKey = resolveLlmApiKey(cfg);
-  if (llmKey) {
-    const provider = cfg.llm?.active || "anthropic";
+  // OAuth providers ignore env-var keys -- the brain reads ~/.pi/agent/auth.json.
+  // If the user switched away from an API-key provider the old key is still in
+  // config.json (preserved on purpose so they can switch back); don't leak it
+  // into the env under a misrouted variable name.
+  if (llmKey && !OAUTH_PROVIDERS.has(provider)) {
     const envVar = PROVIDER_ENV_MAP[provider] || "AI_GATEWAY_API_KEY";
     env[envVar] = llmKey;
   }

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -43,7 +43,15 @@ function maskConfig(cfg: LoomConfig): MaskedLoomConfig {
       providers: Object.fromEntries(
         Object.entries(cfg.llm.providers ?? {}).map(([k, v]) => [
           k,
-          { model: v.model, hasApiKey: Boolean(v.apiKey || v.apiKeyEncrypted) },
+          {
+            model: v.model,
+            // OAuth providers authenticate via ~/.pi/agent/auth.json -- an
+            // orphan apiKey on the entry (manual edit, or the legacy-shape
+            // migrator) is dead weight, not a real credential. Don't surface
+            // it to the renderer or it'll mis-render "Key stored" UI for
+            // an account that actually authenticates by sign-in.
+            hasApiKey: isOAuthProvider(k) ? false : Boolean(v.apiKey || v.apiKeyEncrypted),
+          },
         ]),
       ),
     };
@@ -340,7 +348,11 @@ export function registerIpcHandlers(agent: AgentManager): void {
     if (!isOAuthProvider(provider)) {
       return { ok: false as const, error: `Unknown OAuth provider: ${provider}` };
     }
-    signOutOAuth(provider);
+    try {
+      signOutOAuth(provider);
+    } catch (err) {
+      return { ok: false as const, error: err instanceof Error ? err.message : String(err) };
+    }
     agent.stop();
     agent.start();
     return { ok: true as const };

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -9,6 +9,12 @@ import { loadConfig, saveConfig, type LoomConfig } from "./config.js";
 import { encryptSecret, isAvailable as safeStorageAvailable } from "./secure-config.js";
 import { getProviders, getModels } from "@earendil-works/pi-ai";
 import { checkLatestVersion } from "./version-check.js";
+import {
+  getOAuthStatus,
+  isOAuthProvider,
+  signInOpenAICodex,
+  signOutOAuth,
+} from "./oauth-handler.js";
 
 /**
  * Sentinel the renderer sends back in a secret field when the user did NOT
@@ -308,6 +314,38 @@ export function registerIpcHandlers(agent: AgentManager): void {
     }
   });
 
+  ipcMain.handle("oauth:status", (_e, provider: string) => {
+    if (!isOAuthProvider(provider)) {
+      return { signedIn: false };
+    }
+    return getOAuthStatus(provider);
+  });
+
+  ipcMain.handle("oauth:sign-in", async (_e, provider: string) => {
+    if (provider !== "openai-codex") {
+      return { ok: false as const, error: `Unknown OAuth provider: ${provider}` };
+    }
+    try {
+      const status = await signInOpenAICodex();
+      // Restart the brain so it picks up the new credential on next prompt.
+      agent.stop();
+      agent.start();
+      return { ok: true as const, status };
+    } catch (err) {
+      return { ok: false as const, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  ipcMain.handle("oauth:sign-out", async (_e, provider: string) => {
+    if (!isOAuthProvider(provider)) {
+      return { ok: false as const, error: `Unknown OAuth provider: ${provider}` };
+    }
+    signOutOAuth(provider);
+    agent.stop();
+    agent.start();
+    return { ok: true as const };
+  });
+
   ipcMain.handle("notebook:status", (): { exists: boolean; hasContent: boolean } => {
     const notebookPath = path.join(agent.getCwd(), "notebook.md");
     if (!fs.existsSync(notebookPath)) return { exists: false, hasContent: false };
@@ -463,6 +501,7 @@ export function registerIpcHandlers(agent: AgentManager): void {
     const USER_FACING_PROVIDERS: ReadonlySet<string> = new Set([
       "anthropic",
       "openai",
+      "openai-codex",
       "google",
       "ollama",
       "openrouter",

--- a/app/src/main/oauth-handler.ts
+++ b/app/src/main/oauth-handler.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { shell } from "electron";
+import { loginOpenAICodex } from "@earendil-works/pi-ai/oauth";
+
+/**
+ * OAuth provider integration for the brain's auth.json. The brain (pi-coding-agent)
+ * reads `~/.pi/agent/auth.json` directly when spawned with `--provider <oauth-provider>`,
+ * so all Orbit needs to do is run the OAuth flow and persist the resulting credentials
+ * to that file. The brain handles refresh on its own via AuthStorage's locking.
+ */
+
+const OAUTH_PROVIDERS = new Set<string>(["openai-codex"]);
+
+export function isOAuthProvider(provider: string | undefined): boolean {
+  return Boolean(provider && OAUTH_PROVIDERS.has(provider));
+}
+
+function getAuthPath(): string {
+  // Honor PI_CODING_AGENT_DIR so test/dev overrides land in the same place
+  // the brain subprocess reads from. Mirrors bin/loom.js's agentDir resolution.
+  const envDir = process.env.PI_CODING_AGENT_DIR;
+  const agentDir = envDir
+    ? envDir.replace(/^~(?=$|\/|\\)/, os.homedir())
+    : path.join(os.homedir(), ".pi", "agent");
+  return path.join(agentDir, "auth.json");
+}
+
+function readAuthFile(): Record<string, unknown> {
+  const p = getAuthPath();
+  if (!fs.existsSync(p)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf-8")) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function writeAuthFile(data: Record<string, unknown>): void {
+  const p = getAuthPath();
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(data, null, 2), { mode: 0o600 });
+  try {
+    fs.chmodSync(p, 0o600);
+  } catch {
+    /* best-effort */
+  }
+}
+
+export interface OAuthStatus {
+  signedIn: boolean;
+  /** Seconds until the access token expires. Negative if already expired -- the brain auto-refreshes. */
+  expiresInSeconds?: number;
+  accountId?: string;
+}
+
+export function getOAuthStatus(provider: string): OAuthStatus {
+  const data = readAuthFile();
+  const cred = data[provider] as
+    | { type?: string; expires?: number; accountId?: string }
+    | undefined;
+  if (!cred || cred.type !== "oauth") return { signedIn: false };
+  const expiresInSeconds =
+    typeof cred.expires === "number" ? Math.floor((cred.expires - Date.now()) / 1000) : undefined;
+  return { signedIn: true, expiresInSeconds, accountId: cred.accountId };
+}
+
+export function signOutOAuth(provider: string): void {
+  const data = readAuthFile();
+  if (!(provider in data)) return;
+  delete data[provider];
+  writeAuthFile(data);
+}
+
+/**
+ * Drive the OpenAI Codex OAuth flow. Opens the auth URL in the user's default
+ * browser; pi-ai's loginOpenAICodex spins up a local callback server on
+ * 127.0.0.1:1455 and returns once the browser hands back the code.
+ *
+ * Throws if the flow fails (port conflict, user cancellation, network error).
+ */
+export async function signInOpenAICodex(): Promise<OAuthStatus> {
+  const creds = await loginOpenAICodex({
+    onAuth: ({ url }) => {
+      void shell.openExternal(url);
+    },
+    // Fallback paste path -- only triggered if the local callback server fails
+    // to start (port already in use). Orbit doesn't surface a paste UI today,
+    // so we reject with a guidance message instead of hanging.
+    onPrompt: async () => {
+      throw new Error(
+        "OAuth callback server could not bind to 127.0.0.1:1455. " +
+          "Free the port (e.g. quit Codex CLI) and try again.",
+      );
+    },
+    onProgress: (msg) => console.log("[oauth]", msg),
+    originator: "loom",
+  });
+
+  const data = readAuthFile();
+  data["openai-codex"] = {
+    type: "oauth",
+    access: creds.access,
+    refresh: creds.refresh,
+    expires: creds.expires,
+    accountId: creds.accountId,
+  };
+  writeAuthFile(data);
+
+  return getOAuthStatus("openai-codex");
+}

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -68,6 +68,17 @@ export interface OrbitAPI {
   getConfig(): Promise<Record<string, unknown>>;
   saveConfig(config: Record<string, unknown>): Promise<{ success: boolean; error?: string }>;
   validateApiKey(provider: string, key: string): Promise<{ valid: boolean; error?: string }>;
+  oauthStatus(
+    provider: string,
+  ): Promise<{ signedIn: boolean; expiresInSeconds?: number; accountId?: string }>;
+  oauthSignIn(provider: string): Promise<
+    | {
+        ok: true;
+        status: { signedIn: boolean; expiresInSeconds?: number; accountId?: string };
+      }
+    | { ok: false; error: string }
+  >;
+  oauthSignOut(provider: string): Promise<{ ok: true } | { ok: false; error: string }>;
   respondToUiRequest(id: string, response: Record<string, unknown>): void;
   restartAgent(): Promise<void>;
   resetSession(): Promise<void>;
@@ -139,6 +150,9 @@ const api: OrbitAPI = {
   getConfig: () => ipcRenderer.invoke("config:get"),
   saveConfig: (config) => ipcRenderer.invoke("config:save", config),
   validateApiKey: (provider, key) => ipcRenderer.invoke("apiKey:validate", provider, key),
+  oauthStatus: (provider) => ipcRenderer.invoke("oauth:status", provider),
+  oauthSignIn: (provider) => ipcRenderer.invoke("oauth:sign-in", provider),
+  oauthSignOut: (provider) => ipcRenderer.invoke("oauth:sign-out", provider),
 
   respondToUiRequest: (id, response) => {
     ipcRenderer.send("agent:ui-response", {

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -2416,6 +2416,11 @@ let MODELS_BY_PROVIDER: Record<string, ModelChoice[]> = {
     { id: "o1-mini", label: "o1-mini — $3/$12" },
     { id: "o1", label: "o1 — $15/$60" },
   ],
+  "openai-codex": [
+    { id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
+    { id: "gpt-5.4", label: "GPT-5.4" },
+    { id: "gpt-5.4-mini", label: "GPT-5.4 mini" },
+  ],
   google: [
     { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash — $0.15/$0.60 (cheapest)" },
     { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro — $1.25/$10" },

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -488,12 +488,41 @@ const welcomeProvider = document.getElementById("welcome-provider") as HTMLSelec
 const welcomeModel = document.getElementById("welcome-model") as HTMLSelectElement;
 const welcomeApiKey = document.getElementById("welcome-api-key") as HTMLInputElement;
 const welcomeApiKeyStatus = document.getElementById("welcome-api-key-status")!;
+const welcomeApiKeyRow = document.getElementById("welcome-api-key-row")!;
+const welcomeApiKeyHintRow = document.getElementById("welcome-api-key-hint-row")!;
+const welcomeOauthRow = document.getElementById("welcome-oauth-row")!;
+const welcomeOauthHintRow = document.getElementById("welcome-oauth-hint-row")!;
+const welcomeOauthStatus = document.getElementById("welcome-oauth-status")!;
+const welcomeOauthSignIn = document.getElementById("welcome-oauth-signin") as HTMLButtonElement;
 const welcomeGalaxyUrl = document.getElementById("welcome-galaxy-url") as HTMLInputElement;
 const welcomeGalaxyKey = document.getElementById("welcome-galaxy-key") as HTMLInputElement;
 const welcomeCwd = document.getElementById("welcome-cwd") as HTMLInputElement;
 const welcomeBrowseCwd = document.getElementById("welcome-browse-cwd")!;
 const welcomeSave = document.getElementById("welcome-save")!;
 const welcomeError = document.getElementById("welcome-error")!;
+
+/** Provider IDs that authenticate via OAuth rather than an API key. */
+const OAUTH_PROVIDERS = new Set<string>(["openai-codex"]);
+function isOAuthProvider(provider: string): boolean {
+  return OAUTH_PROVIDERS.has(provider);
+}
+
+function formatOAuthStatus(s: {
+  signedIn: boolean;
+  expiresInSeconds?: number;
+  accountId?: string;
+}): string {
+  if (!s.signedIn) return "Not signed in";
+  const who = s.accountId ? `Signed in (${s.accountId.slice(0, 8)}…)` : "Signed in";
+  // Don't expose the raw expiry -- pi-coding-agent refreshes silently. Only
+  // surface a hint if the token is already expired so users know a refresh
+  // will happen on next call (and so a stale auth.json isn't mistaken for
+  // a working credential).
+  if (typeof s.expiresInSeconds === "number" && s.expiresInSeconds < 0) {
+    return `${who} · token expired, will refresh on next use`;
+  }
+  return who;
+}
 
 // Wire a provider-dropdown / API-key-input / status-label triple to do
 // debounced live validation (see main/ipc-handlers.ts validateApiKey).
@@ -546,8 +575,44 @@ function populateWelcomeModels(provider: string): void {
     welcomeModel.appendChild(opt);
   }
 }
-welcomeProvider.addEventListener("change", () => populateWelcomeModels(welcomeProvider.value));
+welcomeProvider.addEventListener("change", () => {
+  populateWelcomeModels(welcomeProvider.value);
+  void updateWelcomeAuthUi();
+});
 wireApiKeyValidation(welcomeProvider, welcomeApiKey, welcomeApiKeyStatus);
+
+async function updateWelcomeAuthUi(): Promise<void> {
+  const oauth = isOAuthProvider(welcomeProvider.value);
+  welcomeApiKeyRow.classList.toggle("hidden", oauth);
+  welcomeApiKeyHintRow.classList.toggle("hidden", oauth);
+  welcomeOauthRow.classList.toggle("hidden", !oauth);
+  welcomeOauthHintRow.classList.toggle("hidden", !oauth);
+  if (oauth) {
+    const status = await window.orbit.oauthStatus(welcomeProvider.value);
+    welcomeOauthStatus.textContent = formatOAuthStatus(status);
+    welcomeOauthStatus.classList.toggle("signed-in", status.signedIn);
+    welcomeOauthSignIn.textContent = status.signedIn ? "Sign in again" : "Sign in with ChatGPT";
+  }
+}
+
+welcomeOauthSignIn.addEventListener("click", async () => {
+  welcomeError.textContent = "";
+  welcomeOauthSignIn.disabled = true;
+  welcomeOauthStatus.textContent = "Opening browser…";
+  try {
+    const res = await window.orbit.oauthSignIn(welcomeProvider.value);
+    if (res.ok) {
+      welcomeOauthStatus.textContent = formatOAuthStatus(res.status);
+      welcomeOauthStatus.classList.toggle("signed-in", res.status.signedIn);
+      welcomeOauthSignIn.textContent = "Sign in again";
+    } else {
+      welcomeError.textContent = `Sign-in failed: ${res.error}`;
+      welcomeOauthStatus.textContent = "Not signed in";
+    }
+  } finally {
+    welcomeOauthSignIn.disabled = false;
+  }
+});
 
 welcomeBrowseCwd.addEventListener("click", async () => {
   const dir = await window.orbit.selectDirectory();
@@ -556,10 +621,18 @@ welcomeBrowseCwd.addEventListener("click", async () => {
 
 welcomeSave.addEventListener("click", async () => {
   welcomeError.textContent = "";
+  const oauth = isOAuthProvider(welcomeProvider.value);
   const apiKey = welcomeApiKey.value.trim();
-  if (!apiKey) {
+  if (!oauth && !apiKey) {
     welcomeError.textContent = "API key is required";
     return;
+  }
+  if (oauth) {
+    const status = await window.orbit.oauthStatus(welcomeProvider.value);
+    if (!status.signedIn) {
+      welcomeError.textContent = "Sign in with ChatGPT before continuing.";
+      return;
+    }
   }
 
   // Galaxy: both-or-neither. The Preferences modal enforces the same
@@ -573,11 +646,16 @@ welcomeSave.addEventListener("click", async () => {
     return;
   }
 
+  // OAuth providers persist their credential in ~/.pi/agent/auth.json (written
+  // by the sign-in flow above), not in config.json. Skip writing apiKey for
+  // those so a leftover plaintext field doesn't shadow the real auth path.
+  const providerEntry: Record<string, unknown> = { model: welcomeModel.value };
+  if (!oauth) providerEntry.apiKey = apiKey;
   const cfg: Record<string, unknown> = {
     llm: {
       active: welcomeProvider.value,
       providers: {
-        [welcomeProvider.value]: { model: welcomeModel.value, apiKey },
+        [welcomeProvider.value]: providerEntry,
       },
     },
   };
@@ -621,9 +699,16 @@ async function checkFirstRun(): Promise<void> {
     llm?: { active?: string; providers?: Record<string, { hasApiKey?: boolean }> };
   };
   const active = cfg.llm?.active;
+  // Treat an OAuth-only setup (no API key, but provider has a stored token)
+  // as fully configured -- skip the welcome screen.
+  if (active && isOAuthProvider(active)) {
+    const status = await window.orbit.oauthStatus(active);
+    if (status.signedIn) return;
+  }
   const hasKey = active ? Boolean(cfg.llm?.providers?.[active]?.hasApiKey) : false;
   if (!hasKey) {
     populateWelcomeModels(welcomeProvider.value);
+    void updateWelcomeAuthUi();
     welcomeOverlay.classList.remove("hidden");
   }
 }
@@ -2299,6 +2384,13 @@ const prefsProvider = document.getElementById("prefs-provider") as HTMLSelectEle
 const prefsModel = document.getElementById("prefs-model") as HTMLSelectElement;
 const prefsApiKey = document.getElementById("prefs-api-key") as HTMLInputElement;
 const prefsApiKeyStatus = document.getElementById("prefs-api-key-status")!;
+const prefsApiKeyRow = document.getElementById("prefs-api-key-row")!;
+const prefsApiKeyHintRow = document.getElementById("prefs-api-key-hint-row")!;
+const prefsOauthRow = document.getElementById("prefs-oauth-row")!;
+const prefsOauthHintRow = document.getElementById("prefs-oauth-hint-row")!;
+const prefsOauthStatus = document.getElementById("prefs-oauth-status")!;
+const prefsOauthSignIn = document.getElementById("prefs-oauth-signin") as HTMLButtonElement;
+const prefsOauthSignOut = document.getElementById("prefs-oauth-signout") as HTMLButtonElement;
 
 // Model catalog by provider — labels include cost guidance
 // (in/out price per 1M tokens). Fallback only — populateDynamicModelData()
@@ -2364,11 +2456,12 @@ function populateModels(provider: string, selected?: string): void {
   }
 }
 
-// Switching provider: save current fields, load new provider's state.
+// Switching provider: save current fields, load new provider's state, refresh OAuth UI.
 prefsProvider.addEventListener("change", () => {
   snapshotCurrentProvider();
   prefsActiveProvider = prefsProvider.value;
   loadProviderFields(prefsActiveProvider);
+  void updatePrefsAuthUi();
 });
 wireApiKeyValidation(prefsProvider, prefsApiKey, prefsApiKeyStatus);
 // Clear the "✓ Key stored" indicator as soon as the user starts typing.
@@ -2376,6 +2469,54 @@ prefsApiKey.addEventListener("input", () => {
   if (prefsApiKeyStatus.classList.contains("stored")) {
     prefsApiKeyStatus.className = "api-key-status";
     prefsApiKeyStatus.textContent = "";
+  }
+});
+
+async function updatePrefsAuthUi(): Promise<void> {
+  const oauth = isOAuthProvider(prefsProvider.value);
+  prefsApiKeyRow.classList.toggle("hidden", oauth);
+  prefsApiKeyHintRow.classList.toggle("hidden", oauth);
+  prefsOauthRow.classList.toggle("hidden", !oauth);
+  prefsOauthHintRow.classList.toggle("hidden", !oauth);
+  if (oauth) {
+    const status = await window.orbit.oauthStatus(prefsProvider.value);
+    prefsOauthStatus.textContent = formatOAuthStatus(status);
+    prefsOauthStatus.classList.toggle("signed-in", status.signedIn);
+    prefsOauthSignIn.textContent = status.signedIn ? "Sign in again" : "Sign in with ChatGPT";
+    prefsOauthSignOut.classList.toggle("hidden", !status.signedIn);
+  }
+}
+
+prefsOauthSignIn.addEventListener("click", async () => {
+  prefsOauthSignIn.disabled = true;
+  prefsOauthStatus.textContent = "Opening browser…";
+  prefsOauthStatus.classList.remove("signed-in");
+  try {
+    const res = await window.orbit.oauthSignIn(prefsProvider.value);
+    if (res.ok) {
+      prefsOauthStatus.textContent = formatOAuthStatus(res.status);
+      prefsOauthStatus.classList.toggle("signed-in", res.status.signedIn);
+      prefsOauthSignIn.textContent = "Sign in again";
+      prefsOauthSignOut.classList.toggle("hidden", !res.status.signedIn);
+    } else {
+      prefsOauthStatus.textContent = `Sign-in failed: ${res.error}`;
+    }
+  } finally {
+    prefsOauthSignIn.disabled = false;
+  }
+});
+
+prefsOauthSignOut.addEventListener("click", async () => {
+  if (!confirm("Sign out of ChatGPT? You'll need to sign in again to use Codex models.")) return;
+  prefsOauthSignOut.disabled = true;
+  try {
+    await window.orbit.oauthSignOut(prefsProvider.value);
+    prefsOauthStatus.textContent = "Not signed in";
+    prefsOauthStatus.classList.remove("signed-in");
+    prefsOauthSignIn.textContent = "Sign in with ChatGPT";
+    prefsOauthSignOut.classList.add("hidden");
+  } finally {
+    prefsOauthSignOut.disabled = false;
   }
 });
 const prefsGalaxyUrl = document.getElementById("prefs-galaxy-url") as HTMLInputElement;
@@ -2551,6 +2692,7 @@ async function openPreferences(): Promise<void> {
   prefsActiveProvider = config.llm?.active || "anthropic";
   prefsProvider.value = prefsActiveProvider;
   loadProviderFields(prefsActiveProvider);
+  await updatePrefsAuthUi();
 
   // Galaxy: use active profile
   const activeProfile = config.galaxy?.active
@@ -2629,24 +2771,27 @@ async function savePreferences(): Promise<void> {
   const activeProvider = prefsProvider.value;
   const selectedModel = prefsProviderStates[activeProvider]?.model || prefsModel.value || undefined;
 
-  // Build the full providers map from in-memory state.
-  const providers: Record<string, { apiKey: string; model?: string }> = {};
+  // Build the full providers map from in-memory state. OAuth providers persist
+  // credentials in ~/.pi/agent/auth.json -- don't ship an apiKey field (sentinel
+  // or "") for them, or the reconciler would try to preserve/clear a
+  // config.json key that was never there.
+  const providers: Record<string, { apiKey?: string; model?: string }> = {};
   for (const [name, state] of Object.entries(prefsProviderStates)) {
-    const key = state.typedKey.trim()
-      ? state.typedKey.trim()
-      : state.hadKey
-        ? UNCHANGED_SECRET
-        : "";
-    providers[name] = { apiKey: key, model: state.model || undefined };
+    const entry: { apiKey?: string; model?: string } = { model: state.model || undefined };
+    if (!isOAuthProvider(name)) {
+      entry.apiKey = state.typedKey.trim()
+        ? state.typedKey.trim()
+        : state.hadKey
+          ? UNCHANGED_SECRET
+          : "";
+    }
+    providers[name] = entry;
   }
-  // Ensure the active provider is always in the map even if brand-new.
-  if (!providers[activeProvider]) {
-    providers[activeProvider] = { apiKey: llmApiKey, model: selectedModel };
-  } else {
-    // llmApiKey is the resolved key for the active provider — use it as override.
-    providers[activeProvider].apiKey = llmApiKey;
-    providers[activeProvider].model = selectedModel;
-  }
+  // Override the active provider with the resolved current-screen values
+  // (covers the brand-new-provider case too).
+  const activeEntry: { apiKey?: string; model?: string } = { model: selectedModel };
+  if (!isOAuthProvider(activeProvider)) activeEntry.apiKey = llmApiKey;
+  providers[activeProvider] = activeEntry;
 
   const config: Record<string, unknown> = {
     llm: { active: activeProvider, providers },

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -356,6 +356,7 @@
               <select id="prefs-provider">
                 <option value="anthropic">Anthropic</option>
                 <option value="openai">OpenAI</option>
+                <option value="openai-codex">OpenAI Codex (ChatGPT subscription)</option>
                 <option value="google">Google (Gemini)</option>
                 <option value="mistral">Mistral</option>
                 <option value="groq">Groq</option>
@@ -376,13 +377,32 @@
                 Prices in the dropdown are per 1M tokens (input/output).
               </span>
             </div>
-            <div class="prefs-row">
+            <div class="prefs-row" id="prefs-api-key-row">
               <label for="prefs-api-key">API Key</label>
               <input id="prefs-api-key" type="password" placeholder="sk-..." />
             </div>
-            <div class="prefs-row prefs-hint">
+            <div class="prefs-row prefs-hint" id="prefs-api-key-hint-row">
               <span></span>
               <span id="prefs-api-key-status" class="api-key-status"></span>
+            </div>
+            <div class="prefs-row hidden" id="prefs-oauth-row">
+              <label>Sign in</label>
+              <div class="prefs-row-with-btn">
+                <span id="prefs-oauth-status" class="prefs-oauth-status">Not signed in</span>
+                <button id="prefs-oauth-signin" class="plan-btn" type="button">
+                  Sign in with ChatGPT
+                </button>
+                <button id="prefs-oauth-signout" class="plan-btn danger hidden" type="button">
+                  Sign out
+                </button>
+              </div>
+            </div>
+            <div class="prefs-row prefs-hint hidden" id="prefs-oauth-hint-row">
+              <span></span>
+              <span class="prefs-hint-text">
+                Opens your browser to OpenAI. Requires a ChatGPT Plus, Pro, Business, Edu, or
+                Enterprise subscription. Token refresh is handled automatically.
+              </span>
             </div>
           </section>
 
@@ -482,6 +502,7 @@
               <select id="welcome-provider">
                 <option value="anthropic">Anthropic</option>
                 <option value="openai">OpenAI</option>
+                <option value="openai-codex">OpenAI Codex (ChatGPT subscription)</option>
                 <option value="google">Google (Gemini)</option>
                 <option value="mistral">Mistral</option>
                 <option value="groq">Groq</option>
@@ -493,13 +514,29 @@
               <label for="welcome-model">Model</label>
               <select id="welcome-model"></select>
             </div>
-            <div class="prefs-row">
+            <div class="prefs-row" id="welcome-api-key-row">
               <label for="welcome-api-key">API Key</label>
               <input id="welcome-api-key" type="password" placeholder="sk-..." />
             </div>
-            <div class="prefs-row prefs-hint">
+            <div class="prefs-row prefs-hint" id="welcome-api-key-hint-row">
               <span></span>
               <span id="welcome-api-key-status" class="api-key-status"></span>
+            </div>
+            <div class="prefs-row hidden" id="welcome-oauth-row">
+              <label>Sign in</label>
+              <div class="prefs-row-with-btn">
+                <span id="welcome-oauth-status" class="prefs-oauth-status">Not signed in</span>
+                <button id="welcome-oauth-signin" class="plan-btn" type="button">
+                  Sign in with ChatGPT
+                </button>
+              </div>
+            </div>
+            <div class="prefs-row prefs-hint hidden" id="welcome-oauth-hint-row">
+              <span></span>
+              <span class="prefs-hint-text">
+                Opens your browser to OpenAI. Requires a ChatGPT Plus, Pro, Business, Edu, or
+                Enterprise subscription.
+              </span>
             </div>
           </section>
 

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -2032,6 +2032,17 @@ body.platform-darwin #files-title {
   color: #f85149;
 }
 
+.prefs-oauth-status {
+  font-size: 12px;
+  color: var(--text-dim);
+  display: inline-flex;
+  align-items: center;
+  margin-right: 8px;
+}
+.prefs-oauth-status.signed-in {
+  color: #2ea043;
+}
+
 .modal-footer {
   display: flex;
   align-items: center;

--- a/bin/loom.js
+++ b/bin/loom.js
@@ -207,7 +207,27 @@ function checkLLMProvider() {
   if (userArgs.some((a) => skipFlags.some((f) => a.startsWith(f)))) return;
   if (hasArg("--provider")) return;
 
-  // Consolidated config has an API key
+  // OAuth providers authenticate via ~/.pi/agent/auth.json, not config keys.
+  // Short-circuit on a present credential for the active provider; stale
+  // plaintext / encrypted fields on the entry are ignored entirely so they
+  // can't mask a missing OAuth login or falsely trigger the encrypted-key
+  // exit below.
+  if (activeLlmProvider && OAUTH_PROVIDERS.has(activeLlmProvider)) {
+    const authPath = join(agentDir, "auth.json");
+    if (existsSync(authPath)) {
+      try {
+        const auth = JSON.parse(readFileSync(authPath, "utf-8"));
+        if (auth && auth[activeLlmProvider]) return;
+      } catch {}
+    }
+    console.error(`loom: provider "${activeLlmProvider}" requires an OAuth sign-in.
+Launch via Orbit (\`cd app && npm start\`) and sign in from Preferences,
+or unset the active provider in ~/.loom/config.json.
+`);
+    process.exit(1);
+  }
+
+  // Consolidated config has an API key (non-OAuth providers only)
   if (activeLlmConfig?.apiKey) return;
 
   const providerEnvVars = [

--- a/bin/loom.js
+++ b/bin/loom.js
@@ -100,12 +100,18 @@ const PROVIDER_ENV_MAP = {
   xai: "XAI_API_KEY",
 };
 
+// Providers that authenticate via OAuth (~/.pi/agent/auth.json) instead of env vars.
+const OAUTH_PROVIDERS = new Set(["openai-codex"]);
+
 // apiKeyEncrypted isn't readable here -- no Electron safeStorage in the
 // brain process. Orbit decrypts and passes via env when it spawns us;
-// standalone CLI usage only works with plaintext keys.
+// standalone CLI usage only works with plaintext keys. OAuth providers
+// skip env injection entirely: a stale apiKey on the entry shouldn't leak
+// under a misrouted env variable when the brain will authenticate via
+// ~/.pi/agent/auth.json anyway.
 const activeLlmProvider = loomConfig.llm?.active;
 const activeLlmConfig = activeLlmProvider ? loomConfig.llm?.providers?.[activeLlmProvider] : null;
-if (activeLlmConfig?.apiKey) {
+if (activeLlmConfig?.apiKey && !OAUTH_PROVIDERS.has(activeLlmProvider)) {
   const envVar = PROVIDER_ENV_MAP[activeLlmProvider] || "AI_GATEWAY_API_KEY";
   if (!process.env[envVar]) {
     process.env[envVar] = activeLlmConfig.apiKey;


### PR DESCRIPTION
## Summary

Adds `openai-codex` as a selectable LLM provider in Orbit, so users can drive Loom with a ChatGPT Plus/Pro/Business/Edu/Enterprise subscription instead of needing a separate OpenAI Platform API key. The brain already speaks the Codex OAuth protocol via `~/.pi/agent/auth.json` -- when spawned with `--provider openai-codex` pi-coding-agent picks up credentials there and uses them, refresh and all. So this PR is purely the Orbit side: a new main-process `oauth-handler.ts` that drives pi-ai's `loginOpenAICodex`, `oauth:status`/`sign-in`/`sign-out` IPC handlers, a Sign in with ChatGPT row in both Preferences and the Welcome screen that toggles into view when `openai-codex` is the selected provider, and a small guard in `agent.ts`/`bin/loom.js` so a stale API key from a previous provider doesn't leak under a misrouted env var.

Model picker for `openai-codex` populates dynamically from pi-ai's bundled registry (gpt-5.4, gpt-5.5, the codex variants, etc.) -- no hardcoded list to maintain.

GitHub Copilot was briefly scoped into this branch and pulled before this draft went up. After reading the relevant policies, Copilot looked too murky to ship: the `copilot_internal/v2/token` endpoint pi-ai's flow uses, combined with GitHub's reverse-engineering ban and Copilot's "within your code editor" product-terms scope, puts third-party clients on shaky ground. ChatGPT is the opposite case -- the head of Codex at OpenAI publicly [endorsed pi-ai by name](https://x.com/thsottiaux/status/2012030806169121160), and the `originator` field Codex clients pass is the documented protocol for third-party callers. Anthropic Pro/Max OAuth is also off the table (their docs explicitly prohibit third-party subscription use). Copilot can be revisited if the policy picture changes.

## Test plan

- [x] root + app `tsc --noEmit` clean
- [x] vitest 185/185
- [x] eslint 0 errors (pre-existing warnings only)
- [x] `npm run smoke:pack`
- [ ] live OAuth round-trip (browser → callback server → auth.json → brain spawn) -- not yet exercised, draft until verified