### PR TITLE
fix: use ```plan fence in chat draft template

### DIFF
--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -498,8 +498,9 @@ the geographic distribution analysis").
 When the user **does** ask for a plan, follow this order strictly:
 
 1. **Draft in chat (NOT in the notebook yet).** Reply in chat with a
-   fenced markdown block formatted as a plan section (see template
-   below). This is a proposal for review. Do not call Edit/Write to
+   \`\`\`plan fenced block formatted as a plan section (see template
+   below). Orbit renders \`\`\`plan fences as an interactive card with
+   Approve / Edit / Reject buttons. Do not call Edit/Write to
    put it into \`notebook.md\` at this point.
 2. **Wait for explicit plan approval.** The user must signal approval
    with words like "yes", "go", "approve", "looks good", "proceed",
@@ -533,9 +534,10 @@ continuation-indent text into the parent line; sub-bullets render as
 a real nested list.
 
 Worked example -- copy this shape exactly, just substitute domain
-content:
+content. **Use a \`\`\`plan fence** in chat (not \`\`\`markdown) so Orbit
+renders it as an interactive draft card with Approve/Edit/Reject buttons.
 
-\`\`\`markdown
+\`\`\`plan
 ## Plan A: chrM Variant Calling [galaxy]
 
 Identify mitochondrial variants from 4 paired-end WGS samples using

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -523,7 +523,7 @@ If the user explicitly says "save this plan to the notebook even
 though I haven't approved it" or similar, that's a manual override —
 honor it and skip the remaining gates.
 
-### Plan section template (used in the chat draft AND the notebook write)
+### Plan section template (used in the chat draft and -- minus the fence -- the notebook write)
 
 The heading line is rigid: \`## Plan <Letter>: <Title> [<routing>]\`,
 with a literal letter (\`A\`, \`B\`, \`C\` -- pick the next free one),
@@ -566,6 +566,11 @@ the IWC \`bwa-mem-chrM\` workflow. Output: chrM VCF + per-sample QC.
 | 2   | bwa_mem   | --threads                 | 4  | 8  | parallel threads  |
 | 3   | bcftools_call | -p                    | 0.5 | 0.01 | call threshold  |
 \`\`\`
+
+When you eventually Edit/Write the approved plan to \`notebook.md\`,
+**drop the surrounding \`\`\`plan fence** -- it's a chat-only render hint.
+Write the inner content (heading, steps, parameter table) as raw
+markdown so the notebook stays a clean durable record.
 
 Conventions (please re-read the heading line above before drafting):
 


### PR DESCRIPTION
## Problem

The plan draft template in the system prompt used a ` ```markdown ` fence:

```
```markdown
## Plan A: chrM Variant Calling [galaxy]
...
```
```

But Orbit's `extractPlanFences()` in `chat-panel.ts` only matches ` ```plan ` fences to render the interactive draft card (Approve / Edit / Reject buttons). A ` ```markdown ` fence is passed to `marked` and rendered as a raw code block — so users see the raw `## Plan A:...` text instead of the formatted card.

## Fix

- Change the template example from ` ```markdown ` to ` ```plan `
- Add an explicit note at the "Draft in chat" step that Orbit renders ` ```plan ` fences as an interactive card

## Test plan

- [ ] Ask the agent for a plan — should now appear as an interactive draft card with Approve/Edit/Reject buttons
- [x] `npm run typecheck` — clean