### PR TITLE
fix: cost estimator drops and sleep reset

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -134,19 +134,38 @@ function costKey(cwd: string): string {
 function saveCostState(cwd: string): void {
   localStorage.setItem(
     costKey(cwd),
-    JSON.stringify({ sessionUsage: { ...sessionUsage }, sessionCostFromPi }),
+    JSON.stringify({
+      sessionUsage: { ...sessionUsage },
+      sessionCostFromPi,
+      perModelUsage: Object.fromEntries(perModelUsage),
+    }),
   );
 }
 function restoreCostState(cwd: string): void {
   try {
     const raw = localStorage.getItem(costKey(cwd));
     if (!raw) return;
-    const s = JSON.parse(raw) as { sessionUsage: Usage; sessionCostFromPi: number | null };
+    const s = JSON.parse(raw) as {
+      sessionUsage: Usage;
+      sessionCostFromPi: number | null;
+      perModelUsage?: Record<string, Usage>;
+    };
     sessionUsage.input = s.sessionUsage.input ?? 0;
     sessionUsage.output = s.sessionUsage.output ?? 0;
     sessionUsage.cacheRead = s.sessionUsage.cacheRead ?? 0;
     sessionUsage.cacheWrite = s.sessionUsage.cacheWrite ?? 0;
     sessionCostFromPi = s.sessionCostFromPi ?? null;
+    perModelUsage.clear();
+    if (s.perModelUsage) {
+      for (const [model, u] of Object.entries(s.perModelUsage)) {
+        perModelUsage.set(model, {
+          input: u.input ?? 0,
+          output: u.output ?? 0,
+          cacheRead: u.cacheRead ?? 0,
+          cacheWrite: u.cacheWrite ?? 0,
+        });
+      }
+    }
     renderUsage();
   } catch {}
 }
@@ -790,7 +809,12 @@ async function refreshCwd(): Promise<void> {
   }
 }
 
-function resetUiForFreshContext(): void {
+// `clearPersistedCost` defaults to true so /new and other "wipe everything"
+// callers behave as before. `applyCwdChange` passes false so the source cwd's
+// per-cwd cost record survives the switch — otherwise the per-cwd keying is
+// pointless.
+function resetUiForFreshContext(opts: { clearPersistedCost?: boolean } = {}): void {
+  const { clearPersistedCost = true } = opts;
   chat.clear();
   artifacts.clear();
   clearPendingMessage();
@@ -804,9 +828,11 @@ function resetUiForFreshContext(): void {
   turnUsage.cacheWrite = 0;
   perModelUsage.clear();
   sessionCostFromPi = null;
-  try {
-    clearCostState(cwdPathEl.textContent || "");
-  } catch {}
+  if (clearPersistedCost) {
+    try {
+      clearCostState(cwdPathEl.textContent || "");
+    } catch {}
+  }
   renderUsage();
   streaming = false;
   sendBtn.classList.remove("hidden");
@@ -816,10 +842,11 @@ function resetUiForFreshContext(): void {
 }
 
 function applyCwdChange(dir: string): void {
-  resetUiForFreshContext();
+  resetUiForFreshContext({ clearPersistedCost: false });
   chat.setCwd(dir);
   cwdPathEl.textContent = dir;
   cwdPathEl.title = dir;
+  restoreCostState(dir);
   chat.addInfoMessage(
     `<i>Switched analysis directory to <code>${dir.replace(/</g, "&lt;")}</code>.</i>`,
   );

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -124,6 +124,36 @@ let currentModel: string | null = null;
 let sessionCostFromPi: number | null = null;
 let turnCostFromPi: number = 0;
 
+// ── Cost persistence across renderer reloads (sleep/wake GPU reset) ──────────
+// Cost state is in-memory and wiped on renderer reload. Persist to
+// localStorage keyed by cwd so it survives display-sleep recovery reloads.
+
+function costKey(cwd: string): string {
+  return `orbit.cost.${cwd}`;
+}
+function saveCostState(cwd: string): void {
+  localStorage.setItem(
+    costKey(cwd),
+    JSON.stringify({ sessionUsage: { ...sessionUsage }, sessionCostFromPi }),
+  );
+}
+function restoreCostState(cwd: string): void {
+  try {
+    const raw = localStorage.getItem(costKey(cwd));
+    if (!raw) return;
+    const s = JSON.parse(raw) as { sessionUsage: Usage; sessionCostFromPi: number | null };
+    sessionUsage.input = s.sessionUsage.input ?? 0;
+    sessionUsage.output = s.sessionUsage.output ?? 0;
+    sessionUsage.cacheRead = s.sessionUsage.cacheRead ?? 0;
+    sessionUsage.cacheWrite = s.sessionUsage.cacheWrite ?? 0;
+    sessionCostFromPi = s.sessionCostFromPi ?? null;
+    renderUsage();
+  } catch {}
+}
+function clearCostState(cwd: string): void {
+  localStorage.removeItem(costKey(cwd));
+}
+
 /** Match a model ID against the pricing table (handles date suffixes). */
 function findPricing(
   model: string,
@@ -722,6 +752,9 @@ function commitTurnUsage(): void {
   turnUsage.cacheWrite = 0;
   turnCostFromPi = 0;
   renderUsage();
+  try {
+    saveCostState(cwdPathEl.textContent || "");
+  } catch {}
 }
 
 renderUsage();
@@ -751,6 +784,7 @@ async function refreshCwd(): Promise<void> {
     cwdPathEl.textContent = cwd;
     cwdPathEl.title = cwd;
     chat.setCwd(cwd);
+    restoreCostState(cwd);
   } catch {
     /* getCwd not available yet */
   }
@@ -769,6 +803,10 @@ function resetUiForFreshContext(): void {
   turnUsage.cacheRead = 0;
   turnUsage.cacheWrite = 0;
   perModelUsage.clear();
+  sessionCostFromPi = null;
+  try {
+    clearCostState(cwdPathEl.textContent || "");
+  } catch {}
   renderUsage();
   streaming = false;
   sendBtn.classList.remove("hidden");


### PR DESCRIPTION
## Problem

Two related bugs in the footer cost estimator:

1. **Numbers drop after `/new` or cwd change** — `sessionCostFromPi` was never reset in `resetUiForFreshContext()`. After starting a fresh session, the old pi-reported cost persisted in the footer while `sessionUsage` was zeroed, causing an inconsistent display until a new turn overwrote it.

2. **Cost resets to zero after screen sleep** — cost state (`sessionUsage`, `sessionCostFromPi`) is in-memory only. When the renderer reloads on wake-from-sleep GPU reset recovery, all cost data is lost.

## Fix

- Add `sessionCostFromPi = null` to `resetUiForFreshContext()` so `/new` and cwd changes give a clean slate.
- Persist cost state to `localStorage` keyed by cwd (`orbit.cost.<cwd>`). `refreshCwd()` restores it on startup/renderer reload. `resetUiForFreshContext()` clears it. `commitTurnUsage()` saves it after every turn.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `cd app && npx tsc --noEmit` — clean
- [x] `npm test` — 256/256 passing
- [ ] Manual: cost survives display sleep and renderer reload
- [ ] Manual: cost resets cleanly after `/new`