### PR TITLE
orbit: set LOOM_ORBIT_EMBEDDED=1 in brain subprocess env

### DIFF
--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -114,6 +114,7 @@ function buildBrainEnv(fresh: boolean): NodeJS.ProcessEnv {
   // Set the shell-kind marker the extension reads, plus the optional
   // fresh-session sentinel for /new flows.
   env.LOOM_SHELL_KIND = "orbit";
+  env.LOOM_ORBIT_EMBEDDED = "1";
   if (fresh) env.LOOM_FRESH_SESSION = "1";
   return env;
 }


### PR DESCRIPTION
## Summary

- Adds `LOOM_ORBIT_EMBEDDED=1` to the env injected into the brain subprocess
- Tells `pi-mcp-adapter` (and future MCP tooling) that the brain is running inside Orbit so it should skip auto-opening the system browser for OAuth flows
- Without this, `pi-mcp-adapter` calls `xdg-open` with the OAuth callback URL (`http://localhost:<port>/?session=<uuid>`) on every MCP reconnect, spamming the user's browser

## Context

`pi-mcp-adapter` v2.4.0 auto-opens the system browser whenever an MCP server returns 401, with no user gate. A fix was filed upstream at https://github.com/nicobailon/pi-mcp-adapter/issues/121. This PR is the Orbit-side workaround: the env var signals that Orbit owns the UI and the adapter should suppress its own browser calls.

The `pi-mcp-adapter` package checks for this env var in `mcp-auth-flow.ts` before calling `open()`.

## Test plan

- [ ] Configure an OAuth-protected MCP server (e.g. `brc-analytics`)
- [ ] Start Orbit — browser should not open automatically
- [ ] MCP tool results should appear in Orbit chat, not the system browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)