### PR TITLE
macOS code signing + notarization scaffolding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,18 @@ jobs:
             arch: x64
             platform: linux
     runs-on: ${{ matrix.os }}
+    # macOS signing/notarization secrets surfaced as env so steps can gate on
+    # their presence (`env.X != ''`). When they're all empty -- e.g. before the
+    # secrets are added, or on a fork -- the build simply runs unsigned, exactly
+    # as it does today. Populate these in repo Settings -> Secrets to turn on
+    # Developer ID signing + notarization. See docs/macos-codesigning.md.
+    env:
+      MACOS_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
+      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
     steps:
       - uses: actions/checkout@v4
 
@@ -64,6 +76,39 @@ jobs:
       - name: Install app deps
         working-directory: app
         run: npm ci
+
+      # Imports the Developer ID Application cert into a throwaway keychain so
+      # codesign (via electron-forge's osxSign) can find the identity. Skipped
+      # entirely when the cert secret isn't set -> unsigned build.
+      - name: Import Apple signing certificate
+        if: matrix.platform == 'darwin' && env.MACOS_CERTIFICATE_BASE64 != ''
+        run: |
+          CERT_PATH="$RUNNER_TEMP/developer-id.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          echo "$MACOS_CERTIFICATE_BASE64" | base64 --decode > "$CERT_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$MACOS_CERTIFICATE_PASSWORD" \
+            -t cert -f pkcs12 -k "$KEYCHAIN_PATH" \
+            -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+          # Prepend our keychain to the user search list so codesign sees it.
+          security list-keychains -d user -s "$KEYCHAIN_PATH" \
+            $(security list-keychains -d user | sed 's/"//g')
+          rm -f "$CERT_PATH"
+
+      # Decodes the App Store Connect API key (.p8) to a file and exports its
+      # path; forge.config.ts reads APPLE_API_KEY_PATH to enable notarization.
+      # Skipped when the key secret isn't set -> signed-but-not-notarized.
+      - name: Stage notarization API key
+        if: matrix.platform == 'darwin' && env.APPLE_API_KEY_BASE64 != ''
+        run: |
+          KEY_PATH="$RUNNER_TEMP/asc-api-key.p8"
+          echo "$APPLE_API_KEY_BASE64" | base64 --decode > "$KEY_PATH"
+          echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Make Orbit (${{ matrix.platform }}-${{ matrix.arch }})
         working-directory: app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,8 +125,13 @@ jobs:
             app/out/make/**/*.rpm
           if-no-files-found: error
 
+  # Only attach a draft Release on a real tag (or a dispatch re-run against a
+  # tag). A workflow_dispatch on a branch is a build-only test run -- the signed
+  # installers land as workflow artifacts you can download from the run, with no
+  # draft Release and no npm publish, so notarization can be iterated cheaply.
   publish:
     needs: build
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: orbit-${{ matrix.platform }}-${{ matrix.arch }}
+          name: Orbit-${{ matrix.platform }}-${{ matrix.arch }}
           path: |
             app/out/make/**/*.dmg
             app/out/make/**/*.zip

--- a/app/build/entitlements.mac.plist
+++ b/app/build/entitlements.mac.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Hardened Runtime entitlements required to notarize an Electron app that
+    also ships its own native binaries (the staged node + uv, plus native
+    modules like koffi and better-sqlite3).
+
+    allow-jit / allow-unsigned-executable-memory: V8 compiles JS to machine
+    code at runtime and needs writable+executable memory.
+
+    disable-library-validation: lets the app load Mach-O binaries that aren't
+    signed by our own Team ID at the same time -- here, the bundled node/uv
+    executables and the .node native modules. Without it the brain subprocess
+    and native deps fail to load under Hardened Runtime.
+
+    allow-dyld-environment-variables: Electron relies on DYLD_* in some launch
+    paths; harmless to grant and avoids intermittent launch failures.
+  -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+</dict>
+</plist>

--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -238,6 +238,44 @@ async function stageUvBundle(platform: string, arch: string): Promise<void> {
   }
 }
 
+type PackagerOptions = NonNullable<ForgeConfig["packagerConfig"]>;
+
+// macOS code signing + notarization, gated entirely on the CI secrets being
+// present so local builds -- and any CI run before the secrets are added --
+// stay unsigned and keep working exactly as before. APPLE_SIGNING_IDENTITY
+// turns on Developer ID signing; the App Store Connect API key trio
+// (APPLE_API_KEY_PATH/_ID/_ISSUER) additionally turns on notarization. The
+// CI workflow imports the cert into a keychain and stages the .p8 before the
+// make step. See docs/macos-codesigning.md for the exact secrets + one-time
+// Apple-side setup.
+const ENTITLEMENTS_PLIST = path.join(APP_DIR, "build", "entitlements.mac.plist");
+
+const macCodesign: Partial<Pick<PackagerOptions, "osxSign" | "osxNotarize">> =
+  process.platform === "darwin" && process.env.APPLE_SIGNING_IDENTITY
+    ? {
+        osxSign: {
+          identity: process.env.APPLE_SIGNING_IDENTITY,
+          // Same Hardened Runtime entitlements for every Mach-O in the bundle
+          // (app + helpers + bundled node/uv + native modules).
+          optionsForFile: () => ({
+            entitlements: ENTITLEMENTS_PLIST,
+            hardenedRuntime: true,
+          }),
+        },
+        ...(process.env.APPLE_API_KEY_PATH &&
+        process.env.APPLE_API_KEY_ID &&
+        process.env.APPLE_API_ISSUER
+          ? {
+              osxNotarize: {
+                appleApiKey: process.env.APPLE_API_KEY_PATH,
+                appleApiKeyId: process.env.APPLE_API_KEY_ID,
+                appleApiIssuer: process.env.APPLE_API_ISSUER,
+              },
+            }
+          : {}),
+      }
+    : {};
+
 const config: ForgeConfig = {
   packagerConfig: {
     name: "Orbit",
@@ -249,6 +287,7 @@ const config: ForgeConfig = {
     // Contents/Resources/ in the packaged app. agent.ts resolves
     // process.resourcesPath/{loom,node,uv}/... at brain spawn time.
     extraResource: [LOOM_STAGE_DIR, NODE_STAGE_DIR, UV_STAGE_DIR],
+    ...macCodesign,
   },
   hooks: {
     // electron-forge passes (config, platform, arch) so cross-arch

--- a/docs/macos-codesigning.md
+++ b/docs/macos-codesigning.md
@@ -1,0 +1,86 @@
+# macOS code signing & notarization
+
+Orbit's macOS builds need to be signed with an Apple **Developer ID Application**
+certificate and **notarized** by Apple. Without that, anything a user downloads
+carries a quarantine flag and Gatekeeper refuses to open it -- on recent macOS
+(Sequoia) it shows the blunt "Orbit is damaged and can't be opened" dialog, and
+the old right-click -> Open bypass is gone. Notarization is the only path to a
+clean double-click install.
+
+The release workflow already has the signing scaffolding wired in
+(`.github/workflows/release.yml` + `app/forge.config.ts` + the entitlements at
+`app/build/entitlements.mac.plist`). It is **gated on secrets**: with none set,
+the build runs unsigned exactly as before. Add the secrets below and the next
+tagged release signs + notarizes + staples automatically. Nothing else changes.
+
+## What you need (one-time, Apple side)
+
+Requires an **Apple Developer Program** membership ($99/yr). Enroll as an
+individual for the fastest turnaround -- organization enrollment needs a D-U-N-S
+number and manual review. (If Galaxy already has a Developer team, join it and
+skip the fee.)
+
+### 1. Developer ID Application certificate
+
+1. In Keychain Access -> Certificate Assistant -> "Request a Certificate From a
+   Certificate Authority", save a CSR to disk.
+2. At developer.apple.com -> Certificates -> `+` -> **Developer ID Application**,
+   upload the CSR, download the resulting `.cer`, and double-click to install it
+   (it pairs with the private key in your login keychain).
+3. In Keychain Access, find "Developer ID Application: <name> (TEAMID)", export
+   **the cert + its private key** as a `.p12` and set an export password.
+4. Base64 it for the secret:
+   ```
+   base64 -i developer-id.p12 | pbcopy
+   ```
+
+The exact identity string ("Developer ID Application: <name> (TEAMID)") is what
+goes in `APPLE_SIGNING_IDENTITY`. The `TEAMID` is your 10-char Team ID.
+
+### 2. App Store Connect API key (for notarization)
+
+At appstoreconnect.apple.com -> Users and Access -> Integrations -> App Store
+Connect API -> `+`. Give it the **Developer** role. Download the `.p8` (you only
+get one chance), and note the **Key ID** and **Issuer ID**.
+
+```
+base64 -i AuthKey_XXXXXXXXXX.p8 | pbcopy
+```
+
+## GitHub repo secrets
+
+Settings -> Secrets and variables -> Actions. All six are required for a fully
+signed + notarized build; set only the first three to sign without notarizing.
+
+| Secret                       | Value                                       |
+| ---------------------------- | ------------------------------------------- |
+| `MACOS_CERTIFICATE_BASE64`   | base64 of the Developer ID `.p12`           |
+| `MACOS_CERTIFICATE_PASSWORD` | the `.p12` export password                  |
+| `APPLE_SIGNING_IDENTITY`     | `Developer ID Application: <name> (TEAMID)` |
+| `APPLE_API_KEY_BASE64`       | base64 of the App Store Connect `.p8`       |
+| `APPLE_API_KEY_ID`           | the API key's Key ID                        |
+| `APPLE_API_ISSUER`           | the API key's Issuer ID (UUID)              |
+
+## How the gating works
+
+- `APPLE_SIGNING_IDENTITY` present -> the build is Developer ID signed.
+- The API key trio additionally present -> the signed app is also notarized and
+  the ticket is stapled.
+- None present -> unsigned build (current behavior). Local `npm run make` is
+  always unsigned -- the gate checks `process.platform === "darwin"` plus the
+  env vars, neither of which a normal dev machine has.
+
+## Expect a little friction on the first signed build
+
+The app bundles its own native binaries (the staged `node` + `uv`, plus native
+modules like `koffi` and `better-sqlite3`). Notarization requires every Mach-O
+in the bundle to be signed with Hardened Runtime, which the entitlements file
+handles -- but bundled binaries are the usual spot where a first notarization
+attempt surfaces a missing-signature or entitlement error. Budget for an
+iteration round or two; the notary log (printed in the failed run) names the
+exact offending file.
+
+Note also that electron-forge notarizes and staples the **`.app`**, then wraps
+it in the `.dmg`/`.zip`. That's enough for the drag-to-Applications flow (the
+stapled app opens offline). Stapling the `.dmg` itself is a possible follow-up
+if we want the disk image to verify before it's even mounted.


### PR DESCRIPTION
Wires up Developer ID signing + notarization for the Orbit macOS builds, plus a small artifact-naming fix. Opening as a draft because the signing path can't actually run until the Apple Developer secrets are added to the repo -- the membership is still processing.

What's here:

- `app/forge.config.ts` gets a `macCodesign` block that enables `osxSign` when `APPLE_SIGNING_IDENTITY` is set, and `osxNotarize` when the App Store Connect API key trio is also present. Both are gated on the darwin platform plus the env vars, so local builds and any CI run without the secrets stay unsigned exactly as they do today -- a no-op until the secrets land.
- `app/build/entitlements.mac.plist`: Hardened Runtime entitlements for V8's JIT and for the bundled `node`/`uv` + native modules (koffi, better-sqlite3) to load under notarization.
- `.github/workflows/release.yml` imports the Developer ID cert into a throwaway keychain and stages the `.p8` ahead of the make step; both steps skip themselves when the secrets are empty.
- `docs/macos-codesigning.md` documents the six required secrets and the one-time Apple-side cert/key setup.
- Separately, capitalizes the GitHub Actions artifact name (`orbit-` -> `Orbit-`) so builds pulled from the Actions tab match the `Orbit.app`/DMG naming.

Before this leaves draft: add the six secrets (see the doc), then cut a signed test build. Bundled native binaries are the usual spot a first notarization attempt trips on, so expect an iteration round or two.

Validated locally: app `tsc --noEmit` clean, workflow YAML parses.
