### PR TITLE
Support OpenAI-compatible custom LLM endpoints (with Jetstream preset)

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,21 +481,28 @@ Galaxy credentials can also be provided via environment variables (`GALAXY_URL`,
 
 ### Local LLMs
 
-Pi supports any OpenAI-compatible API. For [LiteLLM](https://litellm.ai/), [Ollama](https://ollama.com/), or other local backends:
+Loom works with any OpenAI-compatible API -- a hosted service like [Jetstream](https://docs.jetstream-cloud.org/inference-service/overview/), or a local backend like [LiteLLM](https://litellm.ai/) or [Ollama](https://ollama.com/).
+
+In **Orbit**, open Preferences, set the provider to **OpenAI-compatible endpoint**, enter the base URL + API key (or click the **Jetstream** preset), and pick a model. The key is stored encrypted.
+
+For the **CLI**, add a provider entry with a `baseUrl` to `~/.loom/config.json`:
 
 ```json
 {
   "llm": {
-    "provider": "litellm",
-    "apiKey": "your-key",
-    "model": "your-model-name"
+    "active": "openai-compatible",
+    "providers": {
+      "openai-compatible": {
+        "baseUrl": "http://localhost:4000/v1",
+        "model": "your-model-name",
+        "apiKey": "your-key"
+      }
+    }
   }
 }
 ```
 
-You'll also need `~/.pi/agent/models.json` for model capability metadata (context window, token limits) — see Pi's documentation. The Loom config handles provider selection and API keys; `models.json` handles model metadata Pi needs for request sizing.
-
-Or pass flags directly: `loom --provider litellm --model your-model-name`.
+The `baseUrl` marks the entry as a custom endpoint: Loom registers it with Pi for you (writing the matching `~/.pi/agent/models.json` entry, with sensible metadata defaults) and passes the key to Pi at runtime, so the key never lands in `models.json`. The provider name is yours to choose -- `"openai-compatible"` is just a convention.
 
 ## Local execution safety
 

--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -29,13 +29,20 @@ function buildSecretEnv(): Record<string, string> {
 
   const provider = cfg.llm?.active || "anthropic";
   const llmKey = resolveLlmApiKey(cfg);
+  const isCustom = Boolean(cfg.llm?.providers?.[provider]?.baseUrl);
   // OAuth providers ignore env-var keys -- the brain reads ~/.pi/agent/auth.json.
   // If the user switched away from an API-key provider the old key is still in
   // config.json (preserved on purpose so they can switch back); don't leak it
   // into the env under a misrouted variable name.
   if (llmKey && !OAUTH_PROVIDERS.has(provider)) {
-    const envVar = PROVIDER_ENV_MAP[provider] || "AI_GATEWAY_API_KEY";
-    env[envVar] = llmKey;
+    if (isCustom) {
+      // Custom OpenAI-compatible endpoint: the brain converts this into
+      // pi's --api-key (a built-in env var wouldn't map to the provider).
+      env.LOOM_ACTIVE_LLM_API_KEY = llmKey;
+    } else {
+      const envVar = PROVIDER_ENV_MAP[provider] || "AI_GATEWAY_API_KEY";
+      env[envVar] = llmKey;
+    }
   }
 
   const galaxyKey = resolveGalaxyApiKey(cfg);

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -298,8 +298,13 @@ export function registerIpcHandlers(agent: AgentManager): void {
 
   ipcMain.handle(
     "apiKey:validate",
-    async (_e, provider: string, key: string): Promise<{ valid: boolean; error?: string }> => {
-      return validateApiKey(provider, key);
+    async (
+      _e,
+      provider: string,
+      key: string,
+      baseUrl?: string,
+    ): Promise<{ valid: boolean; error?: string; models?: string[] }> => {
+      return validateApiKey(provider, key, baseUrl);
     },
   );
 
@@ -656,12 +661,37 @@ export function registerIpcHandlers(agent: AgentManager): void {
 async function validateApiKey(
   provider: string,
   key: string,
-): Promise<{ valid: boolean; error?: string }> {
+  baseUrl?: string,
+): Promise<{ valid: boolean; error?: string; models?: string[] }> {
   const trimmed = key.trim();
   if (!trimmed) return { valid: false, error: "Key is empty" };
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 5000);
   try {
+    if (baseUrl) {
+      const trimmedBase = baseUrl.trim().replace(/\/+$/, "");
+      if (!/^https?:\/\//.test(trimmedBase)) {
+        return { valid: false, error: "Base URL must start with http(s)://" };
+      }
+      const res = await fetch(`${trimmedBase}/models`, {
+        headers: { authorization: `Bearer ${trimmed}` },
+        signal: controller.signal,
+      });
+      if (res.status === 401) return { valid: false, error: "Invalid API key (401)" };
+      if (!res.ok) return { valid: false, error: `Unexpected response: HTTP ${res.status}` };
+      try {
+        const body = (await res.json()) as { data?: unknown };
+        const raw = body.data;
+        const models = Array.isArray(raw)
+          ? raw
+              .map((m) => (m && typeof m === "object" ? (m as { id?: unknown }).id : undefined))
+              .filter((id): id is string => typeof id === "string")
+          : [];
+        return { valid: true, models };
+      } catch {
+        return { valid: true };
+      }
+    }
     if (provider === "anthropic") {
       if (!trimmed.startsWith("sk-ant-")) {
         return { valid: false, error: "Anthropic keys start with sk-ant-" };

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -28,7 +28,7 @@ export const UNCHANGED_SECRET = "__loom_unchanged_secret__";
 interface MaskedLoomConfig extends Omit<LoomConfig, "llm" | "galaxy"> {
   llm?: {
     active: string;
-    providers: Record<string, { model?: string; hasApiKey: boolean }>;
+    providers: Record<string, { model?: string; baseUrl?: string; hasApiKey: boolean }>;
   };
   galaxy?: {
     active: string | null;
@@ -47,6 +47,7 @@ function maskConfig(cfg: LoomConfig): MaskedLoomConfig {
           k,
           {
             model: v.model,
+            baseUrl: v.baseUrl,
             // OAuth providers authenticate via ~/.pi/agent/auth.json -- an
             // orphan apiKey on the entry (manual edit, or the legacy-shape
             // migrator) is dead weight, not a real credential. Don't surface
@@ -91,7 +92,7 @@ function reconcileIncomingConfig(incoming: Record<string, unknown>): LoomConfig 
   // LLM multi-provider reconciliation. The renderer sends:
   //   { active, providers: { [name]: { apiKey?, model? } } }
   // where apiKey may be UNCHANGED_SECRET (preserve), "" (clear), or a new value.
-  type IncomingProvider = { apiKey?: string; model?: string };
+  type IncomingProvider = { apiKey?: string; model?: string; baseUrl?: string };
   type IncomingLlm = { active?: string; providers?: Record<string, IncomingProvider> };
   const incomingLlm = (incoming as { llm?: IncomingLlm }).llm;
   if (incomingLlm) {
@@ -103,11 +104,14 @@ function reconcileIncomingConfig(incoming: Record<string, unknown>): LoomConfig 
     for (const [name, p] of Object.entries(incomingLlm.providers ?? {})) {
       const existing = current.llm?.providers?.[name];
       const rawKey = p.apiKey;
-      const entry: { apiKey?: string; apiKeyEncrypted?: string; model?: string } = {};
+      const entry: { apiKey?: string; apiKeyEncrypted?: string; model?: string; baseUrl?: string } =
+        {};
       // Preserve existing model if the incoming entry doesn't carry one --
       // a partial save (e.g. rotate-just-the-key) shouldn't wipe the model.
       if (p.model !== undefined) entry.model = p.model;
       else if (existing?.model) entry.model = existing.model;
+      if (p.baseUrl !== undefined) entry.baseUrl = p.baseUrl;
+      else if (existing?.baseUrl) entry.baseUrl = existing.baseUrl;
       if (rawKey === UNCHANGED_SECRET || rawKey === undefined) {
         if (existing?.apiKeyEncrypted) entry.apiKeyEncrypted = existing.apiKeyEncrypted;
         else if (existing?.apiKey) entry.apiKey = existing.apiKey;

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -74,7 +74,11 @@ export interface OrbitAPI {
   setBypassPermissions(
     enabled: boolean,
   ): Promise<{ ok: boolean; enabled: boolean; cancelled?: boolean }>;
-  validateApiKey(provider: string, key: string): Promise<{ valid: boolean; error?: string }>;
+  validateApiKey(
+    provider: string,
+    key: string,
+    baseUrl?: string,
+  ): Promise<{ valid: boolean; error?: string; models?: string[] }>;
   oauthStatus(
     provider: string,
   ): Promise<{ signedIn: boolean; expiresInSeconds?: number; accountId?: string }>;
@@ -168,7 +172,8 @@ const api: OrbitAPI = {
   getConfig: () => ipcRenderer.invoke("config:get"),
   saveConfig: (config) => ipcRenderer.invoke("config:save", config),
   setBypassPermissions: (enabled) => ipcRenderer.invoke("guardian:set-bypass", enabled),
-  validateApiKey: (provider, key) => ipcRenderer.invoke("apiKey:validate", provider, key),
+  validateApiKey: (provider, key, baseUrl) =>
+    ipcRenderer.invoke("apiKey:validate", provider, key, baseUrl),
   oauthStatus: (provider) => ipcRenderer.invoke("oauth:status", provider),
   oauthSignIn: (provider) => ipcRenderer.invoke("oauth:sign-in", provider),
   oauthSignOut: (provider) => ipcRenderer.invoke("oauth:sign-out", provider),

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -590,6 +590,8 @@ function wireApiKeyValidation(
   providerEl: HTMLSelectElement,
   keyEl: HTMLInputElement,
   statusEl: HTMLElement,
+  baseUrlEl?: HTMLInputElement,
+  modelEl?: HTMLSelectElement,
 ): void {
   let timer: ReturnType<typeof setTimeout> | null = null;
   let seq = 0;
@@ -600,6 +602,7 @@ function wireApiKeyValidation(
   const validateNow = async () => {
     const provider = providerEl.value;
     const key = keyEl.value.trim();
+    const baseUrl = baseUrlEl?.value.trim() || undefined;
     if (!key) {
       setStatus("", "");
       return;
@@ -607,10 +610,22 @@ function wireApiKeyValidation(
     const mySeq = ++seq;
     setStatus("checking", "Checking…");
     try {
-      const res = await window.orbit.validateApiKey(provider, key);
-      if (mySeq !== seq) return; // a newer request superseded this one
-      if (res.valid) setStatus("valid", "\u2713 Valid");
-      else setStatus("invalid", `\u2717 ${res.error || "Invalid"}`);
+      const res = await window.orbit.validateApiKey(provider, key, baseUrl);
+      if (mySeq !== seq) return;
+      if (res.valid) {
+        setStatus("valid", "\u2713 Valid");
+        if (modelEl && res.models && res.models.length > 0) {
+          const selected = modelEl.value;
+          modelEl.innerHTML = "";
+          for (const id of res.models) {
+            const opt = document.createElement("option");
+            opt.value = id;
+            opt.textContent = id;
+            if (id === selected) opt.selected = true;
+            modelEl.appendChild(opt);
+          }
+        }
+      } else setStatus("invalid", `\u2717 ${res.error || "Invalid"}`);
     } catch (err) {
       if (mySeq !== seq) return;
       setStatus("invalid", `\u2717 ${err instanceof Error ? err.message : String(err)}`);
@@ -622,6 +637,7 @@ function wireApiKeyValidation(
   };
   keyEl.addEventListener("input", schedule);
   providerEl.addEventListener("change", schedule);
+  baseUrlEl?.addEventListener("input", schedule);
 }
 
 function populateWelcomeModels(provider: string): void {
@@ -2606,6 +2622,13 @@ const prefsOauthHintRow = document.getElementById("prefs-oauth-hint-row")!;
 const prefsOauthStatus = document.getElementById("prefs-oauth-status")!;
 const prefsOauthSignIn = document.getElementById("prefs-oauth-signin") as HTMLButtonElement;
 const prefsOauthSignOut = document.getElementById("prefs-oauth-signout") as HTMLButtonElement;
+const prefsBaseUrlRow = document.getElementById("prefs-base-url-row")!;
+const prefsBaseUrl = document.getElementById("prefs-base-url") as HTMLInputElement;
+const prefsJetstreamPreset = document.getElementById("prefs-jetstream-preset") as HTMLButtonElement;
+
+/** Jetstream's public, key-reachable proxy + the models it serves. */
+const JETSTREAM_BASE_URL = "https://llm.jetstream-cloud.org/api";
+const JETSTREAM_MODELS = ["gpt-oss-120b", "llama-4-scout"];
 
 // Model catalog by provider — labels include cost guidance
 // (in/out price per 1M tokens). Fallback only — populateDynamicModelData()
@@ -2659,6 +2682,7 @@ let MODELS_BY_PROVIDER: Record<string, ModelChoice[]> = {
     { id: "qwen3-coder:30b", label: "Qwen3-Coder 30B (local, A5000) — free" },
     { id: "qwen3:8b", label: "Qwen3 8B (local, fast) — free" },
   ],
+  "openai-compatible": [],
 };
 
 function populateModels(provider: string, selected?: string): void {
@@ -2688,7 +2712,19 @@ prefsProvider.addEventListener("change", () => {
   loadProviderFields(prefsActiveProvider);
   void updatePrefsAuthUi();
 });
-wireApiKeyValidation(prefsProvider, prefsApiKey, prefsApiKeyStatus);
+wireApiKeyValidation(prefsProvider, prefsApiKey, prefsApiKeyStatus, prefsBaseUrl, prefsModel);
+prefsJetstreamPreset.addEventListener("click", () => {
+  prefsBaseUrl.value = JETSTREAM_BASE_URL;
+  prefsModel.innerHTML = "";
+  for (const id of JETSTREAM_MODELS) {
+    const opt = document.createElement("option");
+    opt.value = id;
+    opt.textContent = id;
+    prefsModel.appendChild(opt);
+  }
+  // Trigger validation/discovery if a key is already entered.
+  prefsBaseUrl.dispatchEvent(new Event("input"));
+});
 // Clear the "✓ Key stored" indicator as soon as the user starts typing.
 prefsApiKey.addEventListener("input", () => {
   if (prefsApiKeyStatus.classList.contains("stored")) {
@@ -2699,6 +2735,8 @@ prefsApiKey.addEventListener("input", () => {
 
 async function updatePrefsAuthUi(): Promise<void> {
   const oauth = isOAuthProvider(prefsProvider.value);
+  const custom = prefsProvider.value === "openai-compatible";
+  prefsBaseUrlRow.classList.toggle("hidden", !custom);
   prefsApiKeyRow.classList.toggle("hidden", oauth);
   prefsApiKeyHintRow.classList.toggle("hidden", oauth);
   prefsOauthRow.classList.toggle("hidden", !oauth);
@@ -2845,6 +2883,7 @@ interface ProviderState {
   hadKey: boolean;
   typedKey: string;
   model: string;
+  baseUrl: string;
 }
 let prefsProviderStates: Record<string, ProviderState> = {};
 let prefsActiveProvider = "anthropic";
@@ -2871,14 +2910,21 @@ function snapshotCurrentProvider(): void {
     hadKey: prefsProviderStates[prefsActiveProvider]?.hadKey ?? false,
     typedKey: prefsApiKey.value,
     model: prefsModel.value,
+    baseUrl: prefsBaseUrl.value.trim(),
   };
 }
 
 /** Load a provider's stored state into the visible fields. */
 function loadProviderFields(provider: string): void {
-  const state = prefsProviderStates[provider] ?? { hadKey: false, typedKey: "", model: "" };
+  const state = prefsProviderStates[provider] ?? {
+    hadKey: false,
+    typedKey: "",
+    model: "",
+    baseUrl: "",
+  };
   populateModels(provider, state.model || undefined);
   prefsApiKey.value = state.typedKey;
+  prefsBaseUrl.value = state.baseUrl;
   prefsApiKey.placeholder = state.hadKey ? "leave blank to keep existing key" : "";
   if (state.hadKey && !state.typedKey) {
     prefsApiKeyStatus.className = "api-key-status stored";
@@ -2894,7 +2940,7 @@ async function openPreferences(): Promise<void> {
   const config = (await window.orbit.getConfig()) as {
     llm?: {
       active?: string;
-      providers?: Record<string, { model?: string; hasApiKey?: boolean }>;
+      providers?: Record<string, { model?: string; baseUrl?: string; hasApiKey?: boolean }>;
     };
     galaxy?: {
       active: string | null;
@@ -2913,6 +2959,7 @@ async function openPreferences(): Promise<void> {
       hadKey: Boolean(p.hasApiKey),
       typedKey: "",
       model: p.model ?? "",
+      baseUrl: p.baseUrl ?? "",
     };
   }
   prefsActiveProvider = config.llm?.active || "anthropic";
@@ -2978,6 +3025,7 @@ async function savePreferences(): Promise<void> {
     hadKey: false,
     typedKey: "",
     model: "",
+    baseUrl: "",
   };
   const typedApiKey = prefsApiKey.value.trim();
   const llmApiKey = typedApiKey ? typedApiKey : activeState.hadKey ? UNCHANGED_SECRET : "";
@@ -3003,9 +3051,12 @@ async function savePreferences(): Promise<void> {
   // credentials in ~/.pi/agent/auth.json -- don't ship an apiKey field (sentinel
   // or "") for them, or the reconciler would try to preserve/clear a
   // config.json key that was never there.
-  const providers: Record<string, { apiKey?: string; model?: string }> = {};
+  const providers: Record<string, { apiKey?: string; model?: string; baseUrl?: string }> = {};
   for (const [name, state] of Object.entries(prefsProviderStates)) {
-    const entry: { apiKey?: string; model?: string } = { model: state.model || undefined };
+    const entry: { apiKey?: string; model?: string; baseUrl?: string } = {
+      model: state.model || undefined,
+    };
+    if (state.baseUrl) entry.baseUrl = state.baseUrl;
     if (!isOAuthProvider(name)) {
       entry.apiKey = state.typedKey.trim()
         ? state.typedKey.trim()
@@ -3017,7 +3068,10 @@ async function savePreferences(): Promise<void> {
   }
   // Override the active provider with the resolved current-screen values
   // (covers the brand-new-provider case too).
-  const activeEntry: { apiKey?: string; model?: string } = { model: selectedModel };
+  const activeEntry: { apiKey?: string; model?: string; baseUrl?: string } = {
+    model: selectedModel,
+  };
+  if (prefsBaseUrl.value.trim()) activeEntry.baseUrl = prefsBaseUrl.value.trim();
   if (!isOAuthProvider(activeProvider)) activeEntry.apiKey = llmApiKey;
   providers[activeProvider] = activeEntry;
 

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -548,6 +548,16 @@ const welcomeModel = document.getElementById("welcome-model") as HTMLSelectEleme
 const welcomeApiKey = document.getElementById("welcome-api-key") as HTMLInputElement;
 const welcomeApiKeyStatus = document.getElementById("welcome-api-key-status")!;
 const welcomeApiKeyRow = document.getElementById("welcome-api-key-row")!;
+const welcomeBaseUrlRow = document.getElementById("welcome-base-url-row")!;
+const welcomeBaseUrl = document.getElementById("welcome-base-url") as HTMLInputElement;
+const welcomeJetstreamPreset = document.getElementById(
+  "welcome-jetstream-preset",
+) as HTMLButtonElement;
+
+/** Jetstream's public, key-reachable proxy + the models it serves. Shared by the welcome screen and Preferences. */
+const JETSTREAM_BASE_URL = "https://llm.jetstream-cloud.org/api";
+const JETSTREAM_MODELS = ["gpt-oss-120b", "llama-4-scout"];
+
 const welcomeApiKeyHintRow = document.getElementById("welcome-api-key-hint-row")!;
 const welcomeOauthRow = document.getElementById("welcome-oauth-row")!;
 const welcomeOauthHintRow = document.getElementById("welcome-oauth-hint-row")!;
@@ -654,10 +664,30 @@ welcomeProvider.addEventListener("change", () => {
   populateWelcomeModels(welcomeProvider.value);
   void updateWelcomeAuthUi();
 });
-wireApiKeyValidation(welcomeProvider, welcomeApiKey, welcomeApiKeyStatus);
+wireApiKeyValidation(
+  welcomeProvider,
+  welcomeApiKey,
+  welcomeApiKeyStatus,
+  welcomeBaseUrl,
+  welcomeModel,
+);
+
+welcomeJetstreamPreset.addEventListener("click", () => {
+  welcomeBaseUrl.value = JETSTREAM_BASE_URL;
+  welcomeModel.innerHTML = "";
+  for (const id of JETSTREAM_MODELS) {
+    const opt = document.createElement("option");
+    opt.value = id;
+    opt.textContent = id;
+    welcomeModel.appendChild(opt);
+  }
+  welcomeBaseUrl.dispatchEvent(new Event("input"));
+});
 
 async function updateWelcomeAuthUi(): Promise<void> {
   const oauth = isOAuthProvider(welcomeProvider.value);
+  const custom = welcomeProvider.value === "openai-compatible";
+  welcomeBaseUrlRow.classList.toggle("hidden", !custom);
   welcomeApiKeyRow.classList.toggle("hidden", oauth);
   welcomeApiKeyHintRow.classList.toggle("hidden", oauth);
   welcomeOauthRow.classList.toggle("hidden", !oauth);
@@ -702,6 +732,11 @@ welcomeSave.addEventListener("click", async () => {
     welcomeError.textContent = "API key is required";
     return;
   }
+  const custom = welcomeProvider.value === "openai-compatible";
+  if (custom && !welcomeBaseUrl.value.trim()) {
+    welcomeError.textContent = "Enter a base URL (or use the Jetstream preset).";
+    return;
+  }
   if (oauth) {
     const status = await window.orbit.oauthStatus(welcomeProvider.value);
     if (!status.signedIn) {
@@ -724,8 +759,9 @@ welcomeSave.addEventListener("click", async () => {
   // OAuth providers persist their credential in ~/.pi/agent/auth.json (written
   // by the sign-in flow above), not in config.json. Skip writing apiKey for
   // those so a leftover plaintext field doesn't shadow the real auth path.
-  const providerEntry: Record<string, unknown> = { model: welcomeModel.value };
+  const providerEntry: Record<string, unknown> = { model: welcomeModel.value || undefined };
   if (!oauth) providerEntry.apiKey = apiKey;
+  if (welcomeBaseUrl.value.trim()) providerEntry.baseUrl = welcomeBaseUrl.value.trim();
   const cfg: Record<string, unknown> = {
     llm: {
       active: welcomeProvider.value,
@@ -2625,10 +2661,6 @@ const prefsOauthSignOut = document.getElementById("prefs-oauth-signout") as HTML
 const prefsBaseUrlRow = document.getElementById("prefs-base-url-row")!;
 const prefsBaseUrl = document.getElementById("prefs-base-url") as HTMLInputElement;
 const prefsJetstreamPreset = document.getElementById("prefs-jetstream-preset") as HTMLButtonElement;
-
-/** Jetstream's public, key-reachable proxy + the models it serves. */
-const JETSTREAM_BASE_URL = "https://llm.jetstream-cloud.org/api";
-const JETSTREAM_MODELS = ["gpt-oss-120b", "llama-4-scout"];
 
 // Model catalog by provider — labels include cost guidance
 // (in/out price per 1M tokens). Fallback only — populateDynamicModelData()

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -609,11 +609,30 @@
                 <option value="xai">xAI</option>
                 <option value="deepseek">DeepSeek</option>
                 <option value="ollama">Ollama (local)</option>
+                <option value="openai-compatible">OpenAI-compatible endpoint</option>
               </select>
             </div>
             <div class="prefs-row">
               <label for="welcome-model">Model</label>
               <select id="welcome-model"></select>
+            </div>
+            <div class="prefs-row hidden" id="welcome-base-url-row">
+              <label for="welcome-base-url">Base URL</label>
+              <div class="prefs-row-with-btn">
+                <input
+                  id="welcome-base-url"
+                  type="text"
+                  placeholder="https://host/v1 (OpenAI-compatible)"
+                />
+                <button
+                  id="welcome-jetstream-preset"
+                  class="plan-btn"
+                  type="button"
+                  title="Fill Jetstream defaults"
+                >
+                  Jetstream
+                </button>
+              </div>
             </div>
             <div class="prefs-row" id="welcome-api-key-row">
               <label for="welcome-api-key">API Key</label>

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -408,6 +408,7 @@
                 <option value="xai">xAI</option>
                 <option value="deepseek">DeepSeek</option>
                 <option value="ollama">Ollama (local)</option>
+                <option value="openai-compatible">OpenAI-compatible endpoint</option>
               </select>
             </div>
             <div class="prefs-row">
@@ -422,6 +423,24 @@
                 execution; reach for flagship (Opus / o1 class) only when you hit complex reasoning.
                 Prices in the dropdown are per 1M tokens (input/output).
               </span>
+            </div>
+            <div class="prefs-row hidden" id="prefs-base-url-row">
+              <label for="prefs-base-url">Base URL</label>
+              <div class="prefs-row-with-btn">
+                <input
+                  id="prefs-base-url"
+                  type="text"
+                  placeholder="https://host/v1 (OpenAI-compatible)"
+                />
+                <button
+                  id="prefs-jetstream-preset"
+                  class="plan-btn"
+                  type="button"
+                  title="Fill Jetstream defaults"
+                >
+                  Jetstream
+                </button>
+              </div>
             </div>
             <div class="prefs-row" id="prefs-api-key-row">
               <label for="prefs-api-key">API Key</label>

--- a/bin/loom.js
+++ b/bin/loom.js
@@ -12,6 +12,11 @@ import {
 import { spawn } from "child_process";
 import { getLoomVersion, detectInstall } from "./update-check.js";
 import { pickChannel } from "../shared/version-compare.js";
+import {
+  isCustomProvider,
+  syncCustomProviderModelsFile,
+  resolveActiveLlmApiKey,
+} from "../shared/custom-provider.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -171,6 +176,11 @@ function readAuthJson() {
 // provider's env var (encrypted config keys aren't decryptable outside Orbit).
 function activeProviderUsable(provider, entry, auth) {
   if (OAUTH_PROVIDERS.has(provider)) return Boolean(auth[provider]);
+  // Custom OpenAI-compatible providers resolve their key from the injected
+  // env var (Orbit) or a plaintext config key (CLI) -- same logic as
+  // checkLLMProvider. Without this, a keyless-on-disk custom provider looks
+  // unusable and the reconciler could silently switch llm.active away from it.
+  if (isCustomProvider(entry)) return Boolean(resolveActiveLlmApiKey(entry, process.env));
   if (entry?.apiKey) return true;
   const envVar = PROVIDER_ENV_MAP[provider];
   return Boolean(envVar && process.env[envVar]);
@@ -209,10 +219,25 @@ reconcileActiveProviderWithAuth();
 // ~/.pi/agent/auth.json anyway.
 const activeLlmProvider = loomConfig.llm?.active;
 const activeLlmConfig = activeLlmProvider ? loomConfig.llm?.providers?.[activeLlmProvider] : null;
-if (activeLlmConfig?.apiKey && !OAUTH_PROVIDERS.has(activeLlmProvider)) {
+if (
+  activeLlmConfig?.apiKey &&
+  !OAUTH_PROVIDERS.has(activeLlmProvider) &&
+  !isCustomProvider(activeLlmConfig)
+) {
   const envVar = PROVIDER_ENV_MAP[activeLlmProvider] || "AI_GATEWAY_API_KEY";
   if (!process.env[envVar]) {
     process.env[envVar] = activeLlmConfig.apiKey;
+  }
+}
+
+// Custom OpenAI-compatible provider: register it in ~/.pi/agent/models.json so
+// pi can resolve --provider/--model. The key is NOT written here; it's supplied
+// at runtime via --api-key below.
+if (!isInformationalCommand && activeLlmProvider && isCustomProvider(activeLlmConfig)) {
+  try {
+    syncCustomProviderModelsFile(join(agentDir, "models.json"), activeLlmProvider, activeLlmConfig);
+  } catch (err) {
+    console.error(`loom: failed to sync custom provider into models.json: ${err}`);
   }
 }
 
@@ -379,6 +404,12 @@ or unset the active provider in ~/.loom/config.json.
     process.exit(1);
   }
 
+  // Custom OpenAI-compatible provider: usable when a key is resolvable from the
+  // injected env var (Orbit) or a plaintext config key (standalone CLI).
+  if (isCustomProvider(activeLlmConfig) && resolveActiveLlmApiKey(activeLlmConfig, process.env)) {
+    return;
+  }
+
   // Consolidated config has an API key (non-OAuth providers only)
   if (activeLlmConfig?.apiKey) return;
 
@@ -488,6 +519,12 @@ if (!hasArg("--provider")) {
     ) {
       providerArgs.push("--model", activeLlmConfig.model);
     }
+    // Custom endpoints have no built-in key resolution; hand pi the key at
+    // runtime so it stays in memory (setRuntimeApiKey) rather than on disk.
+    if (isCustomProvider(activeLlmConfig) && !hasArg("--api-key")) {
+      const key = resolveActiveLlmApiKey(activeLlmConfig, process.env);
+      if (key) providerArgs.push("--api-key", key);
+    }
   } else {
     // Fall back to legacy models.json
     const modelsPath = join(agentDir, "models.json");
@@ -522,7 +559,6 @@ const args = [
   ...providerArgs,
   ...userArgs,
 ];
-
 if (await handleInformationalCommand()) {
   process.exit(0);
 }

--- a/shared/custom-provider.d.ts
+++ b/shared/custom-provider.d.ts
@@ -1,0 +1,35 @@
+import type { LlmProviderConfig } from "./loom-config.js";
+
+export interface CustomModelDef {
+  id: string;
+  name: string;
+  reasoning: boolean;
+  input: ("text" | "image")[];
+  contextWindow: number;
+  maxTokens: number;
+  cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
+}
+
+export interface ModelsConfig {
+  providers?: Record<
+    string,
+    { name?: string; baseUrl?: string; api?: string; apiKey?: string; models?: unknown[] }
+  >;
+}
+
+export function isCustomProvider(entry: LlmProviderConfig | undefined): boolean;
+export function synthesizeModelDef(entry: LlmProviderConfig): CustomModelDef;
+export function mergeCustomProviderIntoModelsConfig(
+  modelsConfig: ModelsConfig,
+  providerName: string,
+  entry: LlmProviderConfig,
+): ModelsConfig;
+export function syncCustomProviderModelsFile(
+  modelsJsonPath: string,
+  providerName: string,
+  entry: LlmProviderConfig,
+): ModelsConfig;
+export function resolveActiveLlmApiKey(
+  entry: LlmProviderConfig | undefined,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>,
+): string | undefined;

--- a/shared/custom-provider.d.ts
+++ b/shared/custom-provider.d.ts
@@ -17,6 +17,7 @@ export interface ModelsConfig {
   >;
 }
 
+export const ACTIVE_LLM_API_KEY_ENV: "LOOM_ACTIVE_LLM_API_KEY";
 export function isCustomProvider(entry: LlmProviderConfig | undefined): boolean;
 export function synthesizeModelDef(entry: LlmProviderConfig): CustomModelDef;
 export function mergeCustomProviderIntoModelsConfig(

--- a/shared/custom-provider.js
+++ b/shared/custom-provider.js
@@ -31,10 +31,23 @@ export function synthesizeModelDef(entry) {
 }
 
 /**
+ * Name of the env var Orbit injects with the decrypted active-LLM key. We write
+ * this *name* (not the secret) into the synthesized models.json apiKey field.
+ */
+export const ACTIVE_LLM_API_KEY_ENV = "LOOM_ACTIVE_LLM_API_KEY";
+
+/**
  * Return a NEW models.json config with the custom provider upserted. Other
- * providers are preserved untouched. The provider entry deliberately omits
- * apiKey -- the key is injected at runtime via pi's --api-key flag so it never
- * lands on disk in plaintext.
+ * providers are preserved untouched.
+ *
+ * The apiKey field is set to the *name* of the env var Orbit injects, never the
+ * secret itself. pi's ModelRegistry rejects any custom (non-built-in) provider
+ * that defines models without an apiKey and drops the whole provider, so
+ * omitting it makes `--provider/--model` fail to resolve and the brain won't
+ * launch. pi resolves a bare apiKey string as an env-var lookup at request
+ * time, so the real key is read from LOOM_ACTIVE_LLM_API_KEY in memory and
+ * still never lands on disk. (The runtime --api-key flag, when passed, takes
+ * precedence over this.)
  */
 export function mergeCustomProviderIntoModelsConfig(modelsConfig, providerName, entry) {
   const providers = { ...((modelsConfig && modelsConfig.providers) || {}) };
@@ -42,6 +55,7 @@ export function mergeCustomProviderIntoModelsConfig(modelsConfig, providerName, 
     name: providerName,
     baseUrl: entry.baseUrl,
     api: "openai-completions",
+    apiKey: ACTIVE_LLM_API_KEY_ENV,
     models: [synthesizeModelDef(entry)],
   };
   return { ...modelsConfig, providers };
@@ -82,5 +96,5 @@ export function syncCustomProviderModelsFile(modelsJsonPath, providerName, entry
  * plaintext apiKey on the entry. Returns undefined when neither is present.
  */
 export function resolveActiveLlmApiKey(entry, env) {
-  return (env && env.LOOM_ACTIVE_LLM_API_KEY) || (entry && entry.apiKey);
+  return (env && env[ACTIVE_LLM_API_KEY_ENV]) || (entry && entry.apiKey);
 }

--- a/shared/custom-provider.js
+++ b/shared/custom-provider.js
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * A provider entry is "custom" (an OpenAI-compatible endpoint) when it carries
+ * a non-empty baseUrl. That single field is the discriminator everywhere.
+ */
+export function isCustomProvider(entry) {
+  return Boolean(entry && entry.baseUrl);
+}
+
+/**
+ * Build a permissive openai-completions model def from just a model id. Cost is
+ * zeroed (custom endpoints are typically free/self-hosted) and the context
+ * window mirrors the defaults used for the existing local litellm setup. The
+ * model is registered for selection; the key is supplied separately at runtime.
+ */
+export function synthesizeModelDef(entry) {
+  if (!entry.model) {
+    throw new Error("custom provider entry requires a model id to synthesize a model def");
+  }
+  return {
+    id: entry.model,
+    name: entry.model,
+    reasoning: false,
+    input: ["text"],
+    contextWindow: 128000,
+    maxTokens: 16384,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  };
+}
+
+/**
+ * Return a NEW models.json config with the custom provider upserted. Other
+ * providers are preserved untouched. The provider entry deliberately omits
+ * apiKey -- the key is injected at runtime via pi's --api-key flag so it never
+ * lands on disk in plaintext.
+ */
+export function mergeCustomProviderIntoModelsConfig(modelsConfig, providerName, entry) {
+  const providers = { ...((modelsConfig && modelsConfig.providers) || {}) };
+  providers[providerName] = {
+    name: providerName,
+    baseUrl: entry.baseUrl,
+    api: "openai-completions",
+    models: [synthesizeModelDef(entry)],
+  };
+  return { ...modelsConfig, providers };
+}
+
+/**
+ * Read models.json (if present), upsert the custom provider, write it back with
+ * mode 0600. Best-effort: a malformed existing file is treated as empty rather
+ * than throwing, matching how bin/loom.js already tolerates models.json.
+ */
+export function syncCustomProviderModelsFile(modelsJsonPath, providerName, entry) {
+  let current = {};
+  try {
+    if (fs.existsSync(modelsJsonPath)) {
+      current = JSON.parse(fs.readFileSync(modelsJsonPath, "utf-8")) || {};
+    }
+  } catch {
+    current = {};
+  }
+  const merged = mergeCustomProviderIntoModelsConfig(current, providerName, entry);
+  fs.mkdirSync(path.dirname(modelsJsonPath), { recursive: true });
+  // Plain write + chmod (not tmp+rename) mirrors how bin/loom.js writes
+  // mcp.json: this file is regenerated on every launch, so a torn write is
+  // self-healing. chmod runs after the write because writeFileSync's mode
+  // option only applies when the file is first created.
+  fs.writeFileSync(modelsJsonPath, JSON.stringify(merged, null, 2), { mode: 0o600 });
+  try {
+    fs.chmodSync(modelsJsonPath, 0o600);
+  } catch {
+    /* best-effort */
+  }
+  return merged;
+}
+
+/**
+ * Resolve the API key for a custom provider at runtime. Orbit injects the
+ * decrypted key via LOOM_ACTIVE_LLM_API_KEY; the standalone CLI uses the
+ * plaintext apiKey on the entry. Returns undefined when neither is present.
+ */
+export function resolveActiveLlmApiKey(entry, env) {
+  return (env && env.LOOM_ACTIVE_LLM_API_KEY) || (entry && entry.apiKey);
+}

--- a/shared/loom-config.d.ts
+++ b/shared/loom-config.d.ts
@@ -5,6 +5,12 @@ export interface LlmProviderConfig {
   /** Base64 ciphertext produced by Electron safeStorage. Orbit-only. */
   apiKeyEncrypted?: string;
   model?: string;
+  /**
+   * Base URL for an OpenAI-compatible endpoint (e.g. Jetstream, vLLM, Ollama).
+   * Presence marks this entry as a custom provider: the brain registers it in
+   * ~/.pi/agent/models.json and supplies the key at runtime via --api-key.
+   */
+  baseUrl?: string;
 }
 
 export interface LoomConfig {

--- a/tests/custom-provider.test.ts
+++ b/tests/custom-provider.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import { ModelRegistry, AuthStorage } from "@earendil-works/pi-coding-agent";
 import {
+  ACTIVE_LLM_API_KEY_ENV,
   isCustomProvider,
   synthesizeModelDef,
   mergeCustomProviderIntoModelsConfig,
@@ -53,9 +55,10 @@ describe("mergeCustomProviderIntoModelsConfig", () => {
     });
     // other providers preserved untouched
     expect(merged.providers.litellm).toEqual(existing.providers.litellm);
-    // new provider is keyless
+    // new provider carries the env-var NAME as apiKey (so pi accepts it), never
+    // a secret -- the real key is resolved from the env var at request time.
     const p = merged.providers["openai-compatible"];
-    expect(p.apiKey).toBeUndefined();
+    expect(p.apiKey).toBe(ACTIVE_LLM_API_KEY_ENV);
     expect(p.baseUrl).toBe("https://llm.jetstream-cloud.org/api");
     expect(p.api).toBe("openai-completions");
     expect(p.models[0].id).toBe("gpt-oss-120b");
@@ -90,7 +93,7 @@ describe("syncCustomProviderModelsFile", () => {
     expect(fs.existsSync(file)).toBe(true);
     const parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
     expect(parsed.providers["openai-compatible"].baseUrl).toBe("https://x/api");
-    expect(parsed.providers["openai-compatible"].apiKey).toBeUndefined();
+    expect(parsed.providers["openai-compatible"].apiKey).toBe(ACTIVE_LLM_API_KEY_ENV);
     // 0600 on POSIX
     if (process.platform !== "win32") {
       expect(fs.statSync(file).mode & 0o777).toBe(0o600);
@@ -114,6 +117,37 @@ describe("syncCustomProviderModelsFile", () => {
     const parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
     expect(parsed.providers.litellm.apiKey).toBe("x");
     expect(parsed.providers["openai-compatible"].baseUrl).toBe("https://x/api");
+  });
+});
+
+describe("synthesized models.json loads through pi's ModelRegistry", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "loom-cp-reg-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  // Regression for the keyless entry: pi's ModelRegistry rejects a custom
+  // provider that defines models without an apiKey and drops it, so the brain
+  // couldn't resolve --provider/--model and never launched. The synthesized
+  // entry must register cleanly while keeping the real key off disk.
+  it("registers the custom model without writing the secret to disk", () => {
+    const file = path.join(dir, "models.json");
+    syncCustomProviderModelsFile(file, "openai-compatible", {
+      baseUrl: "https://llm.jetstream-cloud.org/api",
+      model: "gpt-oss-120b",
+      apiKey: "super-secret-should-never-be-written",
+    });
+
+    // the real key never lands on disk
+    expect(fs.readFileSync(file, "utf-8")).not.toContain("super-secret");
+
+    // pi accepts the config (no load error) and the model resolves
+    const reg = ModelRegistry.create(AuthStorage.inMemory(), file);
+    expect(reg.getError()).toBeUndefined();
+    expect(reg.find("openai-compatible", "gpt-oss-120b")).toBeDefined();
   });
 });
 

--- a/tests/custom-provider.test.ts
+++ b/tests/custom-provider.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import {
+  isCustomProvider,
+  synthesizeModelDef,
+  mergeCustomProviderIntoModelsConfig,
+  syncCustomProviderModelsFile,
+  resolveActiveLlmApiKey,
+} from "../shared/custom-provider.js";
+
+describe("isCustomProvider", () => {
+  it("is true only when baseUrl is set", () => {
+    expect(isCustomProvider({ baseUrl: "https://x/api" })).toBe(true);
+    expect(isCustomProvider({ apiKey: "k" })).toBe(false);
+    expect(isCustomProvider(undefined)).toBe(false);
+    expect(isCustomProvider({ baseUrl: "" })).toBe(false);
+  });
+});
+
+describe("synthesizeModelDef", () => {
+  it("builds an openai-completions model def from the model id with zero cost", () => {
+    const def = synthesizeModelDef({ baseUrl: "https://x/api", model: "gpt-oss-120b" });
+    expect(def.id).toBe("gpt-oss-120b");
+    expect(def.name).toBe("gpt-oss-120b");
+    expect(def.input).toEqual(["text"]);
+    expect(def.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+    expect(def.contextWindow).toBeGreaterThan(0);
+    expect(def.maxTokens).toBeGreaterThan(0);
+  });
+
+  it("throws when the entry has no model id", () => {
+    expect(() => synthesizeModelDef({ baseUrl: "https://x/api" })).toThrow(/model id/);
+  });
+});
+
+describe("mergeCustomProviderIntoModelsConfig", () => {
+  it("adds a keyless openai-completions provider entry and preserves others", () => {
+    const existing = {
+      providers: {
+        litellm: {
+          baseUrl: "http://localhost:4000/v1",
+          api: "openai-completions",
+          apiKey: "x",
+          models: [{ id: "a" }],
+        },
+      },
+    };
+    const merged = mergeCustomProviderIntoModelsConfig(existing, "openai-compatible", {
+      baseUrl: "https://llm.jetstream-cloud.org/api",
+      model: "gpt-oss-120b",
+    });
+    // other providers preserved untouched
+    expect(merged.providers.litellm).toEqual(existing.providers.litellm);
+    // new provider is keyless
+    const p = merged.providers["openai-compatible"];
+    expect(p.apiKey).toBeUndefined();
+    expect(p.baseUrl).toBe("https://llm.jetstream-cloud.org/api");
+    expect(p.api).toBe("openai-completions");
+    expect(p.models[0].id).toBe("gpt-oss-120b");
+  });
+
+  it("does not mutate the input config", () => {
+    const existing = { providers: { litellm: { baseUrl: "x", models: [] } } };
+    const snapshot = JSON.stringify(existing);
+    mergeCustomProviderIntoModelsConfig(existing, "openai-compatible", {
+      baseUrl: "y",
+      model: "m",
+    });
+    expect(JSON.stringify(existing)).toBe(snapshot);
+  });
+});
+
+describe("syncCustomProviderModelsFile", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "loom-cp-test-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("creates models.json with mode 0600 when absent", () => {
+    const file = path.join(dir, "models.json");
+    syncCustomProviderModelsFile(file, "openai-compatible", {
+      baseUrl: "https://x/api",
+      model: "m",
+    });
+    expect(fs.existsSync(file)).toBe(true);
+    const parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
+    expect(parsed.providers["openai-compatible"].baseUrl).toBe("https://x/api");
+    expect(parsed.providers["openai-compatible"].apiKey).toBeUndefined();
+    // 0600 on POSIX
+    if (process.platform !== "win32") {
+      expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("preserves an existing hand-managed provider", () => {
+    const file = path.join(dir, "models.json");
+    fs.writeFileSync(
+      file,
+      JSON.stringify({
+        providers: {
+          litellm: { baseUrl: "http://localhost:4000/v1", apiKey: "x", models: [{ id: "a" }] },
+        },
+      }),
+    );
+    syncCustomProviderModelsFile(file, "openai-compatible", {
+      baseUrl: "https://x/api",
+      model: "m",
+    });
+    const parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
+    expect(parsed.providers.litellm.apiKey).toBe("x");
+    expect(parsed.providers["openai-compatible"].baseUrl).toBe("https://x/api");
+  });
+});
+
+describe("resolveActiveLlmApiKey", () => {
+  it("prefers the injected env var, then plaintext config", () => {
+    expect(resolveActiveLlmApiKey({ apiKey: "cfg" }, { LOOM_ACTIVE_LLM_API_KEY: "env" })).toBe(
+      "env",
+    );
+    expect(resolveActiveLlmApiKey({ apiKey: "cfg" }, {})).toBe("cfg");
+    expect(resolveActiveLlmApiKey({}, {})).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Adds a generic "OpenAI-compatible endpoint" provider so Loom can talk to any OpenAI-compatible inference API -- Jetstream, self-hosted vLLM, Ollama, litellm, etc. -- configured from Orbit Preferences instead of hand-editing `~/.pi/agent/models.json`. There's a one-click **Jetstream** preset that fills in the base URL and its models.

You pick "OpenAI-compatible endpoint" as the provider, enter a base URL + key (or hit the Jetstream preset), and key validation probes `{baseUrl}/models` to both check the key and populate the model dropdown. The key is encrypted at rest like every other provider and is never written to `models.json` -- the brain registers a keyless provider entry there and passes the key to pi at runtime via `--api-key`.

How it hangs together:
- `baseUrl` (optional) added to the provider config; its presence marks an entry as a custom endpoint.
- The brain (`bin/loom.js`) syncs a keyless `models.json` entry from the config and injects the decrypted key at runtime.
- Orbit decrypts the key and hands it to the brain via `LOOM_ACTIVE_LLM_API_KEY`; Preferences gains the base-URL field, live validation/model discovery, and the Jetstream preset.

Scope: one active custom endpoint at a time, `openai-completions` API, Preferences UI (welcome-screen parity left as a follow-up).

Testing: new unit tests for the shared custom-provider logic; full root test suite + root/app typechecks pass. Verified the live wire round-trip against Jetstream's `/api` proxy (models + chat completions return 200). A full in-app GUI pass is still worth doing before merge.

Note on Jetstream: off the Jetstream2/IU network only the `/api` proxy is reachable with a key (the per-model `/v1` endpoints are IP-restricted), so the preset uses `/api`.
