### PR TITLE
orbit: suppress MCP session URLs from opening in browser windows

### DIFF
--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -156,6 +156,13 @@ function openExternalUrlWindow(url: string): void {
   const host = parsed.hostname.toLowerCase();
   const isLoopback = host === "localhost" || host.startsWith("127.") || host === "::1";
 
+  // MCP SSE transport URLs (?session=<uuid>) are internal brain↔server
+  // connections, not user-facing pages — swallow them silently.
+  if (isLoopback && parsed.searchParams.has("session")) {
+    log("openExternalUrlWindow suppressed MCP session URL:", url);
+    return;
+  }
+
   if ((proto === "http:" || proto === "https:") && isLoopback) {
     const win = new BrowserWindow({
       width: 1400,


### PR DESCRIPTION
## Summary

- `pi-mcp-adapter` spins up a local OAuth callback server and generates URLs of the form `http://localhost:<port>/?session=<uuid>` — these are internal brain↔MCP connections, not user-facing pages
- `openExternalUrlWindow` was treating any loopback `http://` URL as a user-facing viewer (IGV, reports, etc.) and opening it in a new `BrowserWindow`
- Result: browser windows pop open on every MCP reconnect, with the OAuth callback page continuously refreshing

## Fix

Guard in `openExternalUrlWindow` — drop any loopback URL that carries a `?session=` query parameter before the BrowserWindow path.

## Related

- Root cause is in `pi-mcp-adapter` (filed as https://github.com/nicobailon/pi-mcp-adapter/issues/121 — OAuth flow should require user consent, not auto-open on every reconnect)
- This PR is a defensive guard on the Orbit side regardless

## Test plan

- [ ] Start Orbit with `brc-analytics` MCP configured — no browser window should open automatically
- [ ] Loopback URLs without `?session=` (IGV viewers, local report servers) still open correctly in a new BrowserWindow

🤖 Generated with [Claude Code](https://claude.com/claude-code)