### PR TITLE
orbit: fix Linux launch crash -- pass --no-sandbox --no-zygote as CLI args

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "main": ".vite/build/main.js",
   "scripts": {
     "prestart": "./scripts/rename-electron-dev.sh",
-    "start": "electron-forge start",
+    "start": "electron-forge start -- --no-sandbox --no-zygote",
     "package": "electron-forge package",
     "make": "electron-forge make"
   },


### PR DESCRIPTION
## Summary

- `app.commandLine.appendSwitch` in `main.ts` runs after Chromium's zygote host initializes in C++, so the switches arrive too late to prevent the namespace-sandbox crash on Linux kernels that restrict user namespaces (Ubuntu 24.04+, systems with `prctl(PR_SET_NO_NEW_PRIVS)`)
- Fix: pass `--no-sandbox --no-zygote` directly to the electron binary via `electron-forge start --`
- The existing `appendSwitch` calls in `main.ts` are kept — they still apply for packaged distribution builds

## Test plan

- [ ] `cd app && npm start` on Linux (Ubuntu 24.04+ or any system where namespace sandboxing is restricted) — Orbit should launch without the `zygote_host_impl_linux.cc` FATAL crash
- [ ] Confirm macOS launch is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)