### PR TITLE
build: drop pi-coding-agent examples/ from the Orbit bundle

### DIFF
--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -81,6 +81,16 @@ function pruneLoomNodeModules(platform: string, arch: string): void {
       }
     }
   }
+
+  // pi-coding-agent bundles an examples/ tree (demo extensions, including a
+  // DOOM WASM overlay) that Loom never loads at runtime -- ~1.2MB of dead
+  // weight that also drags out codesign, since notarization gives every file
+  // an individual --timestamp round-trip. Drop it. (force: true no-ops if the
+  // path is ever absent.)
+  fs.rmSync(
+    path.join(LOOM_STAGE_DIR, "node_modules", "@earendil-works", "pi-coding-agent", "examples"),
+    { recursive: true, force: true },
+  );
 }
 
 function findKoffiBuildDirs(root: string): string[] {


### PR DESCRIPTION
Drops pi-coding-agent's `examples/` tree (a DOOM WASM overlay demo + other example extensions) from the staged Orbit bundle. It's never loaded by Loom at runtime -- ~1.2MB of dead weight that also slowed codesign, since notarization timestamps every file individually.

Pruned in `pruneLoomNodeModules`, right next to the existing koffi foreign-arch trim. Verified locally: an unsigned `electron-forge package` builds clean and the `examples/` tree is absent from the resulting `Orbit.app`. Can't affect signing validity (strictly fewer files); #137 already proved the signed + notarized path end-to-end.
