### PR TITLE
docs: update install instructions for the signed v0.1.1 release

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,24 +1,24 @@
 # Installing Orbit
 
-Orbit is in alpha. Installers ship from the
+Installers ship from the
 [Releases page](https://github.com/galaxyproject/loom/releases) — pick the
-latest tag and download the artifact for your machine.
+latest release and download the artifact for your machine.
 
-Linux installers (`.deb` / `.rpm`) are included starting with the first
-alpha release. Windows is not yet supported natively — see the
-[Windows (via WSL2)](#windows-via-wsl2) section below.
+The macOS build is Developer ID signed and notarized by Apple, so it opens
+with a normal double-click. Linux ships `.deb` / `.rpm` / `.zip`. Windows runs
+via WSL2 — see the [Windows (via WSL2)](#windows-via-wsl2) section below.
 
 ## macOS
 
-Two builds are published per release:
+The macOS installer is built for Apple Silicon:
 
 | File                        | When to pick it                                                   |
 | --------------------------- | ----------------------------------------------------------------- |
 | `Orbit-<version>-arm64.dmg` | Apple Silicon Macs (M1/M2/M3/M4) — anything from late 2020 onward |
-| `Orbit-<version>-x64.dmg`   | Intel Macs                                                        |
 
-Not sure which? Open the Apple menu → About This Mac. "Chip: Apple M..." → arm64.
-"Processor: Intel..." → x64.
+Intel Macs aren't packaged yet — use the developer install (build from source)
+in the [README](README.md#developer-install-build-from-source). Not sure which
+you have? Apple menu → About This Mac: "Chip: Apple M..." is Apple Silicon.
 
 ### Install
 
@@ -26,29 +26,11 @@ Not sure which? Open the Apple menu → About This Mac. "Chip: Apple M..." → a
 2. Double-click the DMG, drag **Orbit** to the **Applications** folder.
 3. Eject the DMG (drag its icon to the trash).
 
-### First launch (Gatekeeper)
+### First launch
 
-The current alpha builds are **unsigned** — Apple's Gatekeeper will block
-the first launch:
-
-> "Orbit can't be opened because Apple cannot check it for malicious software."
-
-To run it the first time:
-
-1. Open the **Applications** folder in Finder.
-2. **Right-click** (or Control-click) **Orbit** → choose **Open**.
-3. The dialog now offers an **Open** button — click it.
-
-macOS remembers the decision. Subsequent launches work via Spotlight,
-Launchpad, or a double-click, with no further prompts.
-
-If you don't see the Open option in the right-click menu, run:
-
-```bash
-xattr -dr com.apple.quarantine /Applications/Orbit.app
-```
-
-This removes the quarantine attribute Gatekeeper sets on downloads.
+The build is **Developer ID signed and notarized by Apple**, so it opens like
+any other app — double-click **Orbit** in Applications. No Gatekeeper warning,
+no right-click dance, no Terminal commands.
 
 ### Updates
 
@@ -57,8 +39,8 @@ available, a banner appears at the top of the window with a link to the
 Releases page. Click the link, download the new DMG, and replace the old
 app in Applications (drag-and-drop will prompt you to overwrite).
 
-There is no auto-installer — unsigned apps can't be patched by macOS's
-update mechanism. Manual download is one click after the banner appears.
+Auto-update isn't wired up yet, so the download is manual — one click after
+the banner appears.
 
 ### Uninstall
 

--- a/README.md
+++ b/README.md
@@ -223,11 +223,11 @@ Three paths, depending on what you want.
 
 ### Desktop app (Orbit)
 
-Orbit ships as a native installer that bundles its own Node runtime, `uv`, and Loom -- no separate prerequisites. macOS DMGs (arm64 + x64) are built and attached to a draft Release on every `v*` tag push; Linux and Windows installers are next. See [INSTALL.md](INSTALL.md) for the macOS install steps and the Gatekeeper workaround (alpha builds are unsigned). See [RELEASING.md](RELEASING.md) for how a release is cut. If your platform isn't packaged yet, use the developer install below.
+Orbit ships as a native installer that bundles its own Node runtime, `uv`, and Loom -- no separate prerequisites. The macOS (Apple Silicon) build is Developer ID signed + notarized, so it opens with a normal double-click; Linux ships `.deb`/`.rpm`/`.zip`. Both are attached to each [release](https://github.com/galaxyproject/loom/releases). Windows runs via WSL2. See [INSTALL.md](INSTALL.md) for per-platform steps and [RELEASING.md](RELEASING.md) for how a release is cut. Intel Macs and other unpackaged targets can use the developer install below.
 
 ### Loom CLI from npm
 
-Run the brain on the command line without Orbit. Requires Node 20+ and (for Galaxy MCP) [uv](https://docs.astral.sh/uv/).
+Run the brain on the command line without Orbit. Requires Node 22+ and (for Galaxy MCP) [uv](https://docs.astral.sh/uv/).
 
 ```bash
 npm install -g @galaxyproject/loom
@@ -317,6 +317,7 @@ cd ~/loom/app && npm start
 ```
 
 > **If the script fails with `Could not get lock /var/lib/dpkg/lock-frontend`**, Ubuntu's automatic updater is running in the background. Stop it first, then re-run:
+>
 > ```bash
 > sudo systemctl stop unattended-upgrades
 > curl -fsSL https://raw.githubusercontent.com/galaxyproject/loom/main/scripts/setup-wsl.sh | bash


### PR DESCRIPTION
Brings the install docs in line with the `v0.1.1` release, which ships **signed + notarized** macOS installers.

- **INSTALL.md:** removed the "unsigned / Gatekeeper workaround / `xattr`" section -- the app now opens with a normal double-click. macOS table is arm64-only (Intel isn't packaged; pointed at the dev install). Dropped the "alpha" framing and the "Windows not supported" / "Linux next" lines (Linux deb/rpm/zip ship; Windows is WSL2). Reframed the no-auto-update note (it's not about signing anymore).
- **README.md:** rewrote the Desktop-app paragraph (signed + notarized, public release, arm64 mac + Linux, Windows via WSL2) and bumped the CLI's stated Node requirement from 20+ to 22+ to match `engines`.

No `@alpha` references existed in the README, so nothing to change there.
