### PR TITLE
brain: default pi-web-access workflow to "none" so web_search returns inline

### DIFF
--- a/bin/loom.js
+++ b/bin/loom.js
@@ -199,6 +199,42 @@ if (!isInformationalCommand) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// pi-web-access default: skip the curator browser popup.
+//
+// pi-web-access ships with the brain and exposes a web_search tool. Its
+// default workflow ("summary-review") opens a curator window in the system
+// browser on every search so the user can prune results before the LLM sees
+// them. In Orbit the chat is the UI, so popping a separate browser tab on
+// every search is jarring -- and on a fresh install with no Exa/Gemini key,
+// the search still routes through Exa MCP (https://mcp.exa.ai/mcp, no auth)
+// so the popup is the only thing standing between the user and a working
+// zero-config web search. Default workflow:"none" returns raw results inline
+// for the LLM to summarize. Users who want the curator back can flip it on
+// with `/curator on` or by setting "workflow":"summary-review" in this file.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const webSearchConfigPath = join(homedir(), ".pi", "web-search.json");
+
+if (!isInformationalCommand) {
+  let webSearchConfig = {};
+  let parseOk = true;
+  if (existsSync(webSearchConfigPath)) {
+    try {
+      webSearchConfig = JSON.parse(readFileSync(webSearchConfigPath, "utf-8"));
+    } catch {
+      // Don't clobber a file we can't parse -- pi-web-access surfaces a
+      // more useful error on its own when it tries to load this.
+      parseOk = false;
+    }
+  }
+  if (parseOk && webSearchConfig.workflow === undefined) {
+    webSearchConfig.workflow = "none";
+    mkdirSync(dirname(webSearchConfigPath), { recursive: true });
+    writeFileSync(webSearchConfigPath, JSON.stringify(webSearchConfig, null, 2));
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Pre-flight: ensure at least one LLM provider is configured
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Sets `workflow: "none"` in `~/.pi/web-search.json` from `bin/loom.js` so `pi-web-access`'s `web_search` tool returns results inline to the LLM instead of opening a curator window in the system browser.

## Why

`pi-web-access` is bundled with the brain and exposes a `web_search` tool the LLM calls autonomously. Its default `workflow: "summary-review"` auto-opens a curator at `http://localhost:<port>/?session=<uuid>` in the system browser on every search so the user can prune results. In Orbit, where the chat is the UI, that popup is jarring and gets reported as an OAuth/MCP bug -- it isn't either, it's the documented curator behavior.

Defaulting to `"none"` keeps the zero-config search path intact (Exa MCP at `https://mcp.exa.ai/mcp` requires no key and no auth), and the LLM just gets raw results to summarize in the chat. Users who want the visual curator back can flip it with `/curator on` or edit the file directly.

## Not the same as #130 / #131

#130 (URL guard in `openExternalUrlWindow`) and #131 (`LOOM_ORBIT_EMBEDDED` env var) both target `pi-mcp-adapter` symptoms downstream. The actual trigger is `pi-web-access`'s default -- different package, different config, different mechanism. This PR addresses the cause; those two can be closed.

## Test plan

- [x] Fresh install (no `~/.pi/web-search.json`) -> file created with `{"workflow": "none"}`
- [x] Existing file with `workflow` already set -> unchanged
- [x] Existing file without `workflow` -> backfilled, other fields preserved
- [x] `npm test`, `prettier --check`, `eslint` all clean
- [ ] Smoke in Orbit: ask a research-y question; `web_search` should run silently and the LLM summarizes in chat