### PR TITLE
docs: note unattended-upgrades dpkg lock workaround for WSL2 setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ cd ~/pi-galaxy-analyst/app && npm start
 > **If the script fails with `Could not get lock /var/lib/dpkg/lock-frontend`**, Ubuntu's automatic updater is running in the background. Stop it first, then re-run:
 > ```bash
 > sudo systemctl stop unattended-upgrades
-> curl -fsSL https://raw.githubusercontent.com/galaxyproject/pi-galaxy-analyst/main/scripts/setup-wsl.sh | bash
+> curl -fsSL https://raw.githubusercontent.com/galaxyproject/loom/main/scripts/setup-wsl.sh | bash
 > ```
 
 Keep your analysis data inside `~/` (the Linux filesystem) — `/mnt/c/` paths are significantly slower across the filesystem boundary.

--- a/README.md
+++ b/README.md
@@ -287,6 +287,12 @@ source ~/.bashrc
 cd ~/pi-galaxy-analyst/app && npm start
 ```
 
+> **If the script fails with `Could not get lock /var/lib/dpkg/lock-frontend`**, Ubuntu's automatic updater is running in the background. Stop it first, then re-run:
+> ```bash
+> sudo systemctl stop unattended-upgrades
+> curl -fsSL https://raw.githubusercontent.com/galaxyproject/pi-galaxy-analyst/main/scripts/setup-wsl.sh | bash
+> ```
+
 Keep your analysis data inside `~/` (the Linux filesystem) — `/mnt/c/` paths are significantly slower across the filesystem boundary.
 
 ### After installation


### PR DESCRIPTION
## Summary

Fresh Ubuntu WSL2 installs often have `unattended-upgrades` running in the background, which holds the dpkg lock and causes `setup-wsl.sh` to fail with:

```
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process XXXX (unattended-upgr)
```

Adds a callout block to the WSL2 install section explaining the workaround (`sudo systemctl stop unattended-upgrades`) before re-running the setup script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)