### PR TITLE
fix: macOS notarization -- strip comment from entitlements plist

### DIFF
--- a/app/build/entitlements.mac.plist
+++ b/app/build/entitlements.mac.plist
@@ -2,22 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <!--
-    Hardened Runtime entitlements required to notarize an Electron app that
-    also ships its own native binaries (the staged node + uv, plus native
-    modules like koffi and better-sqlite3).
-
-    allow-jit / allow-unsigned-executable-memory: V8 compiles JS to machine
-    code at runtime and needs writable+executable memory.
-
-    disable-library-validation: lets the app load Mach-O binaries that aren't
-    signed by our own Team ID at the same time -- here, the bundled node/uv
-    executables and the .node native modules. Without it the brain subprocess
-    and native deps fail to load under Hardened Runtime.
-
-    allow-dyld-environment-variables: Electron relies on DYLD_* in some launch
-    paths; harmless to grant and avoids intermittent launch failures.
-  -->
   <key>com.apple.security.cs.allow-jit</key>
   <true/>
   <key>com.apple.security.cs.allow-unsigned-executable-memory</key>

--- a/docs/macos-codesigning.md
+++ b/docs/macos-codesigning.md
@@ -84,3 +84,22 @@ Note also that electron-forge notarizes and staples the **`.app`**, then wraps
 it in the `.dmg`/`.zip`. That's enough for the drag-to-Applications flow (the
 stapled app opens offline). Stapling the `.dmg` itself is a possible follow-up
 if we want the disk image to verify before it's even mounted.
+
+## The entitlements file
+
+`app/build/entitlements.mac.plist` grants the Hardened Runtime exceptions an
+Electron app that ships its own binaries needs:
+
+- `allow-jit` + `allow-unsigned-executable-memory` -- V8 JITs JS to machine code
+  and needs writable+executable memory.
+- `disable-library-validation` -- lets the bundle load Mach-O not signed by our
+  Team ID: the staged `node`/`uv` and the `.node` native modules (koffi,
+  better-sqlite3). Without it the brain subprocess and native deps fail to load.
+- `allow-dyld-environment-variables` -- Electron relies on `DYLD_*` in some
+  launch paths.
+
+**Do not put XML comments inside this plist.** codesign's entitlements parser
+(`AMFIUnserializeXML`) rejects them with `syntax error near line N`, and because
+electron-packager signs with `continueOnError`, the failure is swallowed as a
+warning and the app silently ships **adhoc** (which notarization then rejects).
+Keep the rationale here, not in the file.


### PR DESCRIPTION
The macOS signing scaffolding from #136 silently shipped an **adhoc** app, which notarization rejected. Root cause: `app/build/entitlements.mac.plist` had an XML comment block, and codesign's entitlements parser (`AMFIUnserializeXML`) rejects comments -- it failed with `syntax error near line 14`. Because electron-packager signs with `continueOnError`, that failure was swallowed as a warning, the app stayed adhoc, and the notarize pre-check then bailed with `code has no resources... Signature=adhoc`.

Fix is just stripping the comment to a clean plist. The entitlement rationale + this gotcha now live in `docs/macos-codesigning.md` instead of the file.

Verified end-to-end via a build-only `workflow_dispatch` on this branch (run 26612767424): the macOS job produced a Developer ID-signed, notarized, stapled `Orbit.app`. On a clean machine:

- `codesign -dvv`: `Authority=Developer ID Application: ... → Apple Root CA`, `flags=0x10000(runtime)`
- `codesign --verify --deep --strict`: valid on disk, satisfies its Designated Requirement
- `spctl -a -vvv -t exec`: **accepted, source=Notarized Developer ID**
- `stapler validate`: ticket stapled (opens offline)

The npm publish + draft-release jobs were correctly skipped (branch dispatch), so this touched neither npm nor releases.
