### PR TITLE
feat: add DeepSeek provider

### DIFF
--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -16,6 +16,7 @@ const PROVIDER_ENV_MAP: Record<string, string> = {
   mistral: "MISTRAL_API_KEY",
   groq: "GROQ_API_KEY",
   xai: "XAI_API_KEY",
+  deepseek: "DEEPSEEK_API_KEY",
 };
 
 /** Providers that authenticate via OAuth (~/.pi/agent/auth.json), not env vars. */

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -520,6 +520,7 @@ export function registerIpcHandlers(agent: AgentManager): void {
       "groq",
       "mistral",
       "xai",
+      "deepseek",
     ]);
     type Pricing = { input: number; output: number; cacheRead?: number; cacheWrite?: number };
     type Entry = { id: string; label: string; pricing: Pricing };

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -784,8 +784,10 @@ async function populateDynamicModelData(): Promise<void> {
       }
     }
     if (Object.keys(newModels).length === 0) return; // never replace with empty
-    MODELS_BY_PROVIDER = newModels;
-    PRICING = newPricing;
+    // Merge rather than replace so hardcoded providers not returned by the
+    // IPC (e.g. deepseek before main process restarts) survive.
+    MODELS_BY_PROVIDER = { ...MODELS_BY_PROVIDER, ...newModels };
+    PRICING = { ...PRICING, ...newPricing };
   } catch {
     /* keep hardcoded fallback */
   }
@@ -2520,6 +2522,10 @@ let MODELS_BY_PROVIDER: Record<string, ModelChoice[]> = {
     { id: "llama-3.1-8b-instant", label: "Llama 3.1 8B (fast)" },
   ],
   xai: [{ id: "grok-2-latest", label: "Grok 2" }],
+  deepseek: [
+    { id: "deepseek-v4-pro", label: "DeepSeek V4 Pro" },
+    { id: "deepseek-v4-flash", label: "DeepSeek V4 Flash (fast)" },
+  ],
   ollama: [
     { id: "qwen3-coder:30b", label: "Qwen3-Coder 30B (local, A5000) — free" },
     { id: "qwen3:8b", label: "Qwen3 8B (local, fast) — free" },

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -361,6 +361,7 @@
                 <option value="mistral">Mistral</option>
                 <option value="groq">Groq</option>
                 <option value="xai">xAI</option>
+                <option value="deepseek">DeepSeek</option>
                 <option value="ollama">Ollama (local)</option>
               </select>
             </div>
@@ -507,6 +508,7 @@
                 <option value="mistral">Mistral</option>
                 <option value="groq">Groq</option>
                 <option value="xai">xAI</option>
+                <option value="deepseek">DeepSeek</option>
                 <option value="ollama">Ollama (local)</option>
               </select>
             </div>

--- a/bin/loom.js
+++ b/bin/loom.js
@@ -340,6 +340,7 @@ or unset the active provider in ~/.loom/config.json.
     "GROQ_API_KEY",
     "MISTRAL_API_KEY",
     "XAI_API_KEY",
+    "DEEPSEEK_API_KEY",
     "OPENROUTER_API_KEY",
     "CEREBRAS_API_KEY",
     "AI_GATEWAY_API_KEY",

--- a/bin/loom.js
+++ b/bin/loom.js
@@ -101,6 +101,7 @@ const PROVIDER_ENV_MAP = {
   mistral: "MISTRAL_API_KEY",
   groq: "GROQ_API_KEY",
   xai: "XAI_API_KEY",
+  deepseek: "DEEPSEEK_API_KEY",
 };
 
 // Providers that authenticate via OAuth (~/.pi/agent/auth.json) instead of env vars.


### PR DESCRIPTION
## Summary

Adds DeepSeek as a selectable LLM provider in Orbit.

- `agent.ts`: `PROVIDER_ENV_MAP` entry `deepseek → DEEPSEEK_API_KEY`
- `index.html`: DeepSeek option in Preferences and welcome-screen provider dropdowns
- `app.ts`: `MODELS_BY_PROVIDER` entries for `deepseek-v4-pro` and `deepseek-v4-flash`

pi-ai already supports DeepSeek natively (`env-api-keys.js: deepseek: "DEEPSEEK_API_KEY"`), so no changes needed in the brain layer.

## Test plan

- [ ] Open Preferences → switch to DeepSeek → enter API key → select model → Save
- [ ] Agent restarts with `DEEPSEEK_API_KEY` in env; model responds
- [x] `cd app && npx tsc --noEmit` — clean