### PR TITLE
fix: restore streaming UI state on wake-from-sleep

### DIFF
--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -173,6 +173,11 @@ export class AgentManager {
   private window: BrowserWindow;
   private status: AgentStatus = "stopped";
   private statusMessage: string | undefined;
+  // `status` only tracks process aliveness; `turnActive` tracks whether the
+  // brain is mid-response. Toggled by parsing agent_start / agent_end events
+  // on stdout so the renderer can re-sync after a reload (display-sleep
+  // recovery) without conflating process-running with turn-running.
+  private turnActive = false;
   private stderr = "";
   private pendingResponses = new Map<string, PendingResponse>();
   private idCounter = 0;
@@ -549,8 +554,8 @@ export class AgentManager {
     return this.status;
   }
 
-  getStatusSnapshot(): { status: AgentStatus; message?: string } {
-    return { status: this.status, message: this.statusMessage };
+  getStatusSnapshot(): { status: AgentStatus; message?: string; turnActive: boolean } {
+    return { status: this.status, message: this.statusMessage, turnActive: this.turnActive };
   }
 
   getStderr(): string {
@@ -560,6 +565,10 @@ export class AgentManager {
   private setStatus(status: AgentStatus, message?: string): void {
     this.status = status;
     this.statusMessage = message;
+    // Process death (clean or otherwise) ends any in-flight turn.
+    if (status === "stopped" || status === "error") {
+      this.turnActive = false;
+    }
     log("status:", status, message || "");
     // During a silent restart we suppress the transient stopped→running flicker;
     // the renderer keeps showing "running" the whole time.
@@ -610,6 +619,12 @@ export class AgentManager {
       }
       this.window.webContents.send("agent:ui-request", data);
       return;
+    }
+
+    if (type === "agent_start") {
+      this.turnActive = true;
+    } else if (type === "agent_end" || type === "error") {
+      this.turnActive = false;
     }
 
     this.window.webContents.send("agent:event", data);

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -91,7 +91,11 @@ export interface OrbitAPI {
   onAgentStatus(
     callback: (status: "running" | "stopped" | "error", msg?: string) => void,
   ): () => void;
-  getAgentStatus(): Promise<{ status: "running" | "stopped" | "error"; message?: string }>;
+  getAgentStatus(): Promise<{
+    status: "running" | "stopped" | "error";
+    message?: string;
+    turnActive: boolean;
+  }>;
   onCwdChanged(callback: (dir: string) => void): () => void;
   onDisplayResume(callback: () => void): () => void;
   onOpenPreferences(callback: () => void): () => void;

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -967,7 +967,7 @@ async function loadNotebookFromDisk(): Promise<void> {
   }
 }
 
-// On wake-from-sleep, auto-restore blank chat and notebook without user action.
+// On wake-from-sleep, auto-restore blank chat, notebook, and streaming UI state.
 window.orbit.onDisplayResume(() => {
   if (!chat.hasContent()) {
     void window.orbit.replayChat().then((r) => {
@@ -981,6 +981,17 @@ window.orbit.onDisplayResume(() => {
   } else {
     void loadNotebookFromDisk();
   }
+  // Re-sync streaming UI with actual agent state. If the agent is mid-turn
+  // (running a long tool like foldseek), restore the abort button so the
+  // user isn't stuck with a yellow send button and no way to interrupt.
+  void window.orbit.getAgentStatus().then(({ status }) => {
+    if (status === "running" && !streaming) {
+      streaming = true;
+      sendBtn.classList.add("hidden");
+      abortBtn.classList.remove("hidden");
+      setStatusBadge("running", "running...");
+    }
+  });
 });
 
 window.orbit.onSessionHistory((history) => {

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -2006,13 +2006,20 @@ window.orbit.onAgentEvent((event) => {
       chat.hideThinking();
       const name = (event as { toolName?: string }).toolName || "tool";
       const id = (event as { toolCallId?: string }).toolCallId || name;
+      const startArgs = (event as { args?: Record<string, unknown> }).args;
       // Per-tool chat cards are noisy and duplicate what the Activity tab
       // shows (shell stream + activity.jsonl). Only team_dispatch keeps a
       // chat card because its collapsible per-turn body is genuinely useful.
       if (name === "team_dispatch") {
         chat.addToolCard(id, name);
       }
-      setStatusBadge("running", `running: ${name}`);
+      // Enrich the status badge with the command/path so users can see what
+      // is running without switching to the Activity tab.
+      const preview = formatArgsPreview(startArgs);
+      const badgeLabel = preview
+        ? `${name}: ${preview.length > 60 ? preview.slice(0, 60) + "…" : preview}`
+        : `running: ${name}`;
+      setStatusBadge("running", badgeLabel);
       break;
     }
 

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -984,8 +984,10 @@ window.orbit.onDisplayResume(() => {
   // Re-sync streaming UI with actual agent state. If the agent is mid-turn
   // (running a long tool like foldseek), restore the abort button so the
   // user isn't stuck with a yellow send button and no way to interrupt.
-  void window.orbit.getAgentStatus().then(({ status }) => {
-    if (status === "running" && !streaming) {
+  // Key on `turnActive`, not `status === "running"`: status === "running"
+  // only means the brain process is alive, which is true between turns too.
+  void window.orbit.getAgentStatus().then(({ turnActive }) => {
+    if (turnActive && !streaming) {
       streaming = true;
       sendBtn.classList.add("hidden");
       abortBtn.classList.remove("hidden");

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -354,11 +354,13 @@ the activity stream.
 
 \`\`\`bash
 # 1. Launch in background. \`disown\` detaches from the tool shell so the
-# job survives this tool invocation. The \`&& touch ... .done\` sentinel
-# is more reliable than \`kill -0 $PID\` (PID reuse over hour-scale jobs).
+# job survives this tool invocation. Drop \`.done\` on success or \`.failed\`
+# on error so polling can distinguish "still running" from "finished badly"
+# — without the \`.failed\` branch a quick crash gets reported as
+# "still running" indefinitely.
 mkdir -p foldseek_work
 nohup sh -c '.loom/env/bin/foldseek easy-cluster ... > foldseek_work/run.log 2>&1 \\
-  && touch foldseek_work/.done' > /dev/null 2>&1 &
+  && touch foldseek_work/.done || touch foldseek_work/.failed' > /dev/null 2>&1 &
 disown
 echo "Launched foldseek — tail foldseek_work/run.log to monitor"
 \`\`\`
@@ -369,6 +371,9 @@ if [ -f foldseek_work/.done ]; then
   echo "Finished"
   ls -lh foldseek_work/vir_struct_cluster_cluster.tsv 2>/dev/null \\
     || echo "output missing — check log for errors"
+  tail -20 foldseek_work/run.log
+elif [ -f foldseek_work/.failed ]; then
+  echo "Failed — check log"
   tail -20 foldseek_work/run.log
 else
   echo "Still running"

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -333,6 +333,51 @@ solves on fresh envs).
 and be killed partway. When you do need a bound, pick generously: 300 s
 for quick commands, 3600 s for short pipelines, 86400 s for overnight.
 Prefer **omitting \`timeout\` entirely** over capping too low.
+
+### Long-running jobs — always background them
+
+If a job will take **more than ~30 seconds** (foldseek ProstT5, mmseqs2
+all-vs-all, MCL on large graphs, STAR genome indexing, assembly, any
+deep-learning inference step), **never block the bash tool on it**.
+A blocked tool holds the entire chat turn; the user cannot send messages,
+the display going to sleep will blank the UI, and a crash or abort kills
+the job mid-run.
+
+**Pattern — launch, record, poll:**
+
+\`\`\`bash
+# 1. Launch in background, redirect output to a log
+nohup .loom/env/bin/foldseek easy-cluster ... > foldseek_work/run.log 2>&1 &
+JOB_PID=$!
+echo $JOB_PID > foldseek_work/job.pid
+echo "Launched foldseek PID $JOB_PID — tail foldseek_work/run.log to monitor"
+\`\`\`
+
+\`\`\`bash
+# 2. Poll in a later bash call (separate tool invocation, minutes later)
+JOB_PID=$(cat foldseek_work/job.pid 2>/dev/null)
+if kill -0 "$JOB_PID" 2>/dev/null; then
+  echo "Still running (PID $JOB_PID)"
+  tail -5 foldseek_work/run.log
+else
+  echo "Finished"
+  ls -lh foldseek_work/vir_struct_cluster_cluster.tsv 2>/dev/null || echo "output missing — check log for errors"
+  tail -20 foldseek_work/run.log
+fi
+\`\`\`
+
+After launching, **return to the user immediately** with a message like
+"foldseek is running in the background (PID 12345). I'll check back in
+a few minutes — or you can ask me to check now." Write the PID and log
+path to the notebook so the session is recoverable after a restart.
+
+**Signals that a job needs backgrounding** (non-exhaustive):
+- Any neural-network inference (ProstT5, ESM, AlphaFold, etc.)
+- mmseqs2 / foldseek on > ~500 sequences
+- MCL clustering on large graphs
+- STAR / hisat2 genome index generation
+- genome assembly (hifiasm, flye, canu)
+- conda env creation on a fresh analysis
 `;
 }
 

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -321,63 +321,67 @@ Common thread flags:
 | fastqc     | \`-t N\`              |
 | cutadapt   | \`-j N\`              |
 
-### Bash timeouts on long-running tools
+### Bash timeouts and long-running jobs
 
 Pi's \`bash\` tool's \`timeout\` is **optional** and in **seconds**. When
 omitted, the command runs to completion — correct default for
 bioinformatics pipelines whose runtime you cannot reliably predict
-(PGGB / assembly / minimap2 / bwa-on-WGS / long variant calling, conda
-solves on fresh envs).
+(minimap2 / bwa-on-WGS / variant calling, fresh-env conda solves,
+short-pipeline assembly).
 
 **Do not guess-cap at 3600 s.** Real pangenome builds will cross an hour
 and be killed partway. When you do need a bound, pick generously: 300 s
 for quick commands, 3600 s for short pipelines, 86400 s for overnight.
 Prefer **omitting \`timeout\` entirely** over capping too low.
 
-### Long-running jobs — always background them
+**Background jobs likely to run 10+ minutes** so the user isn't held
+hostage to a single bash call. A blocked tool holds the chat turn: the
+user cannot send messages, display sleep can interrupt UI updates, and
+a crash or abort kills the job mid-run. Signals to background:
 
-If a job will take **more than ~30 seconds** (foldseek ProstT5, mmseqs2
-all-vs-all, MCL on large graphs, STAR genome indexing, assembly, any
-deep-learning inference step), **never block the bash tool on it**.
-A blocked tool holds the entire chat turn; the user cannot send messages,
-the display going to sleep will blank the UI, and a crash or abort kills
-the job mid-run.
+- Neural-network inference (foldseek ProstT5, ESM, AlphaFold)
+- mmseqs2 / foldseek on > ~500 sequences
+- MCL clustering on large graphs
+- STAR / hisat2 genome index generation
+- Genome assembly (hifiasm, flye, canu)
+- PGGB pangenome builds
+
+Routine multi-package conda installs and standard fastp / bwa / samtools
+steps stay in the synchronous-bash path — backgrounding them just bloats
+the activity stream.
 
 **Pattern — launch, record, poll:**
 
 \`\`\`bash
-# 1. Launch in background, redirect output to a log
-nohup .loom/env/bin/foldseek easy-cluster ... > foldseek_work/run.log 2>&1 &
-JOB_PID=$!
-echo $JOB_PID > foldseek_work/job.pid
-echo "Launched foldseek PID $JOB_PID — tail foldseek_work/run.log to monitor"
+# 1. Launch in background. \`disown\` detaches from the tool shell so the
+# job survives this tool invocation. The \`&& touch ... .done\` sentinel
+# is more reliable than \`kill -0 $PID\` (PID reuse over hour-scale jobs).
+mkdir -p foldseek_work
+nohup sh -c '.loom/env/bin/foldseek easy-cluster ... > foldseek_work/run.log 2>&1 \\
+  && touch foldseek_work/.done' > /dev/null 2>&1 &
+disown
+echo "Launched foldseek — tail foldseek_work/run.log to monitor"
 \`\`\`
 
 \`\`\`bash
 # 2. Poll in a later bash call (separate tool invocation, minutes later)
-JOB_PID=$(cat foldseek_work/job.pid 2>/dev/null)
-if kill -0 "$JOB_PID" 2>/dev/null; then
-  echo "Still running (PID $JOB_PID)"
-  tail -5 foldseek_work/run.log
-else
+if [ -f foldseek_work/.done ]; then
   echo "Finished"
-  ls -lh foldseek_work/vir_struct_cluster_cluster.tsv 2>/dev/null || echo "output missing — check log for errors"
+  ls -lh foldseek_work/vir_struct_cluster_cluster.tsv 2>/dev/null \\
+    || echo "output missing — check log for errors"
   tail -20 foldseek_work/run.log
+else
+  echo "Still running"
+  tail -5 foldseek_work/run.log
 fi
 \`\`\`
 
 After launching, **return to the user immediately** with a message like
-"foldseek is running in the background (PID 12345). I'll check back in
-a few minutes — or you can ask me to check now." Write the PID and log
-path to the notebook so the session is recoverable after a restart.
-
-**Signals that a job needs backgrounding** (non-exhaustive):
-- Any neural-network inference (ProstT5, ESM, AlphaFold, etc.)
-- mmseqs2 / foldseek on > ~500 sequences
-- MCL clustering on large graphs
-- STAR / hisat2 genome index generation
-- genome assembly (hifiasm, flye, canu)
-- conda env creation on a fresh analysis
+"foldseek is running in the background — I'll check back in a few
+minutes, or you can ask me to check now." Append a brief
+\`## Background jobs\` breadcrumb to \`notebook.md\` with the job name,
+start time, and log path so the work is recoverable across renderer
+reloads (skip the PID — it's meaningless after a restart).
 `;
 }
 


### PR DESCRIPTION
## Problem

When the display sleeps mid-turn (e.g. foldseek running for hours), the renderer reloads on wake with `streaming = false`. The send button shows in a stuck yellow state with no abort button, and the user has no way to interrupt the running job.

The existing `display:resume` handler replays chat and restores the notebook, but doesn't re-sync the streaming UI with the actual agent state.

## Fix

After replay, call `getAgentStatus()` and if the agent is still running (`status === "running"`) and `streaming` is false, re-enter streaming mode: hide send, show abort, set status badge to "running".

## Test plan

- [ ] Start a long-running tool (foldseek, BLAST, etc.), let display sleep, wake — abort button should be present and functional
- [x] `cd app && npx tsc --noEmit` — clean