### PR TITLE
Follow-up nits from PR #116 review

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -17,7 +17,12 @@ declare global {
 // macOS uses titleBarStyle: 'hiddenInset', which insets the traffic lights
 // over the top-left of the content. Toggle a body class so we can pad the
 // leftmost masthead away from them and skip the padding on other platforms.
-if (navigator.platform.startsWith("Mac")) document.body.classList.add("platform-darwin");
+// navigator.platform is deprecated; prefer userAgentData and fall back for
+// older Chromium / non-Chromium runtimes that may host the renderer.
+const platformString =
+  (navigator as Navigator & { userAgentData?: { platform?: string } }).userAgentData?.platform ??
+  navigator.platform;
+if (/mac/i.test(platformString)) document.body.classList.add("platform-darwin");
 
 // ── Components ────────────────────────────────────────────────────────────────
 

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -2233,7 +2233,11 @@ divider.addEventListener("mousedown", (e) => {
 
 document.addEventListener("mousemove", (e) => {
   if (!dragging) return;
-  const containerWidth = document.getElementById("app")!.getBoundingClientRect().width;
+  // chatPane is a flex child of #app-main, so its flex-basis percentage
+  // resolves against #app-main's width (not #app's). These are equal today
+  // because #app-main is the only row in #app, but using #app-main keeps the
+  // math correct if the column-flex parent ever grows a sibling.
+  const containerWidth = document.getElementById("app-main")!.getBoundingClientRect().width;
   const chatLeft = chatPane.getBoundingClientRect().left;
   const pct = ((e.clientX - chatLeft) / containerWidth) * 100;
   const clamped = Math.max(25, Math.min(75, pct));

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -640,6 +640,10 @@ body:not(.artifact-collapsed) #artifact-toggle {
   text-transform: uppercase;
   -webkit-app-region: drag;
 }
+/* Children of .pane-title default to "drag" (titlebar drag region on macOS).
+   Re-enable clicks on interactive children. If you add a new interactive
+   element (textarea, [role=button], a custom clickable container, etc.) inside
+   any .pane-title, add it here or it will swallow clicks on macOS. */
 .pane-title button,
 .pane-title input,
 .pane-title select,


### PR DESCRIPTION
## Summary

Three small follow-ups to #116 -- all reviewer suggestions, none functional regressions:

- Use `#app-main` (not `#app`) as the denominator in the chat/artifact divider's flex-basis math. Equal today, but matches the element the percentage actually resolves against.
- Document the `.pane-title` drag-region whitelist. The pattern is opt-out (everything in a pane title is draggable by default), so adding a `textarea` or `[role=button]` in a title without an entry in the no-drag selector will silently swallow clicks on macOS. Comment now lives next to the selector.
- Swap `navigator.platform` (deprecated) for `navigator.userAgentData.platform`, with `navigator.platform` as the fallback. The class still toggles on substring `mac` so both `"macOS"` and `"MacIntel"` keep working.

## Test plan

- [x] `npm run typecheck` (root) -- clean
- [x] `cd app && npx tsc --noEmit` -- clean
- [x] `npm test` -- 185/185 passing
- [ ] Manual: divider drag still tracks the cursor on macOS
- [ ] Manual: `body.platform-darwin` class still gets added on macOS (traffic-light padding visible on the Files masthead)