### PR TITLE
Add a Loom <-> Galaxy-flavored-markdown adapter for Pages sync

### DIFF
--- a/extensions/loom/galaxy-markdown-adapter.ts
+++ b/extensions/loom/galaxy-markdown-adapter.ts
@@ -11,9 +11,11 @@
  * of quotes and newlines, so the carrier is always one well-formed line.
  *
  * Phase 2 adds a visible ` ```galaxy ` directive alongside the carrier; pull
- * strips those directives (Loom owns the projection under the loom-canonical
- * model), which is why galaxyMarkdownToLoom removes ```galaxy blocks here even
- * though Phase 1 never emits them -- it keeps pull forward-compatible.
+ * strips the directives Loom emitted (Loom owns the projection under the
+ * loom-canonical model and regenerates them each push). A Loom directive always
+ * sits immediately above a carrier with no blank line between, so pull strips
+ * only ```galaxy blocks in that position -- a ```galaxy fence a human wrote (or
+ * a co-author added on the Galaxy side) survives the round trip.
  */
 
 import { galaxyGet } from "./galaxy-api";
@@ -57,16 +59,29 @@ export function loomToGalaxyMarkdown(body: string): string {
   return out.join("\n");
 }
 
-/** Pull: carriers -> original loom-invocation fences; strip any ```galaxy blocks. */
+/** Pull: strip the ```galaxy directives Loom emitted, then carriers -> original
+ *  loom-invocation fences. Stripping runs first, while carriers are still single
+ *  lines, so the "directive sits directly above a carrier" check is exact. */
 export function galaxyMarkdownToLoom(body: string): string {
-  const restored = body.replace(CARRIER_RE, (_m, b64: string) =>
+  const withoutLoomDirectives = stripLoomGalaxyDirectiveBlocks(body);
+  return withoutLoomDirectives.replace(CARRIER_RE, (_m, b64: string) =>
     Buffer.from(b64, "base64").toString("utf8"),
   );
-  return stripGalaxyDirectiveBlocks(restored);
 }
 
-/** Remove ```galaxy ... ``` fenced blocks (Loom-emitted projection, regenerated each push). */
-function stripGalaxyDirectiveBlocks(body: string): string {
+// Single-line carrier matcher. CARRIER_RE is global/multiline (stateful via
+// lastIndex), so it's unsafe for a one-off .test(); this is the per-line form.
+const CARRIER_LINE_RE = /^\[loom-invocation:v1\]: #loom "[A-Za-z0-9+/=]+"$/;
+
+/**
+ * Remove only the ```galaxy directive blocks Loom itself emitted.
+ * loomToGalaxyMarkdownRich always writes the directive immediately above the
+ * invocation's carrier with no blank line between, so a ```galaxy block is
+ * Loom's iff the line right after its closing fence is a carrier. Every other
+ * ```galaxy block was authored by a human and is preserved verbatim -- stripping
+ * those unconditionally was silent data loss on pull.
+ */
+function stripLoomGalaxyDirectiveBlocks(body: string): string {
   const lines = body.split("\n");
   const out: string[] = [];
   let i = 0;
@@ -74,11 +89,15 @@ function stripGalaxyDirectiveBlocks(body: string): string {
     if (lines[i].trim() === GALAXY_FENCE_OPEN) {
       let end = i + 1;
       while (end < lines.length && lines[end].trim() !== FENCE_CLOSE) end++;
-      i = end + 1;
-    } else {
-      out.push(lines[i]);
-      i++;
+      // `end` is the closing fence (or EOF). Drop the block only when Loom's
+      // carrier immediately follows it; otherwise fall through and keep it.
+      if (end + 1 < lines.length && CARRIER_LINE_RE.test(lines[end + 1])) {
+        i = end + 1;
+        continue;
+      }
     }
+    out.push(lines[i]);
+    i++;
   }
   return out.join("\n");
 }

--- a/extensions/loom/galaxy-markdown-adapter.ts
+++ b/extensions/loom/galaxy-markdown-adapter.ts
@@ -1,0 +1,67 @@
+/**
+ * Loom <-> Galaxy-flavored-markdown content adapter. notebook.md is canonical.
+ *
+ * Push replaces each `loom-invocation` fenced block with a hidden HTML-comment
+ * carrier holding the literal block, base64-encoded. Galaxy preserves both the
+ * markdown body and HTML comments byte-for-byte (verified against 26.1.rc1), so
+ * pull restores the original fences exactly. base64 keeps the payload free of
+ * `-->` and newlines, so the comment is always single-line and well-formed.
+ *
+ * Phase 2 adds a visible ` ```galaxy ` directive alongside the carrier; pull
+ * strips those directives (Loom owns the projection under the loom-canonical
+ * model), which is why galaxyMarkdownToLoom removes ```galaxy blocks here even
+ * though Phase 1 never emits them -- it keeps pull forward-compatible.
+ */
+
+const INV_FENCE_OPEN = "```loom-invocation";
+const FENCE_CLOSE = "```";
+const GALAXY_FENCE_OPEN = "```galaxy";
+
+const CARRIER_RE = /<!-- loom-invocation:v1 ([A-Za-z0-9+/=]+) -->/g;
+
+/** Push: loom-invocation fences -> hidden base64 carriers. Narrative untouched. */
+export function loomToGalaxyMarkdown(body: string): string {
+  const lines = body.split("\n");
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (lines[i].trim() === INV_FENCE_OPEN) {
+      let end = i + 1;
+      while (end < lines.length && lines[end].trim() !== FENCE_CLOSE) end++;
+      const block = lines.slice(i, end + 1).join("\n");
+      const b64 = Buffer.from(block, "utf8").toString("base64");
+      out.push(`<!-- loom-invocation:v1 ${b64} -->`);
+      i = end + 1;
+    } else {
+      out.push(lines[i]);
+      i++;
+    }
+  }
+  return out.join("\n");
+}
+
+/** Pull: carriers -> original loom-invocation fences; strip any ```galaxy blocks. */
+export function galaxyMarkdownToLoom(body: string): string {
+  const restored = body.replace(CARRIER_RE, (_m, b64: string) =>
+    Buffer.from(b64, "base64").toString("utf8"),
+  );
+  return stripGalaxyDirectiveBlocks(restored);
+}
+
+/** Remove ```galaxy ... ``` fenced blocks (Loom-emitted projection, regenerated each push). */
+function stripGalaxyDirectiveBlocks(body: string): string {
+  const lines = body.split("\n");
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (lines[i].trim() === GALAXY_FENCE_OPEN) {
+      let end = i + 1;
+      while (end < lines.length && lines[end].trim() !== FENCE_CLOSE) end++;
+      i = end + 1;
+    } else {
+      out.push(lines[i]);
+      i++;
+    }
+  }
+  return out.join("\n");
+}

--- a/extensions/loom/galaxy-markdown-adapter.ts
+++ b/extensions/loom/galaxy-markdown-adapter.ts
@@ -13,6 +13,8 @@
  * though Phase 1 never emits them -- it keeps pull forward-compatible.
  */
 
+import { galaxyGet } from "./galaxy-api";
+
 const INV_FENCE_OPEN = "```loom-invocation";
 const FENCE_CLOSE = "```";
 const GALAXY_FENCE_OPEN = "```galaxy";
@@ -57,6 +59,66 @@ function stripGalaxyDirectiveBlocks(body: string): string {
     if (lines[i].trim() === GALAXY_FENCE_OPEN) {
       let end = i + 1;
       while (end < lines.length && lines[end].trim() !== FENCE_CLOSE) end++;
+      i = end + 1;
+    } else {
+      out.push(lines[i]);
+      i++;
+    }
+  }
+  return out.join("\n");
+}
+
+/** Decides whether an invocation id is renderable on the connected server. */
+export interface InvocationValidator {
+  isValid(invocationId: string): Promise<boolean>;
+}
+
+/** Real validator: a GET that resolves means the id decodes and exists. */
+export const galaxyInvocationValidator: InvocationValidator = {
+  async isValid(invocationId: string): Promise<boolean> {
+    try {
+      await galaxyGet(`/invocations/${invocationId}`);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+};
+
+const INV_ID_RE = /^invocation_id:\s*(.+)$/;
+
+/**
+ * Push with rich rendering: each loom-invocation block becomes a hidden carrier
+ * AND, when its id validates, a visible `invocation_outputs` directive. The
+ * directive is gated because Galaxy 400s the whole page on an undecodable id.
+ */
+export async function loomToGalaxyMarkdownRich(
+  body: string,
+  validator: InvocationValidator,
+): Promise<string> {
+  const lines = body.split("\n");
+  const out: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    if (lines[i].trim() === INV_FENCE_OPEN) {
+      let end = i + 1;
+      let invId: string | null = null;
+      while (end < lines.length && lines[end].trim() !== FENCE_CLOSE) {
+        const m = lines[end].match(INV_ID_RE);
+        if (m) invId = m[1].trim();
+        end++;
+      }
+      const block = lines.slice(i, end + 1).join("\n");
+      const carrier = `<!-- loom-invocation:v1 ${Buffer.from(block, "utf8").toString("base64")} -->`;
+      // Emit the directive immediately before the carrier with NO extra blank
+      // line, so stripping the 3 fence lines on pull restores the carrier in
+      // the block's exact original position -- keeping the round trip identical.
+      if (invId && (await validator.isValid(invId))) {
+        out.push(GALAXY_FENCE_OPEN);
+        out.push(`invocation_outputs(invocation_id=${invId})`);
+        out.push(FENCE_CLOSE);
+      }
+      out.push(carrier);
       i = end + 1;
     } else {
       out.push(lines[i]);

--- a/extensions/loom/galaxy-markdown-adapter.ts
+++ b/extensions/loom/galaxy-markdown-adapter.ts
@@ -19,9 +19,18 @@ const INV_FENCE_OPEN = "```loom-invocation";
 const FENCE_CLOSE = "```";
 const GALAXY_FENCE_OPEN = "```galaxy";
 
-const CARRIER_RE = /<!-- loom-invocation:v1 ([A-Za-z0-9+/=]+) -->/g;
+// Anchored to a whole line (`m` flag): carriers are always emitted as their own
+// line, so this never decodes carrier-like syntax that appears inline in prose
+// (e.g. a notebook documenting Loom's own format). The `g` flag is required to
+// replace every carrier, not just the first.
+const CARRIER_RE = /^<!-- loom-invocation:v1 ([A-Za-z0-9+/=]+) -->$/gm;
 
-/** Push: loom-invocation fences -> hidden base64 carriers. Narrative untouched. */
+/**
+ * Push (pure, no network): loom-invocation fences -> hidden base64 carriers,
+ * narrative untouched. The sync helper pushes via loomToGalaxyMarkdownRich
+ * (which also emits validated directives); this plain form is kept for
+ * non-network callers and the round-trip tests.
+ */
 export function loomToGalaxyMarkdown(body: string): string {
   const lines = body.split("\n");
   const out: string[] = [];

--- a/extensions/loom/galaxy-markdown-adapter.ts
+++ b/extensions/loom/galaxy-markdown-adapter.ts
@@ -1,11 +1,14 @@
 /**
  * Loom <-> Galaxy-flavored-markdown content adapter. notebook.md is canonical.
  *
- * Push replaces each `loom-invocation` fenced block with a hidden HTML-comment
- * carrier holding the literal block, base64-encoded. Galaxy preserves both the
- * markdown body and HTML comments byte-for-byte (verified against 26.1.rc1), so
- * pull restores the original fences exactly. base64 keeps the payload free of
- * `-->` and newlines, so the comment is always single-line and well-formed.
+ * Push replaces each `loom-invocation` fenced block with a hidden carrier holding
+ * the literal block, base64-encoded. The carrier is a CommonMark link-reference
+ * definition (`[loom-invocation:v1]: #loom "<base64>"`): it renders to nothing and
+ * is preserved byte-for-byte on store, so pull restores the original fences exactly.
+ * (HTML comments do NOT work here -- Galaxy's page renderer escapes them to visible
+ * text rather than hiding them, verified live against 26.1.rc1. A reference
+ * definition is pure markdown, so it stays invisible.) base64 keeps the payload free
+ * of quotes and newlines, so the carrier is always one well-formed line.
  *
  * Phase 2 adds a visible ` ```galaxy ` directive alongside the carrier; pull
  * strips those directives (Loom owns the projection under the loom-canonical
@@ -19,11 +22,15 @@ const INV_FENCE_OPEN = "```loom-invocation";
 const FENCE_CLOSE = "```";
 const GALAXY_FENCE_OPEN = "```galaxy";
 
-// Anchored to a whole line (`m` flag): carriers are always emitted as their own
-// line, so this never decodes carrier-like syntax that appears inline in prose
-// (e.g. a notebook documenting Loom's own format). The `g` flag is required to
-// replace every carrier, not just the first.
-const CARRIER_RE = /^<!-- loom-invocation:v1 ([A-Za-z0-9+/=]+) -->$/gm;
+// Anchored to a whole line (`m` flag): the carrier is always its own line, so
+// this never decodes carrier-like syntax that appears inline in prose (e.g. a
+// notebook documenting Loom's own format). The `g` flag replaces every carrier.
+const CARRIER_RE = /^\[loom-invocation:v1\]: #loom "([A-Za-z0-9+/=]+)"$/gm;
+
+/** base64 a loom-invocation block into a (render-invisible) link-reference carrier. */
+function encodeCarrier(block: string): string {
+  return `[loom-invocation:v1]: #loom "${Buffer.from(block, "utf8").toString("base64")}"`;
+}
 
 /**
  * Push (pure, no network): loom-invocation fences -> hidden base64 carriers,
@@ -40,8 +47,7 @@ export function loomToGalaxyMarkdown(body: string): string {
       let end = i + 1;
       while (end < lines.length && lines[end].trim() !== FENCE_CLOSE) end++;
       const block = lines.slice(i, end + 1).join("\n");
-      const b64 = Buffer.from(block, "utf8").toString("base64");
-      out.push(`<!-- loom-invocation:v1 ${b64} -->`);
+      out.push(encodeCarrier(block));
       i = end + 1;
     } else {
       out.push(lines[i]);
@@ -124,7 +130,7 @@ export async function loomToGalaxyMarkdownRich(
         end++;
       }
       const block = lines.slice(i, end + 1).join("\n");
-      const carrier = `<!-- loom-invocation:v1 ${Buffer.from(block, "utf8").toString("base64")} -->`;
+      const carrier = encodeCarrier(block);
       // Emit the directive immediately before the carrier with NO extra blank
       // line, so stripping the 3 fence lines on pull restores the carrier in
       // the block's exact original position -- keeping the round trip identical.

--- a/extensions/loom/galaxy-markdown-adapter.ts
+++ b/extensions/loom/galaxy-markdown-adapter.ts
@@ -27,7 +27,9 @@ const GALAXY_FENCE_OPEN = "```galaxy";
 // Anchored to a whole line (`m` flag): the carrier is always its own line, so
 // this never decodes carrier-like syntax that appears inline in prose (e.g. a
 // notebook documenting Loom's own format). The `g` flag replaces every carrier.
-const CARRIER_RE = /^\[loom-invocation:v1\]: #loom "([A-Za-z0-9+/=]+)"$/gm;
+// Tolerate trailing horizontal whitespace -- a storage round trip can append a
+// space, and an unmatched carrier silently loses the invocation on pull.
+const CARRIER_RE = /^\[loom-invocation:v1\]: #loom "([A-Za-z0-9+/=]+)"[ \t]*$/gm;
 
 /** base64 a loom-invocation block into a (render-invisible) link-reference carrier. */
 function encodeCarrier(block: string): string {
@@ -71,7 +73,9 @@ export function galaxyMarkdownToLoom(body: string): string {
 
 // Single-line carrier matcher. CARRIER_RE is global/multiline (stateful via
 // lastIndex), so it's unsafe for a one-off .test(); this is the per-line form.
-const CARRIER_LINE_RE = /^\[loom-invocation:v1\]: #loom "[A-Za-z0-9+/=]+"$/;
+// Same trailing-whitespace tolerance as CARRIER_RE so the strip heuristic and
+// the decoder agree on what counts as a carrier line.
+const CARRIER_LINE_RE = /^\[loom-invocation:v1\]: #loom "[A-Za-z0-9+/=]+"[ \t]*$/;
 
 /**
  * Remove only the ```galaxy directive blocks Loom itself emitted.
@@ -108,17 +112,30 @@ export interface InvocationValidator {
 }
 
 /**
- * Real validator: a GET that resolves means the id decodes and exists. It
- * queries the ambient configured server (galaxyGet reads GALAXY_URL), not a
- * block's own galaxy_server_url -- so an id from a different server validates
- * as false and its directive is safely omitted, which is correct under the
- * single-server push model.
+ * Real validator: a GET that resolves AND echoes back the same id means the id
+ * decodes and exists on the connected server (galaxyGet reads GALAXY_URL, not a
+ * block's own galaxy_server_url -- so an id from a different server validates as
+ * false and its directive is safely omitted, correct under the single-server
+ * push model).
+ *
+ * Two guards stop a malformed id from smuggling a directive onto the page:
+ * encoded ids are hex, so anything else is rejected before any network call (a
+ * value like "../histories" would otherwise dot-segment-normalize to a real
+ * endpoint, return 200, and pass); and the response id must equal the requested
+ * id, so a 200 for some *other* resource doesn't count. Both matter because
+ * pulled page content is untrusted -- a hostile carrier must not 400 the next
+ * push.
  */
+const ENCODED_ID_RE = /^[0-9a-fA-F]+$/;
+
 export const galaxyInvocationValidator: InvocationValidator = {
   async isValid(invocationId: string): Promise<boolean> {
+    if (!ENCODED_ID_RE.test(invocationId)) return false;
     try {
-      await galaxyGet(`/invocations/${invocationId}`);
-      return true;
+      const inv = await galaxyGet<{ id?: string }>(
+        `/invocations/${encodeURIComponent(invocationId)}`,
+      );
+      return inv?.id === invocationId;
     } catch {
       return false;
     }

--- a/extensions/loom/galaxy-markdown-adapter.ts
+++ b/extensions/loom/galaxy-markdown-adapter.ts
@@ -73,7 +73,13 @@ export interface InvocationValidator {
   isValid(invocationId: string): Promise<boolean>;
 }
 
-/** Real validator: a GET that resolves means the id decodes and exists. */
+/**
+ * Real validator: a GET that resolves means the id decodes and exists. It
+ * queries the ambient configured server (galaxyGet reads GALAXY_URL), not a
+ * block's own galaxy_server_url -- so an id from a different server validates
+ * as false and its directive is safely omitted, which is correct under the
+ * single-server push model.
+ */
 export const galaxyInvocationValidator: InvocationValidator = {
   async isValid(invocationId: string): Promise<boolean> {
     try {

--- a/extensions/loom/galaxy-pages-sync.ts
+++ b/extensions/loom/galaxy-pages-sync.ts
@@ -12,7 +12,11 @@ import { getNotebookPath } from "./state";
 import { getGalaxyConfig, type GalaxyConfig } from "./galaxy-api";
 import { readNotebook, writeNotebook, withNotebookLock } from "./notebook-writer";
 import { createPage, updatePage, getPage } from "./galaxy-pages-api";
-import { loomToGalaxyMarkdown, galaxyMarkdownToLoom } from "./galaxy-markdown-adapter";
+import {
+  loomToGalaxyMarkdownRich,
+  galaxyInvocationValidator,
+  galaxyMarkdownToLoom,
+} from "./galaxy-markdown-adapter";
 import {
   findGalaxyPageBlocks,
   upsertGalaxyPageBlock,
@@ -243,7 +247,7 @@ export async function pushNotebookToGalaxy(opts: PushOptions = {}): Promise<Push
         );
       }
       const updated = await updatePage(existing.pageId, {
-        content: loomToGalaxyMarkdown(stripped),
+        content: await loomToGalaxyMarkdownRich(stripped, galaxyInvocationValidator),
         content_format: "markdown",
         edit_source: "agent",
       });
@@ -269,7 +273,7 @@ export async function pushNotebookToGalaxy(opts: PushOptions = {}): Promise<Push
       title: opts.title ?? "Untitled notebook",
       slug: opts.slug,
       annotation: opts.annotation,
-      content: loomToGalaxyMarkdown(stripped),
+      content: await loomToGalaxyMarkdownRich(stripped, galaxyInvocationValidator),
       content_format: "markdown",
     });
     const binding: GalaxyPageBindingYaml = {

--- a/extensions/loom/galaxy-pages-sync.ts
+++ b/extensions/loom/galaxy-pages-sync.ts
@@ -12,6 +12,7 @@ import { getNotebookPath } from "./state";
 import { getGalaxyConfig, type GalaxyConfig } from "./galaxy-api";
 import { readNotebook, writeNotebook, withNotebookLock } from "./notebook-writer";
 import { createPage, updatePage, getPage } from "./galaxy-pages-api";
+import { loomToGalaxyMarkdown, galaxyMarkdownToLoom } from "./galaxy-markdown-adapter";
 import {
   findGalaxyPageBlocks,
   upsertGalaxyPageBlock,
@@ -168,7 +169,7 @@ export async function resumeGalaxyPage(
       );
     }
 
-    const remoteBody = wrapUntrustedRemoteBody(page.content ?? "");
+    const remoteBody = wrapUntrustedRemoteBody(galaxyMarkdownToLoom(page.content ?? ""));
     const binding: GalaxyPageBindingYaml = {
       pageId: page.id,
       pageSlug: page.slug ?? null,
@@ -211,7 +212,7 @@ export async function pullNotebookFromGalaxy(): Promise<PullResult> {
       );
     }
     const page = await getPage(existing.pageId);
-    const remoteBody = wrapUntrustedRemoteBody(page.content ?? "");
+    const remoteBody = wrapUntrustedRemoteBody(galaxyMarkdownToLoom(page.content ?? ""));
     const refreshed: GalaxyPageBindingYaml = {
       ...existing,
       pageSlug: page.slug ?? existing.pageSlug,
@@ -242,7 +243,7 @@ export async function pushNotebookToGalaxy(opts: PushOptions = {}): Promise<Push
         );
       }
       const updated = await updatePage(existing.pageId, {
-        content: stripped,
+        content: loomToGalaxyMarkdown(stripped),
         content_format: "markdown",
         edit_source: "agent",
       });
@@ -268,7 +269,7 @@ export async function pushNotebookToGalaxy(opts: PushOptions = {}): Promise<Push
       title: opts.title ?? "Untitled notebook",
       slug: opts.slug,
       annotation: opts.annotation,
-      content: stripped,
+      content: loomToGalaxyMarkdown(stripped),
       content_format: "markdown",
     });
     const binding: GalaxyPageBindingYaml = {

--- a/extensions/loom/galaxy-pages-sync.ts
+++ b/extensions/loom/galaxy-pages-sync.ts
@@ -234,8 +234,12 @@ export async function pushNotebookToGalaxy(opts: PushOptions = {}): Promise<Push
   return withNotebookLock(nbPath, async () => {
     const content = await readNotebook(nbPath);
     const existing = findGalaxyPageBlocks(content)[0];
-    // Strip both the binding block and any untrusted-content markers so the
-    // body sent to Galaxy (and re-persisted) is clean -- no marker round-trip.
+    // `stripped` is the canonical local notebook with the binding block and any
+    // untrusted-content markers removed, so the body sent to Galaxy (and
+    // re-persisted locally) is clean -- no marker round-trip. Push projects it to
+    // Galaxy via loomToGalaxyMarkdownRich; the local writeNotebook calls below
+    // persist `stripped` as-is, so notebook.md never holds the projected
+    // (carrier/directive) form.
     const stripped = stripUntrustedMarkers(stripGalaxyPageBlocks(content));
 
     if (existing) {

--- a/tests/galaxy-markdown-adapter.test.ts
+++ b/tests/galaxy-markdown-adapter.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import {
+  loomToGalaxyMarkdown,
+  galaxyMarkdownToLoom,
+} from "../extensions/loom/galaxy-markdown-adapter";
+
+const NOTEBOOK = [
+  "# chrM Variant Calling",
+  "",
+  "## Plan A: chrM Variant Calling [hybrid]",
+  "",
+  "- [x] {#plan-a-step-2} BWA alignment",
+  "",
+  "```loom-invocation",
+  "invocation_id: abc123",
+  "galaxy_server_url: https://test.galaxyproject.org",
+  "notebook_anchor: plan-a-step-2",
+  "label: BWA alignment",
+  "submitted_at: 2026-05-29T12:00:00Z",
+  "status: completed",
+  "```",
+  "",
+  "| sample | mapped % |",
+  "|--------|----------|",
+  "| s1     | 96.2     |",
+].join("\n");
+
+describe("galaxy-markdown-adapter -- push", () => {
+  it("replaces the loom-invocation fence with a hidden carrier and leaves narrative intact", () => {
+    const out = loomToGalaxyMarkdown(NOTEBOOK);
+    expect(out).not.toContain("```loom-invocation");
+    expect(out).toMatch(/<!-- loom-invocation:v1 [A-Za-z0-9+/=]+ -->/);
+    expect(out).toContain("## Plan A: chrM Variant Calling [hybrid]");
+    expect(out).toContain("- [x] {#plan-a-step-2} BWA alignment");
+    expect(out).toContain("| s1     | 96.2     |");
+  });
+});
+
+describe("galaxy-markdown-adapter -- round trip", () => {
+  it("loom -> galaxy -> loom is the identity", () => {
+    expect(galaxyMarkdownToLoom(loomToGalaxyMarkdown(NOTEBOOK))).toBe(NOTEBOOK);
+  });
+
+  it("is a no-op on content with no invocation blocks", () => {
+    const plain = "# Title\n\nsome prose\n";
+    expect(loomToGalaxyMarkdown(plain)).toBe(plain);
+    expect(galaxyMarkdownToLoom(plain)).toBe(plain);
+  });
+
+  it("handles multiple invocation blocks", () => {
+    const two =
+      NOTEBOOK +
+      "\n\n```loom-invocation\ninvocation_id: def456\ngalaxy_server_url: https://test.galaxyproject.org\nnotebook_anchor: plan-a-step-3\nlabel: calling\nsubmitted_at: 2026-05-29T13:00:00Z\nstatus: in_progress\n```\n";
+    const pushed = loomToGalaxyMarkdown(two);
+    expect((pushed.match(/<!-- loom-invocation:v1 /g) ?? []).length).toBe(2);
+    expect(galaxyMarkdownToLoom(pushed)).toBe(two);
+  });
+});

--- a/tests/galaxy-markdown-adapter.test.ts
+++ b/tests/galaxy-markdown-adapter.test.ts
@@ -61,6 +61,38 @@ describe("galaxy-markdown-adapter -- round trip", () => {
     expect(galaxyMarkdownToLoom(prose)).toBe(prose);
   });
 
+  it("preserves a human-authored ```galaxy fence on pull", () => {
+    // A narrative galaxy directive someone wrote by hand (no carrier following)
+    // must survive -- only Loom's own directives, which sit directly above a
+    // carrier, get stripped.
+    const authored = [
+      "# Notes",
+      "",
+      "Example of a Galaxy directive you can use:",
+      "",
+      "```galaxy",
+      "history_dataset_display(history_dataset_id=abc)",
+      "```",
+      "",
+      "more prose",
+      "",
+    ].join("\n");
+    expect(galaxyMarkdownToLoom(authored)).toBe(authored);
+  });
+
+  it("strips Loom's directive but keeps an adjacent human-authored ```galaxy fence", async () => {
+    const human = ["```galaxy", "history_dataset_display(history_dataset_id=abc)", "```"].join(
+      "\n",
+    );
+    const pushed = await loomToGalaxyMarkdownRich(NOTEBOOK, { isValid: async () => true });
+    // Drop a hand-authored galaxy fence into the pushed page (with a blank line,
+    // as a human would), then pull.
+    const pulled = galaxyMarkdownToLoom(`${human}\n\n${pushed}`);
+    expect(pulled).toContain("history_dataset_display(history_dataset_id=abc)");
+    expect(pulled).toContain("```loom-invocation");
+    expect(pulled).not.toContain("invocation_outputs(");
+  });
+
   it("handles multiple invocation blocks", () => {
     const two =
       NOTEBOOK +

--- a/tests/galaxy-markdown-adapter.test.ts
+++ b/tests/galaxy-markdown-adapter.test.ts
@@ -74,4 +74,27 @@ describe("galaxy-markdown-adapter -- rich push", () => {
     expect(out).toMatch(/<!-- loom-invocation:v1 [A-Za-z0-9+/=]+ -->/);
     expect(galaxyMarkdownToLoom(out)).toBe(NOTEBOOK);
   });
+
+  it("omits the directive without calling the validator when the block has no invocation_id", async () => {
+    const noId = [
+      "# Notes",
+      "",
+      "```loom-invocation",
+      "galaxy_server_url: https://test.galaxyproject.org",
+      "notebook_anchor: plan-a-step-2",
+      "label: BWA alignment",
+      "status: completed",
+      "```",
+      "",
+    ].join("\n");
+    const validator = {
+      isValid: async () => {
+        throw new Error("validator must not be consulted when there is no invocation_id");
+      },
+    };
+    const out = await loomToGalaxyMarkdownRich(noId, validator);
+    expect(out).not.toContain("```galaxy");
+    expect(out).toMatch(/<!-- loom-invocation:v1 [A-Za-z0-9+/=]+ -->/);
+    expect(galaxyMarkdownToLoom(out)).toBe(noId);
+  });
 });

--- a/tests/galaxy-markdown-adapter.test.ts
+++ b/tests/galaxy-markdown-adapter.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   loomToGalaxyMarkdown,
   galaxyMarkdownToLoom,
   loomToGalaxyMarkdownRich,
+  galaxyInvocationValidator,
 } from "../extensions/loom/galaxy-markdown-adapter";
+import * as galaxyApi from "../extensions/loom/galaxy-api";
+
+vi.mock("../extensions/loom/galaxy-api");
 
 const NOTEBOOK = [
   "# chrM Variant Calling",
@@ -141,5 +145,48 @@ describe("galaxy-markdown-adapter -- rich push", () => {
     expect(out).not.toContain("```galaxy");
     expect(out).toMatch(/^\[loom-invocation:v1\]: #loom "[A-Za-z0-9+/=]+"$/m);
     expect(galaxyMarkdownToLoom(out)).toBe(noId);
+  });
+});
+
+describe("galaxy-markdown-adapter -- carrier whitespace tolerance", () => {
+  it("decodes a carrier that picked up trailing whitespace and still strips its directive", async () => {
+    const rich = await loomToGalaxyMarkdownRich(NOTEBOOK, { isValid: async () => true });
+    // Simulate a storage round trip that appended whitespace to the carrier line.
+    const withTrailingWs = rich.replace(
+      /(\[loom-invocation:v1\]: #loom "[A-Za-z0-9+/=]+")$/m,
+      "$1  ",
+    );
+    expect(withTrailingWs).not.toBe(rich); // guard: the mutation actually landed
+
+    const pulled = galaxyMarkdownToLoom(withTrailingWs);
+    expect(pulled).toContain("```loom-invocation");
+    expect(pulled).toContain("invocation_id: abc123");
+    expect(pulled).not.toContain("[loom-invocation:v1]"); // carrier was decoded, not left behind
+    expect(pulled).not.toContain("invocation_outputs("); // Loom's own directive was stripped
+  });
+});
+
+describe("galaxy-markdown-adapter -- galaxyInvocationValidator", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejects a path-like id before making any network call", async () => {
+    expect(await galaxyInvocationValidator.isValid("../histories")).toBe(false);
+    expect(galaxyApi.galaxyGet).not.toHaveBeenCalled();
+  });
+
+  it("validates a hex id (encoded into the path) when the server echoes the same id", async () => {
+    vi.mocked(galaxyApi.galaxyGet).mockResolvedValue({ id: "abc123" });
+    expect(await galaxyInvocationValidator.isValid("abc123")).toBe(true);
+    expect(galaxyApi.galaxyGet).toHaveBeenCalledWith("/invocations/abc123");
+  });
+
+  it("rejects when the server returns 200 for a different resource", async () => {
+    vi.mocked(galaxyApi.galaxyGet).mockResolvedValue({ id: "somethingelse" });
+    expect(await galaxyInvocationValidator.isValid("abc123")).toBe(false);
+  });
+
+  it("rejects when the lookup throws", async () => {
+    vi.mocked(galaxyApi.galaxyGet).mockRejectedValue(new Error("404"));
+    expect(await galaxyInvocationValidator.isValid("abc123")).toBe(false);
   });
 });

--- a/tests/galaxy-markdown-adapter.test.ts
+++ b/tests/galaxy-markdown-adapter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   loomToGalaxyMarkdown,
   galaxyMarkdownToLoom,
+  loomToGalaxyMarkdownRich,
 } from "../extensions/loom/galaxy-markdown-adapter";
 
 const NOTEBOOK = [
@@ -54,5 +55,23 @@ describe("galaxy-markdown-adapter -- round trip", () => {
     const pushed = loomToGalaxyMarkdown(two);
     expect((pushed.match(/<!-- loom-invocation:v1 /g) ?? []).length).toBe(2);
     expect(galaxyMarkdownToLoom(pushed)).toBe(two);
+  });
+});
+
+describe("galaxy-markdown-adapter -- rich push", () => {
+  it("emits a galaxy directive when the invocation id validates, plus the carrier", async () => {
+    const out = await loomToGalaxyMarkdownRich(NOTEBOOK, { isValid: async () => true });
+    expect(out).toContain("```galaxy");
+    expect(out).toContain("invocation_outputs(invocation_id=abc123)");
+    expect(out).toMatch(/<!-- loom-invocation:v1 [A-Za-z0-9+/=]+ -->/);
+    // round trip still restores the original, stripping the directive
+    expect(galaxyMarkdownToLoom(out)).toBe(NOTEBOOK);
+  });
+
+  it("omits the directive when the id does not validate, but keeps the carrier", async () => {
+    const out = await loomToGalaxyMarkdownRich(NOTEBOOK, { isValid: async () => false });
+    expect(out).not.toContain("```galaxy");
+    expect(out).toMatch(/<!-- loom-invocation:v1 [A-Za-z0-9+/=]+ -->/);
+    expect(galaxyMarkdownToLoom(out)).toBe(NOTEBOOK);
   });
 });

--- a/tests/galaxy-markdown-adapter.test.ts
+++ b/tests/galaxy-markdown-adapter.test.ts
@@ -30,7 +30,7 @@ describe("galaxy-markdown-adapter -- push", () => {
   it("replaces the loom-invocation fence with a hidden carrier and leaves narrative intact", () => {
     const out = loomToGalaxyMarkdown(NOTEBOOK);
     expect(out).not.toContain("```loom-invocation");
-    expect(out).toMatch(/<!-- loom-invocation:v1 [A-Za-z0-9+/=]+ -->/);
+    expect(out).toMatch(/^\[loom-invocation:v1\]: #loom "[A-Za-z0-9+/=]+"$/m);
     expect(out).toContain("## Plan A: chrM Variant Calling [hybrid]");
     expect(out).toContain("- [x] {#plan-a-step-2} BWA alignment");
     expect(out).toContain("| s1     | 96.2     |");
@@ -50,11 +50,11 @@ describe("galaxy-markdown-adapter -- round trip", () => {
 
   it("does not decode carrier-like syntax that appears inline in prose", () => {
     // A notebook documenting Loom's own format must survive the round trip: an
-    // inline mention of the carrier comment is not a real (standalone-line) carrier.
+    // inline mention of the carrier is not a real (standalone-line) carrier.
     const prose = [
       "# Format docs",
       "",
-      "On push, Loom emits `<!-- loom-invocation:v1 YWJj -->` for each block.",
+      'On push, Loom emits `[loom-invocation:v1]: #loom "YWJj"` for each block.',
       "",
     ].join("\n");
     expect(loomToGalaxyMarkdown(prose)).toBe(prose);
@@ -66,7 +66,7 @@ describe("galaxy-markdown-adapter -- round trip", () => {
       NOTEBOOK +
       "\n\n```loom-invocation\ninvocation_id: def456\ngalaxy_server_url: https://test.galaxyproject.org\nnotebook_anchor: plan-a-step-3\nlabel: calling\nsubmitted_at: 2026-05-29T13:00:00Z\nstatus: in_progress\n```\n";
     const pushed = loomToGalaxyMarkdown(two);
-    expect((pushed.match(/<!-- loom-invocation:v1 /g) ?? []).length).toBe(2);
+    expect((pushed.match(/^\[loom-invocation:v1\]: #loom "/gm) ?? []).length).toBe(2);
     expect(galaxyMarkdownToLoom(pushed)).toBe(two);
   });
 });
@@ -76,7 +76,7 @@ describe("galaxy-markdown-adapter -- rich push", () => {
     const out = await loomToGalaxyMarkdownRich(NOTEBOOK, { isValid: async () => true });
     expect(out).toContain("```galaxy");
     expect(out).toContain("invocation_outputs(invocation_id=abc123)");
-    expect(out).toMatch(/<!-- loom-invocation:v1 [A-Za-z0-9+/=]+ -->/);
+    expect(out).toMatch(/^\[loom-invocation:v1\]: #loom "[A-Za-z0-9+/=]+"$/m);
     // round trip still restores the original, stripping the directive
     expect(galaxyMarkdownToLoom(out)).toBe(NOTEBOOK);
   });
@@ -84,7 +84,7 @@ describe("galaxy-markdown-adapter -- rich push", () => {
   it("omits the directive when the id does not validate, but keeps the carrier", async () => {
     const out = await loomToGalaxyMarkdownRich(NOTEBOOK, { isValid: async () => false });
     expect(out).not.toContain("```galaxy");
-    expect(out).toMatch(/<!-- loom-invocation:v1 [A-Za-z0-9+/=]+ -->/);
+    expect(out).toMatch(/^\[loom-invocation:v1\]: #loom "[A-Za-z0-9+/=]+"$/m);
     expect(galaxyMarkdownToLoom(out)).toBe(NOTEBOOK);
   });
 
@@ -107,7 +107,7 @@ describe("galaxy-markdown-adapter -- rich push", () => {
     };
     const out = await loomToGalaxyMarkdownRich(noId, validator);
     expect(out).not.toContain("```galaxy");
-    expect(out).toMatch(/<!-- loom-invocation:v1 [A-Za-z0-9+/=]+ -->/);
+    expect(out).toMatch(/^\[loom-invocation:v1\]: #loom "[A-Za-z0-9+/=]+"$/m);
     expect(galaxyMarkdownToLoom(out)).toBe(noId);
   });
 });

--- a/tests/galaxy-markdown-adapter.test.ts
+++ b/tests/galaxy-markdown-adapter.test.ts
@@ -48,6 +48,19 @@ describe("galaxy-markdown-adapter -- round trip", () => {
     expect(galaxyMarkdownToLoom(plain)).toBe(plain);
   });
 
+  it("does not decode carrier-like syntax that appears inline in prose", () => {
+    // A notebook documenting Loom's own format must survive the round trip: an
+    // inline mention of the carrier comment is not a real (standalone-line) carrier.
+    const prose = [
+      "# Format docs",
+      "",
+      "On push, Loom emits `<!-- loom-invocation:v1 YWJj -->` for each block.",
+      "",
+    ].join("\n");
+    expect(loomToGalaxyMarkdown(prose)).toBe(prose);
+    expect(galaxyMarkdownToLoom(prose)).toBe(prose);
+  });
+
   it("handles multiple invocation blocks", () => {
     const two =
       NOTEBOOK +

--- a/tests/galaxy-pages-sync.test.ts
+++ b/tests/galaxy-pages-sync.test.ts
@@ -8,7 +8,10 @@ import {
   pullNotebookFromGalaxy,
   linkGalaxyPage,
   resumeGalaxyPage,
+  UNTRUSTED_BEGIN,
+  UNTRUSTED_END,
 } from "../extensions/loom/galaxy-pages-sync";
+import { loomToGalaxyMarkdown } from "../extensions/loom/galaxy-markdown-adapter";
 
 vi.mock("../extensions/loom/galaxy-pages-api");
 vi.mock("../extensions/loom/galaxy-api");
@@ -244,6 +247,55 @@ describe("pullNotebookFromGalaxy", () => {
     expect(written).not.toContain("Some local edits.");
     expect(written).toContain("```loom-galaxy-page");
     expect(written).toContain("last_synced_revision: r2");
+  });
+
+  it("reconstructs loom carriers and wraps the reconstructed body in untrusted markers", async () => {
+    const bound = [
+      "Local edits.",
+      "",
+      "```loom-galaxy-page",
+      "page_id: p1",
+      "page_slug: a",
+      'galaxy_server_url: "https://galaxy.example"',
+      "history_id: h1",
+      "last_synced_revision: r1",
+      "bound_at: 2026-05-20T10:00:00Z",
+      "```",
+      "",
+    ].join("\n");
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
+
+    // A page body as it would look after a Loom push: the loom-invocation fence
+    // is encoded to a render-invisible carrier. Pull must decode it back AND
+    // still apply the untrusted-content wrap -- the two transforms compose.
+    const loomBlock = ["```loom-invocation", "invocation_id: abc123", "label: QC", "```"].join("\n");
+    const remoteWithCarrier = loomToGalaxyMarkdown(`# Remote report\n\n${loomBlock}\n`);
+    vi.mocked(pagesApi.getPage).mockResolvedValue({
+      id: "p1",
+      slug: "a",
+      latest_revision_id: "r2",
+      revision_ids: ["r1", "r2"],
+      title: "A",
+      content: remoteWithCarrier,
+      content_format: "markdown",
+      create_time: "2026-05-20T00:00:00Z",
+      update_time: "2026-05-21T00:00:00Z",
+    });
+
+    await pullNotebookFromGalaxy();
+
+    const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(-1)![1];
+    // Carrier decoded back to the original fence; the raw carrier is gone.
+    expect(written).toContain("```loom-invocation");
+    expect(written).toContain("invocation_id: abc123");
+    expect(written).not.toContain("[loom-invocation:v1]");
+    // Untrusted wrap is present and encloses the reconstructed body.
+    const begin = written.indexOf(UNTRUSTED_BEGIN);
+    const block = written.indexOf("```loom-invocation");
+    const end = written.indexOf(UNTRUSTED_END);
+    expect(begin).toBeGreaterThanOrEqual(0);
+    expect(block).toBeGreaterThan(begin);
+    expect(end).toBeGreaterThan(block);
   });
 });
 

--- a/tests/galaxy-pages-sync.test.ts
+++ b/tests/galaxy-pages-sync.test.ts
@@ -78,14 +78,14 @@ describe("pushNotebookToGalaxy", () => {
   });
 
   it("projects loom-invocation blocks to a carrier + validated directive on the page", async () => {
-    // galaxyGet resolves, so galaxyInvocationValidator reports the id valid and
-    // the rich push emits the directive alongside the hidden carrier.
-    vi.mocked(galaxyApi.galaxyGet).mockResolvedValue({});
+    // galaxyGet echoes back the same id, so galaxyInvocationValidator reports it
+    // valid and the rich push emits the directive alongside the hidden carrier.
+    vi.mocked(galaxyApi.galaxyGet).mockResolvedValue({ id: "f2db41e1fa331b3e" });
     const notebook = [
       "# Analysis",
       "",
       "```loom-invocation",
-      "invocation_id: inv-abc",
+      "invocation_id: f2db41e1fa331b3e",
       'galaxy_server_url: "https://galaxy.example"',
       "notebook_anchor: plan-a-step-2",
       "label: BWA alignment",
@@ -109,7 +109,7 @@ describe("pushNotebookToGalaxy", () => {
 
     const sent = vi.mocked(pagesApi.createPage).mock.calls[0][0].content;
     expect(sent).toMatch(/^\[loom-invocation:v1\]: #loom "/m);
-    expect(sent).toContain("invocation_outputs(invocation_id=inv-abc)");
+    expect(sent).toContain("invocation_outputs(invocation_id=f2db41e1fa331b3e)");
     expect(sent).not.toContain("```loom-invocation");
     // the local notebook stays canonical -- the raw fence, not the projection
     const writtenLocal = vi.mocked(notebookWriter.writeNotebook).mock.calls[0][1];
@@ -268,7 +268,9 @@ describe("pullNotebookFromGalaxy", () => {
     // A page body as it would look after a Loom push: the loom-invocation fence
     // is encoded to a render-invisible carrier. Pull must decode it back AND
     // still apply the untrusted-content wrap -- the two transforms compose.
-    const loomBlock = ["```loom-invocation", "invocation_id: abc123", "label: QC", "```"].join("\n");
+    const loomBlock = ["```loom-invocation", "invocation_id: abc123", "label: QC", "```"].join(
+      "\n",
+    );
     const remoteWithCarrier = loomToGalaxyMarkdown(`# Remote report\n\n${loomBlock}\n`);
     vi.mocked(pagesApi.getPage).mockResolvedValue({
       id: "p1",

--- a/tests/galaxy-pages-sync.test.ts
+++ b/tests/galaxy-pages-sync.test.ts
@@ -74,6 +74,45 @@ describe("pushNotebookToGalaxy", () => {
     expect(written).toContain("last_synced_revision: r1");
   });
 
+  it("projects loom-invocation blocks to a carrier + validated directive on the page", async () => {
+    // galaxyGet resolves, so galaxyInvocationValidator reports the id valid and
+    // the rich push emits the directive alongside the hidden carrier.
+    vi.mocked(galaxyApi.galaxyGet).mockResolvedValue({});
+    const notebook = [
+      "# Analysis",
+      "",
+      "```loom-invocation",
+      "invocation_id: inv-abc",
+      'galaxy_server_url: "https://galaxy.example"',
+      "notebook_anchor: plan-a-step-2",
+      "label: BWA alignment",
+      "submitted_at: 2026-05-20T12:00:00Z",
+      "status: completed",
+      "```",
+      "",
+    ].join("\n");
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue(notebook);
+    vi.mocked(pagesApi.createPage).mockResolvedValue({
+      id: "p1",
+      slug: "analysis",
+      latest_revision_id: "r1",
+      revision_ids: ["r1"],
+      title: "Analysis",
+      create_time: "2026-05-20T00:00:00Z",
+      update_time: "2026-05-20T00:00:00Z",
+    });
+
+    await pushNotebookToGalaxy({ historyId: "h1", title: "Analysis" });
+
+    const sent = vi.mocked(pagesApi.createPage).mock.calls[0][0].content;
+    expect(sent).toContain("<!-- loom-invocation:v1 ");
+    expect(sent).toContain("invocation_outputs(invocation_id=inv-abc)");
+    expect(sent).not.toContain("```loom-invocation");
+    // the local notebook stays canonical -- the raw fence, not the projection
+    const writtenLocal = vi.mocked(notebookWriter.writeNotebook).mock.calls[0][1];
+    expect(writtenLocal).toContain("```loom-invocation");
+  });
+
   it("updates the existing page when a binding is present", async () => {
     const initial = [
       "# Analysis",

--- a/tests/galaxy-pages-sync.test.ts
+++ b/tests/galaxy-pages-sync.test.ts
@@ -105,7 +105,7 @@ describe("pushNotebookToGalaxy", () => {
     await pushNotebookToGalaxy({ historyId: "h1", title: "Analysis" });
 
     const sent = vi.mocked(pagesApi.createPage).mock.calls[0][0].content;
-    expect(sent).toContain("<!-- loom-invocation:v1 ");
+    expect(sent).toMatch(/^\[loom-invocation:v1\]: #loom "/m);
     expect(sent).toContain("invocation_outputs(invocation_id=inv-abc)");
     expect(sent).not.toContain("```loom-invocation");
     // the local notebook stays canonical -- the raw fence, not the projection

--- a/tests/galaxy-pages-sync.test.ts
+++ b/tests/galaxy-pages-sync.test.ts
@@ -4,447 +4,422 @@ import * as galaxyApi from "../extensions/loom/galaxy-api";
 import * as notebookWriter from "../extensions/loom/notebook-writer";
 import * as state from "../extensions/loom/state";
 import {
-    pushNotebookToGalaxy,
-    pullNotebookFromGalaxy,
-    linkGalaxyPage,
-    resumeGalaxyPage,
+  pushNotebookToGalaxy,
+  pullNotebookFromGalaxy,
+  linkGalaxyPage,
+  resumeGalaxyPage,
 } from "../extensions/loom/galaxy-pages-sync";
 
 vi.mock("../extensions/loom/galaxy-pages-api");
 vi.mock("../extensions/loom/galaxy-api");
 vi.mock("../extensions/loom/notebook-writer", async (importOriginal) => {
-    const actual = await importOriginal<typeof notebookWriter>();
-    return {
-        ...actual,
-        readNotebook: vi.fn(),
-        writeNotebook: vi.fn(),
-        withNotebookLock: vi.fn(async (_p: string, fn: () => Promise<unknown>) => fn()),
-    };
+  const actual = await importOriginal<typeof notebookWriter>();
+  return {
+    ...actual,
+    readNotebook: vi.fn(),
+    writeNotebook: vi.fn(),
+    withNotebookLock: vi.fn(async (_p: string, fn: () => Promise<unknown>) => fn()),
+  };
 });
 vi.mock("../extensions/loom/state");
 
 beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(state.getNotebookPath).mockReturnValue("/work/notebook.md");
-    vi.mocked(galaxyApi.getGalaxyConfig).mockReturnValue({
-        url: "https://galaxy.example",
-        apiKey: "k",
-    });
-    vi.mocked(notebookWriter.withNotebookLock).mockImplementation(
-        async (_p: string, fn: () => Promise<unknown>) => fn() as Promise<never>,
-    );
+  vi.clearAllMocks();
+  vi.mocked(state.getNotebookPath).mockReturnValue("/work/notebook.md");
+  vi.mocked(galaxyApi.getGalaxyConfig).mockReturnValue({
+    url: "https://galaxy.example",
+    apiKey: "k",
+  });
+  vi.mocked(notebookWriter.withNotebookLock).mockImplementation(
+    async (_p: string, fn: () => Promise<unknown>) => fn() as Promise<never>,
+  );
 });
 
 describe("pushNotebookToGalaxy", () => {
-    it("creates a new page when notebook has no binding", async () => {
-        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(
-            "# Analysis\n\nBody content.\n",
-        );
-        vi.mocked(pagesApi.createPage).mockResolvedValue({
-            id: "p1",
-            slug: "analysis",
-            latest_revision_id: "r1",
-            revision_ids: ["r1"],
-            title: "Analysis",
-            create_time: "2026-05-20T00:00:00Z",
-            update_time: "2026-05-20T00:00:00Z",
-        });
-
-        const result = await pushNotebookToGalaxy({
-            historyId: "h1",
-            title: "Analysis",
-        });
-
-        expect(pagesApi.createPage).toHaveBeenCalledWith({
-            history_id: "h1",
-            title: "Analysis",
-            slug: undefined,
-            annotation: undefined,
-            content: "# Analysis\n\nBody content.\n",
-            content_format: "markdown",
-        });
-        expect(result).toEqual({
-            pageId: "p1",
-            pageSlug: "analysis",
-            latestRevisionId: "r1",
-            action: "created",
-        });
-        expect(notebookWriter.writeNotebook).toHaveBeenCalledOnce();
-        const written = vi.mocked(notebookWriter.writeNotebook).mock
-            .calls[0][1];
-        expect(written).toContain("```loom-galaxy-page");
-        expect(written).toContain("page_id: p1");
-        expect(written).toContain("last_synced_revision: r1");
+  it("creates a new page when notebook has no binding", async () => {
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue("# Analysis\n\nBody content.\n");
+    vi.mocked(pagesApi.createPage).mockResolvedValue({
+      id: "p1",
+      slug: "analysis",
+      latest_revision_id: "r1",
+      revision_ids: ["r1"],
+      title: "Analysis",
+      create_time: "2026-05-20T00:00:00Z",
+      update_time: "2026-05-20T00:00:00Z",
     });
 
-    it("updates the existing page when a binding is present", async () => {
-        const initial = [
-            "# Analysis",
-            "",
-            "Body content.",
-            "",
-            "```loom-galaxy-page",
-            "page_id: p1",
-            "page_slug: analysis",
-            'galaxy_server_url: "https://galaxy.example"',
-            "history_id: h1",
-            "last_synced_revision: r1",
-            "bound_at: 2026-05-20T10:00:00Z",
-            "```",
-            "",
-        ].join("\n");
-        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(initial);
-        vi.mocked(pagesApi.updatePage).mockResolvedValue({
-            id: "p1",
-            slug: "analysis",
-            latest_revision_id: "r2",
-            revision_ids: ["r1", "r2"],
-            title: "Analysis",
-            create_time: "2026-05-20T00:00:00Z",
-            update_time: "2026-05-21T00:00:00Z",
-        });
-
-        const result = await pushNotebookToGalaxy();
-
-        expect(pagesApi.updatePage).toHaveBeenCalledWith(
-            "p1",
-            expect.objectContaining({
-                content: expect.not.stringContaining("loom-galaxy-page"),
-                content_format: "markdown",
-                edit_source: "agent",
-            }),
-        );
-        expect(result).toEqual({
-            pageId: "p1",
-            pageSlug: "analysis",
-            latestRevisionId: "r2",
-            action: "updated",
-        });
-        const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(
-            -1,
-        )![1];
-        expect(written).toContain("last_synced_revision: r2");
+    const result = await pushNotebookToGalaxy({
+      historyId: "h1",
+      title: "Analysis",
     });
 
-    it("throws on server-URL mismatch before calling Galaxy", async () => {
-        const initial = [
-            "```loom-galaxy-page",
-            "page_id: p1",
-            "page_slug: a",
-            'galaxy_server_url: "https://other.example"',
-            "history_id: h1",
-            "last_synced_revision: r1",
-            "bound_at: 2026-05-20T10:00:00Z",
-            "```",
-            "",
-        ].join("\n");
-        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(initial);
-
-        await expect(pushNotebookToGalaxy()).rejects.toThrow(
-            /bound to.*other\.example.*connected to.*galaxy\.example/,
-        );
-        expect(pagesApi.updatePage).not.toHaveBeenCalled();
+    expect(pagesApi.createPage).toHaveBeenCalledWith({
+      history_id: "h1",
+      title: "Analysis",
+      slug: undefined,
+      annotation: undefined,
+      content: "# Analysis\n\nBody content.\n",
+      content_format: "markdown",
     });
+    expect(result).toEqual({
+      pageId: "p1",
+      pageSlug: "analysis",
+      latestRevisionId: "r1",
+      action: "created",
+    });
+    expect(notebookWriter.writeNotebook).toHaveBeenCalledOnce();
+    const written = vi.mocked(notebookWriter.writeNotebook).mock.calls[0][1];
+    expect(written).toContain("```loom-galaxy-page");
+    expect(written).toContain("page_id: p1");
+    expect(written).toContain("last_synced_revision: r1");
+  });
+
+  it("updates the existing page when a binding is present", async () => {
+    const initial = [
+      "# Analysis",
+      "",
+      "Body content.",
+      "",
+      "```loom-galaxy-page",
+      "page_id: p1",
+      "page_slug: analysis",
+      'galaxy_server_url: "https://galaxy.example"',
+      "history_id: h1",
+      "last_synced_revision: r1",
+      "bound_at: 2026-05-20T10:00:00Z",
+      "```",
+      "",
+    ].join("\n");
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue(initial);
+    vi.mocked(pagesApi.updatePage).mockResolvedValue({
+      id: "p1",
+      slug: "analysis",
+      latest_revision_id: "r2",
+      revision_ids: ["r1", "r2"],
+      title: "Analysis",
+      create_time: "2026-05-20T00:00:00Z",
+      update_time: "2026-05-21T00:00:00Z",
+    });
+
+    const result = await pushNotebookToGalaxy();
+
+    expect(pagesApi.updatePage).toHaveBeenCalledWith(
+      "p1",
+      expect.objectContaining({
+        content: expect.not.stringContaining("loom-galaxy-page"),
+        content_format: "markdown",
+        edit_source: "agent",
+      }),
+    );
+    expect(result).toEqual({
+      pageId: "p1",
+      pageSlug: "analysis",
+      latestRevisionId: "r2",
+      action: "updated",
+    });
+    const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(-1)![1];
+    expect(written).toContain("last_synced_revision: r2");
+  });
+
+  it("throws on server-URL mismatch before calling Galaxy", async () => {
+    const initial = [
+      "```loom-galaxy-page",
+      "page_id: p1",
+      "page_slug: a",
+      'galaxy_server_url: "https://other.example"',
+      "history_id: h1",
+      "last_synced_revision: r1",
+      "bound_at: 2026-05-20T10:00:00Z",
+      "```",
+      "",
+    ].join("\n");
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue(initial);
+
+    await expect(pushNotebookToGalaxy()).rejects.toThrow(
+      /bound to.*other\.example.*connected to.*galaxy\.example/,
+    );
+    expect(pagesApi.updatePage).not.toHaveBeenCalled();
+  });
 });
 
 describe("pullNotebookFromGalaxy", () => {
-    it("throws when notebook has no binding", async () => {
-        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(
-            "# No binding here\n",
-        );
-        await expect(pullNotebookFromGalaxy()).rejects.toThrow(
-            /not bound to a Galaxy page/,
-        );
-        expect(pagesApi.getPage).not.toHaveBeenCalled();
+  it("throws when notebook has no binding", async () => {
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue("# No binding here\n");
+    await expect(pullNotebookFromGalaxy()).rejects.toThrow(/not bound to a Galaxy page/);
+    expect(pagesApi.getPage).not.toHaveBeenCalled();
+  });
+
+  it("throws on server-URL mismatch", async () => {
+    const bound = [
+      "```loom-galaxy-page",
+      "page_id: p1",
+      "page_slug: a",
+      'galaxy_server_url: "https://other.example"',
+      "history_id: h1",
+      "last_synced_revision: r1",
+      "bound_at: 2026-05-20T10:00:00Z",
+      "```",
+      "",
+    ].join("\n");
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
+    await expect(pullNotebookFromGalaxy()).rejects.toThrow(
+      /bound to.*other\.example.*connected to.*galaxy\.example/,
+    );
+    expect(pagesApi.getPage).not.toHaveBeenCalled();
+  });
+
+  it("replaces notebook with remote body and re-applies binding with new revision", async () => {
+    const bound = [
+      "Some local edits.",
+      "",
+      "```loom-galaxy-page",
+      "page_id: p1",
+      "page_slug: a",
+      'galaxy_server_url: "https://galaxy.example"',
+      "history_id: h1",
+      "last_synced_revision: r1",
+      "bound_at: 2026-05-20T10:00:00Z",
+      "```",
+      "",
+    ].join("\n");
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
+    vi.mocked(pagesApi.getPage).mockResolvedValue({
+      id: "p1",
+      slug: "a",
+      latest_revision_id: "r2",
+      revision_ids: ["r1", "r2"],
+      title: "A",
+      content: "# Remote body\n\nUpdated server-side.\n",
+      content_format: "markdown",
+      create_time: "2026-05-20T00:00:00Z",
+      update_time: "2026-05-21T00:00:00Z",
     });
 
-    it("throws on server-URL mismatch", async () => {
-        const bound = [
-            "```loom-galaxy-page",
-            "page_id: p1",
-            "page_slug: a",
-            'galaxy_server_url: "https://other.example"',
-            "history_id: h1",
-            "last_synced_revision: r1",
-            "bound_at: 2026-05-20T10:00:00Z",
-            "```",
-            "",
-        ].join("\n");
-        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
-        await expect(pullNotebookFromGalaxy()).rejects.toThrow(
-            /bound to.*other\.example.*connected to.*galaxy\.example/,
-        );
-        expect(pagesApi.getPage).not.toHaveBeenCalled();
-    });
+    const result = await pullNotebookFromGalaxy();
 
-    it("replaces notebook with remote body and re-applies binding with new revision", async () => {
-        const bound = [
-            "Some local edits.",
-            "",
-            "```loom-galaxy-page",
-            "page_id: p1",
-            "page_slug: a",
-            'galaxy_server_url: "https://galaxy.example"',
-            "history_id: h1",
-            "last_synced_revision: r1",
-            "bound_at: 2026-05-20T10:00:00Z",
-            "```",
-            "",
-        ].join("\n");
-        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
-        vi.mocked(pagesApi.getPage).mockResolvedValue({
-            id: "p1",
-            slug: "a",
-            latest_revision_id: "r2",
-            revision_ids: ["r1", "r2"],
-            title: "A",
-            content: "# Remote body\n\nUpdated server-side.\n",
-            content_format: "markdown",
-            create_time: "2026-05-20T00:00:00Z",
-            update_time: "2026-05-21T00:00:00Z",
-        });
-
-        const result = await pullNotebookFromGalaxy();
-
-        expect(pagesApi.getPage).toHaveBeenCalledWith("p1");
-        expect(result).toEqual({ pageId: "p1", latestRevisionId: "r2" });
-        const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(
-            -1,
-        )![1];
-        expect(written).toContain("# Remote body");
-        expect(written).toContain("Updated server-side.");
-        expect(written).not.toContain("Some local edits.");
-        expect(written).toContain("```loom-galaxy-page");
-        expect(written).toContain("last_synced_revision: r2");
-    });
+    expect(pagesApi.getPage).toHaveBeenCalledWith("p1");
+    expect(result).toEqual({ pageId: "p1", latestRevisionId: "r2" });
+    const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(-1)![1];
+    expect(written).toContain("# Remote body");
+    expect(written).toContain("Updated server-side.");
+    expect(written).not.toContain("Some local edits.");
+    expect(written).toContain("```loom-galaxy-page");
+    expect(written).toContain("last_synced_revision: r2");
+  });
 });
 
 describe("linkGalaxyPage", () => {
-    it("inserts a binding block from a getPage response", async () => {
-        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(
-            "# Notebook\n\nNo binding yet.\n",
-        );
-        vi.mocked(pagesApi.getPage).mockResolvedValue({
-            id: "p7",
-            slug: "linked-page",
-            latest_revision_id: "r3",
-            revision_ids: ["r3"],
-            title: "Linked",
-            content: "ignored",
-            content_format: "markdown",
-            history_id: "h7",
-            create_time: "2026-05-20T00:00:00Z",
-            update_time: "2026-05-20T00:00:00Z",
-        });
-
-        const result = await linkGalaxyPage("p7");
-
-        expect(pagesApi.getPage).toHaveBeenCalledWith("p7");
-        expect(result).toEqual({ pageId: "p7", latestRevisionId: "r3" });
-        const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(
-            -1,
-        )![1];
-        expect(written).toContain("page_id: p7");
-        expect(written).toContain("page_slug: linked-page");
-        expect(written).toContain("history_id: h7");
-        expect(written).toContain("# Notebook");
+  it("inserts a binding block from a getPage response", async () => {
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue("# Notebook\n\nNo binding yet.\n");
+    vi.mocked(pagesApi.getPage).mockResolvedValue({
+      id: "p7",
+      slug: "linked-page",
+      latest_revision_id: "r3",
+      revision_ids: ["r3"],
+      title: "Linked",
+      content: "ignored",
+      content_format: "markdown",
+      history_id: "h7",
+      create_time: "2026-05-20T00:00:00Z",
+      update_time: "2026-05-20T00:00:00Z",
     });
 
-    it("requires explicit history_id when the page response doesn't carry one", async () => {
-        vi.mocked(notebookWriter.readNotebook).mockResolvedValue("# Notebook\n");
-        vi.mocked(pagesApi.getPage).mockResolvedValue({
-            id: "p8",
-            slug: "no-hist",
-            latest_revision_id: "r4",
-            revision_ids: ["r4"],
-            title: "NoHist",
-            content: "",
-            content_format: "markdown",
-            create_time: "2026-05-20T00:00:00Z",
-            update_time: "2026-05-20T00:00:00Z",
-        });
+    const result = await linkGalaxyPage("p7");
 
-        await expect(linkGalaxyPage("p8")).rejects.toThrow(/history_id/);
+    expect(pagesApi.getPage).toHaveBeenCalledWith("p7");
+    expect(result).toEqual({ pageId: "p7", latestRevisionId: "r3" });
+    const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(-1)![1];
+    expect(written).toContain("page_id: p7");
+    expect(written).toContain("page_slug: linked-page");
+    expect(written).toContain("history_id: h7");
+    expect(written).toContain("# Notebook");
+  });
+
+  it("requires explicit history_id when the page response doesn't carry one", async () => {
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue("# Notebook\n");
+    vi.mocked(pagesApi.getPage).mockResolvedValue({
+      id: "p8",
+      slug: "no-hist",
+      latest_revision_id: "r4",
+      revision_ids: ["r4"],
+      title: "NoHist",
+      content: "",
+      content_format: "markdown",
+      create_time: "2026-05-20T00:00:00Z",
+      update_time: "2026-05-20T00:00:00Z",
     });
 
-    it("uses provided history_id when caller supplies one", async () => {
-        vi.mocked(notebookWriter.readNotebook).mockResolvedValue("# Notebook\n");
-        vi.mocked(pagesApi.getPage).mockResolvedValue({
-            id: "p9",
-            slug: "x",
-            latest_revision_id: "r5",
-            revision_ids: ["r5"],
-            title: "X",
-            content: "",
-            content_format: "markdown",
-            create_time: "2026-05-20T00:00:00Z",
-            update_time: "2026-05-20T00:00:00Z",
-        });
+    await expect(linkGalaxyPage("p8")).rejects.toThrow(/history_id/);
+  });
 
-        const result = await linkGalaxyPage("p9", { historyId: "h9-explicit" });
-
-        expect(result.pageId).toBe("p9");
-        const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(
-            -1,
-        )![1];
-        expect(written).toContain("history_id: h9-explicit");
+  it("uses provided history_id when caller supplies one", async () => {
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue("# Notebook\n");
+    vi.mocked(pagesApi.getPage).mockResolvedValue({
+      id: "p9",
+      slug: "x",
+      latest_revision_id: "r5",
+      revision_ids: ["r5"],
+      title: "X",
+      content: "",
+      content_format: "markdown",
+      create_time: "2026-05-20T00:00:00Z",
+      update_time: "2026-05-20T00:00:00Z",
     });
+
+    const result = await linkGalaxyPage("p9", { historyId: "h9-explicit" });
+
+    expect(result.pageId).toBe("p9");
+    const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(-1)![1];
+    expect(written).toContain("history_id: h9-explicit");
+  });
 });
 
 describe("resumeGalaxyPage", () => {
-    it("links and pulls when notebook has no binding", async () => {
-        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(
-            "# Template\n\nNothing here yet.\n",
-        );
-        vi.mocked(pagesApi.getPage).mockResolvedValue({
-            id: "p10",
-            slug: "resumed",
-            latest_revision_id: "r10",
-            revision_ids: ["r10"],
-            title: "Resumed",
-            content: "# Remote analysis\n\nReal work happened here.\n",
-            content_format: "markdown",
-            history_id: "h10",
-            create_time: "2026-05-20T00:00:00Z",
-            update_time: "2026-05-20T00:00:00Z",
-        });
-
-        const result = await resumeGalaxyPage("p10");
-
-        expect(pagesApi.getPage).toHaveBeenCalledWith("p10");
-        expect(result).toEqual({
-            pageId: "p10",
-            latestRevisionId: "r10",
-            action: "linked",
-        });
-        const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(
-            -1,
-        )![1];
-        expect(written).toContain("# Remote analysis");
-        expect(written).toContain("Real work happened here.");
-        expect(written).not.toContain("Template");
-        expect(written).toContain("page_id: p10");
-        expect(written).toContain("history_id: h10");
-        expect(written).toContain("last_synced_revision: r10");
+  it("links and pulls when notebook has no binding", async () => {
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue("# Template\n\nNothing here yet.\n");
+    vi.mocked(pagesApi.getPage).mockResolvedValue({
+      id: "p10",
+      slug: "resumed",
+      latest_revision_id: "r10",
+      revision_ids: ["r10"],
+      title: "Resumed",
+      content: "# Remote analysis\n\nReal work happened here.\n",
+      content_format: "markdown",
+      history_id: "h10",
+      create_time: "2026-05-20T00:00:00Z",
+      update_time: "2026-05-20T00:00:00Z",
     });
 
-    it("refreshes when already bound to the same page (preserves bound_at)", async () => {
-        const bound = [
-            "Local stale content.",
-            "",
-            "```loom-galaxy-page",
-            "page_id: p11",
-            "page_slug: same",
-            'galaxy_server_url: "https://galaxy.example"',
-            "history_id: h11",
-            "last_synced_revision: r11",
-            "bound_at: 2026-05-20T10:00:00Z",
-            "```",
-            "",
-        ].join("\n");
-        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
-        vi.mocked(pagesApi.getPage).mockResolvedValue({
-            id: "p11",
-            slug: "same",
-            latest_revision_id: "r12",
-            revision_ids: ["r11", "r12"],
-            title: "Same",
-            content: "# Fresh from server\n",
-            content_format: "markdown",
-            history_id: "h11",
-            create_time: "2026-05-20T00:00:00Z",
-            update_time: "2026-05-21T00:00:00Z",
-        });
+    const result = await resumeGalaxyPage("p10");
 
-        const result = await resumeGalaxyPage("p11");
+    expect(pagesApi.getPage).toHaveBeenCalledWith("p10");
+    expect(result).toEqual({
+      pageId: "p10",
+      latestRevisionId: "r10",
+      action: "linked",
+    });
+    const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(-1)![1];
+    expect(written).toContain("# Remote analysis");
+    expect(written).toContain("Real work happened here.");
+    expect(written).not.toContain("Template");
+    expect(written).toContain("page_id: p10");
+    expect(written).toContain("history_id: h10");
+    expect(written).toContain("last_synced_revision: r10");
+  });
 
-        expect(result.action).toBe("refreshed");
-        const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(
-            -1,
-        )![1];
-        expect(written).toContain("# Fresh from server");
-        expect(written).not.toContain("Local stale content.");
-        expect(written).toContain("last_synced_revision: r12");
-        expect(written).toContain("bound_at: 2026-05-20T10:00:00Z");
+  it("refreshes when already bound to the same page (preserves bound_at)", async () => {
+    const bound = [
+      "Local stale content.",
+      "",
+      "```loom-galaxy-page",
+      "page_id: p11",
+      "page_slug: same",
+      'galaxy_server_url: "https://galaxy.example"',
+      "history_id: h11",
+      "last_synced_revision: r11",
+      "bound_at: 2026-05-20T10:00:00Z",
+      "```",
+      "",
+    ].join("\n");
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
+    vi.mocked(pagesApi.getPage).mockResolvedValue({
+      id: "p11",
+      slug: "same",
+      latest_revision_id: "r12",
+      revision_ids: ["r11", "r12"],
+      title: "Same",
+      content: "# Fresh from server\n",
+      content_format: "markdown",
+      history_id: "h11",
+      create_time: "2026-05-20T00:00:00Z",
+      update_time: "2026-05-21T00:00:00Z",
     });
 
-    it("refuses to clobber when bound to a different page on the same server", async () => {
-        const bound = [
-            "```loom-galaxy-page",
-            "page_id: p-mine",
-            "page_slug: mine",
-            'galaxy_server_url: "https://galaxy.example"',
-            "history_id: h1",
-            "last_synced_revision: r1",
-            "bound_at: 2026-05-20T10:00:00Z",
-            "```",
-            "",
-        ].join("\n");
-        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
-        vi.mocked(pagesApi.getPage).mockResolvedValue({
-            id: "p-other",
-            slug: "other",
-            latest_revision_id: "r2",
-            revision_ids: ["r2"],
-            title: "Other",
-            content: "should not land",
-            content_format: "markdown",
-            history_id: "h1",
-            create_time: "2026-05-20T00:00:00Z",
-            update_time: "2026-05-20T00:00:00Z",
-        });
+    const result = await resumeGalaxyPage("p11");
 
-        await expect(resumeGalaxyPage("p-other")).rejects.toThrow(
-            /already bound to page p-mine/,
-        );
-        expect(notebookWriter.writeNotebook).not.toHaveBeenCalled();
+    expect(result.action).toBe("refreshed");
+    const written = vi.mocked(notebookWriter.writeNotebook).mock.calls.at(-1)![1];
+    expect(written).toContain("# Fresh from server");
+    expect(written).not.toContain("Local stale content.");
+    expect(written).toContain("last_synced_revision: r12");
+    expect(written).toContain("bound_at: 2026-05-20T10:00:00Z");
+  });
+
+  it("refuses to clobber when bound to a different page on the same server", async () => {
+    const bound = [
+      "```loom-galaxy-page",
+      "page_id: p-mine",
+      "page_slug: mine",
+      'galaxy_server_url: "https://galaxy.example"',
+      "history_id: h1",
+      "last_synced_revision: r1",
+      "bound_at: 2026-05-20T10:00:00Z",
+      "```",
+      "",
+    ].join("\n");
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
+    vi.mocked(pagesApi.getPage).mockResolvedValue({
+      id: "p-other",
+      slug: "other",
+      latest_revision_id: "r2",
+      revision_ids: ["r2"],
+      title: "Other",
+      content: "should not land",
+      content_format: "markdown",
+      history_id: "h1",
+      create_time: "2026-05-20T00:00:00Z",
+      update_time: "2026-05-20T00:00:00Z",
     });
 
-    it("throws on server-URL mismatch before writing", async () => {
-        const bound = [
-            "```loom-galaxy-page",
-            "page_id: p1",
-            "page_slug: a",
-            'galaxy_server_url: "https://other.example"',
-            "history_id: h1",
-            "last_synced_revision: r1",
-            "bound_at: 2026-05-20T10:00:00Z",
-            "```",
-            "",
-        ].join("\n");
-        vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
-        vi.mocked(pagesApi.getPage).mockResolvedValue({
-            id: "p1",
-            slug: "a",
-            latest_revision_id: "r1",
-            revision_ids: ["r1"],
-            title: "A",
-            content: "",
-            content_format: "markdown",
-            history_id: "h1",
-            create_time: "2026-05-20T00:00:00Z",
-            update_time: "2026-05-20T00:00:00Z",
-        });
-        await expect(resumeGalaxyPage("p1")).rejects.toThrow(
-            /bound to.*other\.example.*connected to.*galaxy\.example/,
-        );
-        expect(notebookWriter.writeNotebook).not.toHaveBeenCalled();
+    await expect(resumeGalaxyPage("p-other")).rejects.toThrow(/already bound to page p-mine/);
+    expect(notebookWriter.writeNotebook).not.toHaveBeenCalled();
+  });
+
+  it("throws on server-URL mismatch before writing", async () => {
+    const bound = [
+      "```loom-galaxy-page",
+      "page_id: p1",
+      "page_slug: a",
+      'galaxy_server_url: "https://other.example"',
+      "history_id: h1",
+      "last_synced_revision: r1",
+      "bound_at: 2026-05-20T10:00:00Z",
+      "```",
+      "",
+    ].join("\n");
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue(bound);
+    vi.mocked(pagesApi.getPage).mockResolvedValue({
+      id: "p1",
+      slug: "a",
+      latest_revision_id: "r1",
+      revision_ids: ["r1"],
+      title: "A",
+      content: "",
+      content_format: "markdown",
+      history_id: "h1",
+      create_time: "2026-05-20T00:00:00Z",
+      update_time: "2026-05-20T00:00:00Z",
+    });
+    await expect(resumeGalaxyPage("p1")).rejects.toThrow(
+      /bound to.*other\.example.*connected to.*galaxy\.example/,
+    );
+    expect(notebookWriter.writeNotebook).not.toHaveBeenCalled();
+  });
+
+  it("requires history_id when the page response doesn't carry one", async () => {
+    vi.mocked(notebookWriter.readNotebook).mockResolvedValue("# Template\n");
+    vi.mocked(pagesApi.getPage).mockResolvedValue({
+      id: "p20",
+      slug: "no-hist",
+      latest_revision_id: "r20",
+      revision_ids: ["r20"],
+      title: "NoHist",
+      content: "body",
+      content_format: "markdown",
+      create_time: "2026-05-20T00:00:00Z",
+      update_time: "2026-05-20T00:00:00Z",
     });
 
-    it("requires history_id when the page response doesn't carry one", async () => {
-        vi.mocked(notebookWriter.readNotebook).mockResolvedValue("# Template\n");
-        vi.mocked(pagesApi.getPage).mockResolvedValue({
-            id: "p20",
-            slug: "no-hist",
-            latest_revision_id: "r20",
-            revision_ids: ["r20"],
-            title: "NoHist",
-            content: "body",
-            content_format: "markdown",
-            create_time: "2026-05-20T00:00:00Z",
-            update_time: "2026-05-20T00:00:00Z",
-        });
-
-        await expect(resumeGalaxyPage("p20")).rejects.toThrow(/history_id/);
-    });
+    await expect(resumeGalaxyPage("p20")).rejects.toThrow(/history_id/);
+  });
 });


### PR DESCRIPTION
PR #114 wired up Loom <-> Galaxy Page sync (the `loom-galaxy-page` binding block,
the `/sync` command, and the push/pull/link tools) but deliberately left the page
*content* untransformed: push stripped the binding block and sent everything else
verbatim. So a synced page mirrored the notebook's raw markdown -- `loom-invocation`
blocks showed up as inert YAML fences instead of native Galaxy embeds, and pull had
no defined way to reconstruct them. This adds the content adapter #114 left as a
follow-up.

## What it does

`notebook.md` stays canonical; the Galaxy page is a faithful, reconstructable projection.

**Push** -- each `loom-invocation` block becomes:
- a hidden carrier holding the literal block (base64), and
- when the invocation id validates on the connected server, a visible Galaxy
  `invocation_outputs(invocation_id=...)` directive (inside a `galaxy` fenced block),
  so the page renders a real invocation embed.

Narrative (prose, plan sections, anchors, checkboxes, tables) passes through untouched.

**Pull / resume** -- restores the original `loom-invocation` fences from the carriers
(every field intact, including `notebook_anchor`, so no network re-derive) and strips
the directives, since Loom owns the projection and regenerates it on each push.

## Two things the live server decided for us

- **Directive ids are validated at store time.** An undecodable invocation id 400s the
  *entire* page, so the directive is gated -- emitted only when the id validates,
  otherwise just the carrier goes out (graceful degrade, never a 400).
- **The carrier is a link-reference definition, not an HTML comment.** HTML comments
  survive storage but Galaxy's renderer escapes them to *visible* text. A CommonMark
  reference definition (`[loom-invocation:v1]: #loom "<base64>"`) renders to nothing and
  is pure markdown, so the page stays clean while the carrier round-trips byte-for-byte.

## Verification

- Fixture tests both directions: round-trip identity, multiple blocks, narrative that
  happens to mention carrier syntax, the validated-vs-degraded rich push, and the wired
  push path through `pushNotebookToGalaxy`.
- Live against test.galaxyproject.org (Galaxy 26.1.rc1): the carrier round-trip (clean
  carrier-only page, byte-identical reconstruction) and the rendered output --
  `invocation_outputs` renders the outputs table and the carriers are invisible,
  confirmed on single- and multi-invocation pages.

Full test suite green; root and Orbit typechecks clean.

## Notes for review

- Two `chore: normalize ... to 2-space` commits are pure prettier/eslint reformatting of
  two files that predated the formatter -- split out so the behavioral diffs stay
  readable (the lint-staged hook reformats them on any touch anyway).
- Loom-canonical, single-server for now: the validator checks ids against the connected
  server (not a block's own `galaxy_server_url`), and pull stays remote-wins (the lossless
  round-trip removes the silent-corruption risk). Symmetric reconcile, a Galaxy-canonical
  mode, and richer directive coverage (datasets, workflows) are deferred.
