### PR TITLE
Fix multi-slot prompt queue

### DIFF
--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -146,6 +146,19 @@ function log(...args: unknown[]): void {
   console.log("[ipc]", ...args);
 }
 
+interface AgentPromptOptions {
+  streamingBehavior?: "steer" | "followUp";
+}
+
+function promptPayload(message: string, options?: AgentPromptOptions): Record<string, unknown> {
+  const payload: Record<string, unknown> = { type: "prompt", message };
+  const streamingBehavior = options?.streamingBehavior;
+  if (streamingBehavior === "steer" || streamingBehavior === "followUp") {
+    payload.streamingBehavior = streamingBehavior;
+  }
+  return payload;
+}
+
 /**
  * Ask the user to confirm that switching analysis directories will start
  * a fresh agent session and clear the current chat/plan/notebook view.
@@ -166,9 +179,9 @@ export async function confirmCwdChange(window?: BrowserWindow): Promise<boolean>
 }
 
 export function registerIpcHandlers(agent: AgentManager): void {
-  ipcMain.handle("agent:prompt", async (_e, message: string) => {
+  ipcMain.handle("agent:prompt", async (_e, message: string, options?: AgentPromptOptions) => {
     log("prompt:", message.slice(0, 80));
-    agent.send({ type: "prompt", message });
+    agent.send(promptPayload(message, options));
   });
 
   ipcMain.handle("agent:abort", async () => {

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -43,8 +43,12 @@ export interface FileNode {
   children?: FileNode[];
 }
 
+export interface PromptOptions {
+  streamingBehavior?: "steer" | "followUp";
+}
+
 export interface OrbitAPI {
-  prompt(message: string): Promise<void>;
+  prompt(message: string, options?: PromptOptions): Promise<void>;
   abort(): Promise<void>;
   newSession(): Promise<{ cancelled: boolean }>;
   getState(): Promise<unknown>;
@@ -137,7 +141,7 @@ export interface OrbitAPI {
 }
 
 const api: OrbitAPI = {
-  prompt: (message) => ipcRenderer.invoke("agent:prompt", message),
+  prompt: (message, options) => ipcRenderer.invoke("agent:prompt", message, options),
   abort: () => ipcRenderer.invoke("agent:abort"),
   newSession: () => ipcRenderer.invoke("agent:new-session"),
   getState: () => ipcRenderer.invoke("agent:get-state"),

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -5,6 +5,7 @@ import { ArtifactPanel } from "./artifacts/artifact-panel.js";
 import { FilesPanel } from "./files/files-panel.js";
 import { FileViewer } from "./files/file-viewer.js";
 import { refreshGalaxyInvocations } from "./galaxy-invocations.js";
+import { PromptQueue, queuedPreview } from "./prompt-queue.js";
 import { LoomWidgetKey, decodeMarkdownWidget } from "../../../shared/loom-shell-contract.js";
 import { ALLOWED_SKILLS_PREFIX, isAllowedSkillUrl } from "../../../shared/loom-config.js";
 
@@ -1034,26 +1035,17 @@ refreshCwd();
 // ── Chat Input ────────────────────────────────────────────────────────────────
 
 /** Queued messages — stashed FIFO when user submits while agent is streaming. */
-let pendingQueue: string[] = [];
-let pendingQueueCollapsed = false;
-
-const QUEUED_PREVIEW_LIMIT = 80;
-
-function queuedPreview(text: string): string {
-  const normalized = text.replace(/\s+/g, " ").trim();
-  if (normalized.length <= QUEUED_PREVIEW_LIMIT) return normalized;
-  return normalized.slice(0, QUEUED_PREVIEW_LIMIT - 1) + "…";
-}
+const pendingQueue = new PromptQueue();
 
 function updateQueuedIndicator(): void {
   queuedPanelEl.classList.toggle("hidden", pendingQueue.length === 0);
   queuedCountEl.textContent = `${pendingQueue.length} queued`;
-  queuedToggleBtn.setAttribute("aria-expanded", String(!pendingQueueCollapsed));
-  queuedToggleIconEl.textContent = pendingQueueCollapsed ? "▸" : "▾";
-  queuedListEl.classList.toggle("hidden", pendingQueueCollapsed);
+  queuedToggleBtn.setAttribute("aria-expanded", String(!pendingQueue.collapsed));
+  queuedToggleIconEl.textContent = pendingQueue.collapsed ? "▸" : "▾";
+  queuedListEl.classList.toggle("hidden", pendingQueue.collapsed);
 
   const rows = document.createDocumentFragment();
-  pendingQueue.forEach((message, index) => {
+  pendingQueue.items.forEach((message, index) => {
     const row = document.createElement("div");
     row.className = "queued-row";
     row.role = "listitem";
@@ -1081,39 +1073,24 @@ function updateQueuedIndicator(): void {
   queuedListEl.replaceChildren(rows);
 }
 
-function syncQueueCollapseAfterChange(previousLength: number): void {
-  if (pendingQueue.length <= 2) {
-    pendingQueueCollapsed = false;
-  } else if (previousLength <= 2) {
-    pendingQueueCollapsed = true;
-  }
-}
-
 function enqueueMessage(text: string): void {
-  const previousLength = pendingQueue.length;
-  pendingQueue.push(text);
-  syncQueueCollapseAfterChange(previousLength);
+  pendingQueue.enqueue(text);
   updateQueuedIndicator();
 }
 
 function removeFromQueue(index: number): void {
-  if (index < 0 || index >= pendingQueue.length) return;
-  const previousLength = pendingQueue.length;
-  pendingQueue.splice(index, 1);
-  syncQueueCollapseAfterChange(previousLength);
+  pendingQueue.remove(index);
   updateQueuedIndicator();
 }
 
 /** Clear all queued messages without sending them. */
 function clearQueue(): void {
-  pendingQueue = [];
-  pendingQueueCollapsed = false;
+  pendingQueue.clear();
   updateQueuedIndicator();
 }
 
 queuedToggleBtn.addEventListener("click", () => {
-  if (pendingQueue.length === 0) return;
-  pendingQueueCollapsed = !pendingQueueCollapsed;
+  pendingQueue.toggleCollapsed();
   updateQueuedIndicator();
 });
 
@@ -1201,7 +1178,12 @@ function dispatchSubmittedText(text: string): void {
   chat.addUserMessage(text);
   chat.showThinking();
   setStatusBadge("thinking", "thinking...");
-  window.orbit.prompt(text);
+  promptAgent(text);
+}
+
+function promptAgent(message: string): void {
+  const options = streaming ? ({ streamingBehavior: "followUp" } as const) : undefined;
+  void window.orbit.prompt(message, options);
 }
 
 // Plan draft actions from chat cards — forward approve/reject as user messages,
@@ -1228,11 +1210,8 @@ messagesEl.addEventListener("plan-draft-action", (e) => {
 
 /** Flush the next queued message after the current turn ends. */
 function flushNextQueuedMessage(): void {
-  if (pendingQueue.length === 0) return;
-  const previousLength = pendingQueue.length;
-  const text = pendingQueue.shift();
+  const text = pendingQueue.flushNext();
   if (!text) return;
-  syncQueueCollapseAfterChange(previousLength);
   updateQueuedIndicator();
   // Use requestAnimationFrame so the UI updates before we start the next turn
   requestAnimationFrame(() => {
@@ -1373,14 +1352,14 @@ function handleSlashCommand(text: string): boolean {
   if (cmd === "notebook") {
     chat.addUserMessage(text);
     void loadNotebookFromDisk();
-    window.orbit.prompt("/notebook");
+    promptAgent("/notebook");
     return true;
   }
 
   // Loom commands — pass through to agent
   if (cmd === "plan" || cmd === "status" || cmd === "decisions" || cmd === "profiles") {
     chat.addUserMessage(text);
-    window.orbit.prompt(`/${cmd}`);
+    promptAgent(`/${cmd}`);
     return true;
   }
 
@@ -1470,34 +1449,14 @@ function handleSummarize(raw: string, argStr: string): void {
   );
   chat.showThinking();
   setStatusBadge("thinking", "thinking...");
-  window.orbit.prompt(prompt);
-}
-
-async function appendCostSectionToNotebook(section: string): Promise<void> {
-  const notebook = await window.orbit.loadNotebook();
-  if (!notebook.ok) {
-    throw new Error("Could not load notebook.md");
-  }
-  const current = notebook.content ?? "";
-  const separator =
-    current.length === 0
-      ? ""
-      : current.endsWith("\n\n")
-        ? ""
-        : current.endsWith("\n")
-          ? "\n"
-          : "\n\n";
-  const result = await window.orbit.writeFile("notebook.md", `${current}${separator}${section}\n`);
-  if (!result.ok) {
-    throw new Error(result.error);
-  }
-  await loadNotebookFromDisk();
+  promptAgent(prompt);
 }
 
 /**
- * /cost — snapshot completed-turn usage per model, price it against the
- * renderer's pricing table, and append the breakdown directly to notebook.md.
- * This is intentionally local so it can run while the agent is streaming.
+ * /cost — snapshot session token usage per model, price it against the renderer's
+ * pricing table, and ask the agent to append the breakdown to notebook.md.
+ * The renderer is the authoritative source for usage numbers; the agent just
+ * writes them out.
  */
 function handleCost(raw: string): void {
   if (perModelUsage.size === 0) {
@@ -1540,19 +1499,27 @@ function handleCost(raw: string): void {
     rows.join("\n");
 
   const heading = "## Session cost";
-  const section = `${heading}\n\n${table}`;
+  const prompt =
+    `Append the following session cost breakdown verbatim to the notebook file ` +
+    `(notebook.md) in the current working directory. Use Edit or Write to append — ` +
+    `do NOT regenerate, reformat, or wrap the table. The numbers below are authoritative ` +
+    `(captured from the renderer's usage counters, same source as the masthead), so ` +
+    `use them as-is.\n\n` +
+    `Use exactly this heading (H2, verbatim) on its own line, followed by a blank line, ` +
+    `then the table:\n` +
+    `    ${heading}\n\n` +
+    `--- Cost table ---\n` +
+    table +
+    `\n--- end table ---`;
 
   chat.addUserMessage(raw);
-  chat.addInfoMessage(`<i>Appending the session cost breakdown to <code>notebook.md</code>…</i>`);
-  void appendCostSectionToNotebook(section)
-    .then(() => {
-      chat.addInfoMessage(
-        `<i>Appended the session cost breakdown to <code>notebook.md</code>.</i>`,
-      );
-    })
-    .catch((err) => {
-      chat.addErrorMessage(`/cost: ${err instanceof Error ? err.message : String(err)}`);
-    });
+  chat.addInfoMessage(
+    `<i>Asking the agent to append the session cost breakdown to ` +
+      `<code>notebook.md</code>…</i>`,
+  );
+  chat.showThinking();
+  setStatusBadge("thinking", "thinking...");
+  promptAgent(prompt);
 }
 
 /**
@@ -2054,6 +2021,14 @@ window.orbit.onAgentEvent((event) => {
       // Don't hide thinking yet — wait for actual text content
       break;
 
+    case "message_start": {
+      const msg = (event as { message?: { role?: string } }).message;
+      if (msg?.role === "user") {
+        chat.finishAssistantMessage();
+      }
+      break;
+    }
+
     case "message_update": {
       // Pi.dev wraps events in assistantMessageEvent
       const ame = (event as { assistantMessageEvent?: Record<string, unknown> })
@@ -2516,6 +2491,8 @@ window.orbit.onAgentStatus((status, msg) => {
     sendBtn.classList.remove("hidden");
     abortBtn.classList.add("hidden");
     chat.hideThinking();
+    chat.finishAssistantMessage();
+    clearQueue();
   }
 
   // Show cwd welcome once, after the first successful agent start.

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -30,6 +30,12 @@ const messagesEl = document.getElementById("messages")!;
 const inputEl = document.getElementById("input") as HTMLTextAreaElement;
 const sendBtn = document.getElementById("send-btn")!;
 const abortBtn = document.getElementById("abort-btn")!;
+const queuedPanelEl = document.getElementById("queued-panel")!;
+const queuedToggleBtn = document.getElementById("queued-toggle") as HTMLButtonElement;
+const queuedCountEl = document.getElementById("queued-count")!;
+const queuedToggleIconEl = document.getElementById("queued-toggle-icon")!;
+const queuedListEl = document.getElementById("queued-list")!;
+const queuedClearBtn = document.getElementById("queued-clear") as HTMLButtonElement;
 const statusBadge = document.getElementById("agent-status")!;
 
 const cwdPathEl = document.getElementById("cwd-path")!;
@@ -904,7 +910,7 @@ function resetUiForFreshContext(opts: { clearPersistedCost?: boolean } = {}): vo
   const { clearPersistedCost = true } = opts;
   chat.clear();
   artifacts.clear();
-  clearPendingMessage();
+  clearQueue();
   sessionUsage.input = 0;
   sessionUsage.output = 0;
   sessionUsage.cacheRead = 0;
@@ -1027,29 +1033,99 @@ refreshCwd();
 
 // ── Chat Input ────────────────────────────────────────────────────────────────
 
-/** Queued message — stashed when user submits while agent is streaming. */
-let pendingMessage: string | null = null;
+/** Queued messages — stashed FIFO when user submits while agent is streaming. */
+let pendingQueue: string[] = [];
+let pendingQueueCollapsed = false;
+
+const QUEUED_PREVIEW_LIMIT = 80;
+
+function queuedPreview(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= QUEUED_PREVIEW_LIMIT) return normalized;
+  return normalized.slice(0, QUEUED_PREVIEW_LIMIT - 1) + "…";
+}
 
 function updateQueuedIndicator(): void {
-  const indicator = document.getElementById("queued-indicator");
-  if (!indicator) return;
-  if (pendingMessage) {
-    indicator.classList.remove("hidden");
-    indicator.title = `Queued: ${pendingMessage.slice(0, 100)}${pendingMessage.length > 100 ? "…" : ""} (click to cancel)`;
-  } else {
-    indicator.classList.add("hidden");
+  queuedPanelEl.classList.toggle("hidden", pendingQueue.length === 0);
+  queuedCountEl.textContent = `${pendingQueue.length} queued`;
+  queuedToggleBtn.setAttribute("aria-expanded", String(!pendingQueueCollapsed));
+  queuedToggleIconEl.textContent = pendingQueueCollapsed ? "▸" : "▾";
+  queuedListEl.classList.toggle("hidden", pendingQueueCollapsed);
+
+  const rows = document.createDocumentFragment();
+  pendingQueue.forEach((message, index) => {
+    const row = document.createElement("div");
+    row.className = "queued-row";
+    row.role = "listitem";
+
+    const position = document.createElement("span");
+    position.className = "queued-position";
+    position.textContent = `${index + 1}.`;
+
+    const preview = document.createElement("span");
+    preview.className = "queued-preview";
+    preview.textContent = queuedPreview(message);
+    preview.title = message;
+
+    const remove = document.createElement("button");
+    remove.className = "queued-remove";
+    remove.type = "button";
+    remove.dataset.queueIndex = String(index);
+    remove.title = `Remove queued message ${index + 1}`;
+    remove.setAttribute("aria-label", `Remove queued message ${index + 1}`);
+    remove.textContent = "×";
+
+    row.append(position, preview, remove);
+    rows.append(row);
+  });
+  queuedListEl.replaceChildren(rows);
+}
+
+function syncQueueCollapseAfterChange(previousLength: number): void {
+  if (pendingQueue.length <= 2) {
+    pendingQueueCollapsed = false;
+  } else if (previousLength <= 2) {
+    pendingQueueCollapsed = true;
   }
 }
 
-/** Clear any queued message without sending it. */
-function clearPendingMessage(): void {
-  pendingMessage = null;
+function enqueueMessage(text: string): void {
+  const previousLength = pendingQueue.length;
+  pendingQueue.push(text);
+  syncQueueCollapseAfterChange(previousLength);
   updateQueuedIndicator();
 }
 
-// Click the indicator to cancel the queued message
-document.getElementById("queued-indicator")?.addEventListener("click", () => {
-  clearPendingMessage();
+function removeFromQueue(index: number): void {
+  if (index < 0 || index >= pendingQueue.length) return;
+  const previousLength = pendingQueue.length;
+  pendingQueue.splice(index, 1);
+  syncQueueCollapseAfterChange(previousLength);
+  updateQueuedIndicator();
+}
+
+/** Clear all queued messages without sending them. */
+function clearQueue(): void {
+  pendingQueue = [];
+  pendingQueueCollapsed = false;
+  updateQueuedIndicator();
+}
+
+queuedToggleBtn.addEventListener("click", () => {
+  if (pendingQueue.length === 0) return;
+  pendingQueueCollapsed = !pendingQueueCollapsed;
+  updateQueuedIndicator();
+});
+
+queuedClearBtn.addEventListener("click", () => {
+  clearQueue();
+});
+
+queuedListEl.addEventListener("click", (e) => {
+  const target = e.target as HTMLElement | null;
+  const remove = target?.closest<HTMLButtonElement>("[data-queue-index]");
+  if (!remove) return;
+  removeFromQueue(Number(remove.dataset.queueIndex));
 });
 
 // Cheaper-model nudge state. Suppress per-session if the user dismisses
@@ -1102,30 +1178,30 @@ function submit(): void {
   // gets the hint inline above the agent's thinking response.
   maybeShowCheaperModelNudge(text);
 
-  // Slash commands — handled locally, no LLM round-trip (allowed even while streaming)
-  if (text.startsWith("/")) {
-    if (handleSlashCommand(text)) {
-      inputEl.value = "";
-      inputEl.style.height = "auto";
-      return;
-    }
-  }
-
   // If the agent is mid-turn, queue the message and flush when agent_end fires.
-  if (streaming) {
-    pendingMessage = text;
+  // Purely local slash commands still run immediately; slash commands that
+  // prompt the agent must join the FIFO queue like any other LLM turn.
+  if (streaming && !isLocalSlashCommand(text)) {
+    enqueueMessage(text);
     inputEl.value = "";
     inputEl.style.height = "auto";
-    updateQueuedIndicator();
     return;
   }
+
+  dispatchSubmittedText(text);
+  inputEl.value = "";
+  inputEl.style.height = "auto";
+}
+
+function dispatchSubmittedText(text: string): void {
+  // Slash commands handled locally may run without an LLM round-trip. Commands
+  // that do call the agent run here only after the current turn is idle.
+  if (text.startsWith("/") && handleSlashCommand(text)) return;
 
   chat.addUserMessage(text);
   chat.showThinking();
   setStatusBadge("thinking", "thinking...");
   window.orbit.prompt(text);
-  inputEl.value = "";
-  inputEl.style.height = "auto";
 }
 
 // Plan draft actions from chat cards — forward approve/reject as user messages,
@@ -1150,18 +1226,17 @@ messagesEl.addEventListener("plan-draft-action", (e) => {
   }
 });
 
-/** Flush any queued message after the current turn ends. */
-function flushPendingMessage(): void {
-  if (!pendingMessage) return;
-  const text = pendingMessage;
-  pendingMessage = null;
+/** Flush the next queued message after the current turn ends. */
+function flushNextQueuedMessage(): void {
+  if (pendingQueue.length === 0) return;
+  const previousLength = pendingQueue.length;
+  const text = pendingQueue.shift();
+  if (!text) return;
+  syncQueueCollapseAfterChange(previousLength);
   updateQueuedIndicator();
   // Use requestAnimationFrame so the UI updates before we start the next turn
   requestAnimationFrame(() => {
-    chat.addUserMessage(text);
-    chat.showThinking();
-    setStatusBadge("thinking", "thinking...");
-    window.orbit.prompt(text);
+    dispatchSubmittedText(text);
   });
 }
 
@@ -1214,6 +1289,26 @@ const SLASH_COMMANDS: SlashCommand[] = [
   { name: "connect", description: "open Galaxy connection settings" },
   { name: "help", description: "show this help" },
 ];
+
+const LOCAL_SLASH_COMMANDS = new Set([
+  "model",
+  "new",
+  "reset",
+  "clear",
+  "resume",
+  "continue",
+  "chat",
+  "connect",
+  "help",
+]);
+
+function slashCommandName(text: string): string {
+  return text.slice(1).split(/\s+/)[0] ?? "";
+}
+
+function isLocalSlashCommand(text: string): boolean {
+  return text.startsWith("/") && LOCAL_SLASH_COMMANDS.has(slashCommandName(text));
+}
 
 function escapeHtmlBasic(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -1903,13 +1998,11 @@ sendBtn.addEventListener("click", submit);
 
 abortBtn.addEventListener("click", () => {
   window.orbit.abort();
-  clearPendingMessage();
 });
 
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape" && streaming) {
     window.orbit.abort();
-    clearPendingMessage();
   }
 });
 
@@ -1993,10 +2086,18 @@ window.orbit.onAgentEvent((event) => {
         commitTurnUsage();
         // Surface assistant-side errors (e.g. 401 invalid API key) so the user
         // isn't staring at a silent UI after a failed call.
-        if (msg.stopReason === "error" && msg.errorMessage) {
+        if (msg.stopReason === "error") {
           chat.hideThinking();
-          chat.addErrorMessage(humanizeAgentError(msg.errorMessage).text);
+          chat.finishAssistantMessage();
+          if (msg.errorMessage) {
+            chat.addErrorMessage(humanizeAgentError(msg.errorMessage).text);
+          }
+          streaming = false;
+          stopTurnTimer();
           setStatusBadge("error");
+          sendBtn.classList.remove("hidden");
+          abortBtn.classList.add("hidden");
+          clearQueue();
         }
       }
       break;
@@ -2061,7 +2162,7 @@ window.orbit.onAgentEvent((event) => {
       chat.finishAssistantMessage();
       // Safety: clear any stuck button busy states if the turn ends without the
       // expected completion event arriving
-      flushPendingMessage();
+      flushNextQueuedMessage();
       hasRevealedActivityThisTurn = false;
       break;
 
@@ -2074,8 +2175,7 @@ window.orbit.onAgentEvent((event) => {
       setStatusBadge("error");
       sendBtn.classList.remove("hidden");
       abortBtn.classList.add("hidden");
-      // Clear any queued message on error so the indicator doesn't get stuck
-      clearPendingMessage();
+      clearQueue();
       break;
     }
   }

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -1298,6 +1298,7 @@ const LOCAL_SLASH_COMMANDS = new Set([
   "resume",
   "continue",
   "chat",
+  "cost",
   "connect",
   "help",
 ]);
@@ -1472,11 +1473,31 @@ function handleSummarize(raw: string, argStr: string): void {
   window.orbit.prompt(prompt);
 }
 
+async function appendCostSectionToNotebook(section: string): Promise<void> {
+  const notebook = await window.orbit.loadNotebook();
+  if (!notebook.ok) {
+    throw new Error("Could not load notebook.md");
+  }
+  const current = notebook.content ?? "";
+  const separator =
+    current.length === 0
+      ? ""
+      : current.endsWith("\n\n")
+        ? ""
+        : current.endsWith("\n")
+          ? "\n"
+          : "\n\n";
+  const result = await window.orbit.writeFile("notebook.md", `${current}${separator}${section}\n`);
+  if (!result.ok) {
+    throw new Error(result.error);
+  }
+  await loadNotebookFromDisk();
+}
+
 /**
- * /cost — snapshot session token usage per model, price it against the renderer's
- * pricing table, and ask the agent to append the breakdown to notebook.md.
- * The renderer is the authoritative source for usage numbers; the agent just
- * writes them out.
+ * /cost — snapshot completed-turn usage per model, price it against the
+ * renderer's pricing table, and append the breakdown directly to notebook.md.
+ * This is intentionally local so it can run while the agent is streaming.
  */
 function handleCost(raw: string): void {
   if (perModelUsage.size === 0) {
@@ -1519,27 +1540,19 @@ function handleCost(raw: string): void {
     rows.join("\n");
 
   const heading = "## Session cost";
-  const prompt =
-    `Append the following session cost breakdown verbatim to the notebook file ` +
-    `(notebook.md) in the current working directory. Use Edit or Write to append — ` +
-    `do NOT regenerate, reformat, or wrap the table. The numbers below are authoritative ` +
-    `(captured from the renderer's usage counters, same source as the masthead), so ` +
-    `use them as-is.\n\n` +
-    `Use exactly this heading (H2, verbatim) on its own line, followed by a blank line, ` +
-    `then the table:\n` +
-    `    ${heading}\n\n` +
-    `--- Cost table ---\n` +
-    table +
-    `\n--- end table ---`;
+  const section = `${heading}\n\n${table}`;
 
   chat.addUserMessage(raw);
-  chat.addInfoMessage(
-    `<i>Asking the agent to append the session cost breakdown to ` +
-      `<code>notebook.md</code>…</i>`,
-  );
-  chat.showThinking();
-  setStatusBadge("thinking", "thinking...");
-  window.orbit.prompt(prompt);
+  chat.addInfoMessage(`<i>Appending the session cost breakdown to <code>notebook.md</code>…</i>`);
+  void appendCostSectionToNotebook(section)
+    .then(() => {
+      chat.addInfoMessage(
+        `<i>Appended the session cost breakdown to <code>notebook.md</code>.</i>`,
+      );
+    })
+    .catch((err) => {
+      chat.addErrorMessage(`/cost: ${err instanceof Error ? err.message : String(err)}`);
+    });
 }
 
 /**
@@ -1996,13 +2009,16 @@ inputEl.addEventListener("blur", () => {
 
 sendBtn.addEventListener("click", submit);
 
-abortBtn.addEventListener("click", () => {
+function abortCurrentTurn(): void {
+  clearQueue();
   window.orbit.abort();
-});
+}
+
+abortBtn.addEventListener("click", abortCurrentTurn);
 
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape" && streaming) {
-    window.orbit.abort();
+    abortCurrentTurn();
   }
 });
 

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -139,39 +139,64 @@
 
           <div id="input-area">
             <div id="slash-popup" class="hidden" role="listbox" aria-label="Slash commands"></div>
-            <span
-              id="queued-indicator"
-              class="hidden"
-              title="Queued — will send when agent is ready"
-              >queued <span aria-hidden="true">↓</span></span
-            >
-            <textarea
-              id="input"
-              placeholder="Ask for a plan, drop a file path, or type / for commands"
-              rows="1"
-              aria-label="Chat input"
-              aria-haspopup="listbox"
-              aria-controls="slash-popup"
-              aria-autocomplete="list"
-              aria-expanded="false"
-            ></textarea>
-            <button id="send-btn" title="Send" aria-label="Send message">
-              <svg
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
+            <div id="queued-panel" class="queued-panel hidden" aria-live="polite">
+              <div class="queued-panel-header">
+                <button
+                  id="queued-toggle"
+                  class="queued-toggle"
+                  type="button"
+                  aria-expanded="true"
+                  aria-controls="queued-list"
+                >
+                  <span id="queued-count">0 queued</span>
+                  <span id="queued-toggle-icon" aria-hidden="true">▾</span>
+                </button>
+                <button
+                  id="queued-clear"
+                  class="queued-clear"
+                  type="button"
+                  title="Clear queue"
+                  aria-label="Clear queued messages"
+                >
+                  clear
+                </button>
+              </div>
+              <div id="queued-list" class="queued-list" role="list"></div>
+            </div>
+            <div class="composer-row">
+              <textarea
+                id="input"
+                placeholder="Ask for a plan, drop a file path, or type / for commands"
+                rows="1"
+                aria-label="Chat input"
+                aria-haspopup="listbox"
+                aria-controls="slash-popup"
+                aria-autocomplete="list"
+                aria-expanded="false"
+              ></textarea>
+              <button id="send-btn" title="Send" aria-label="Send message">
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path d="M22 2L11 13M22 2L15 22L11 13M22 2L2 9L11 13" />
+                </svg>
+              </button>
+              <button
+                id="abort-btn"
+                title="Stop"
+                class="hidden"
+                aria-label="Stop streaming response"
               >
-                <path d="M22 2L11 13M22 2L15 22L11 13M22 2L2 9L11 13" />
-              </svg>
-            </button>
-            <button id="abort-btn" title="Stop" class="hidden" aria-label="Stop streaming response">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                <rect x="6" y="6" width="12" height="12" rx="2" />
-              </svg>
-            </button>
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                  <rect x="6" y="6" width="12" height="12" rx="2" />
+                </svg>
+              </button>
+            </div>
           </div>
           <div id="input-hint">
             <span>Type <code>/</code> to see available commands</span>

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -139,7 +139,7 @@
 
           <div id="input-area">
             <div id="slash-popup" class="hidden" role="listbox" aria-label="Slash commands"></div>
-            <div id="queued-panel" class="queued-panel hidden" aria-live="polite">
+            <div id="queued-panel" class="queued-panel hidden">
               <div class="queued-panel-header">
                 <button
                   id="queued-toggle"
@@ -148,7 +148,7 @@
                   aria-expanded="true"
                   aria-controls="queued-list"
                 >
-                  <span id="queued-count">0 queued</span>
+                  <span id="queued-count" aria-live="polite" aria-atomic="true">0 queued</span>
                   <span id="queued-toggle-icon" aria-hidden="true">▾</span>
                 </button>
                 <button

--- a/app/src/renderer/prompt-queue.ts
+++ b/app/src/renderer/prompt-queue.ts
@@ -1,0 +1,63 @@
+export const QUEUED_PREVIEW_LIMIT = 80;
+
+export function queuedPreview(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= QUEUED_PREVIEW_LIMIT) return normalized;
+  return normalized.slice(0, QUEUED_PREVIEW_LIMIT - 1) + "\u2026";
+}
+
+export class PromptQueue {
+  private pending: string[] = [];
+  private isCollapsed = false;
+
+  get items(): readonly string[] {
+    return this.pending;
+  }
+
+  get length(): number {
+    return this.pending.length;
+  }
+
+  get collapsed(): boolean {
+    return this.isCollapsed;
+  }
+
+  enqueue(text: string): void {
+    const previousLength = this.pending.length;
+    this.pending.push(text);
+    this.syncCollapseAfterChange(previousLength);
+  }
+
+  remove(index: number): void {
+    if (index < 0 || index >= this.pending.length) return;
+    const previousLength = this.pending.length;
+    this.pending.splice(index, 1);
+    this.syncCollapseAfterChange(previousLength);
+  }
+
+  clear(): void {
+    this.pending = [];
+    this.isCollapsed = false;
+  }
+
+  flushNext(): string | undefined {
+    const previousLength = this.pending.length;
+    const text = this.pending.shift();
+    if (text === undefined) return undefined;
+    this.syncCollapseAfterChange(previousLength);
+    return text;
+  }
+
+  toggleCollapsed(): void {
+    if (this.pending.length === 0) return;
+    this.isCollapsed = !this.isCollapsed;
+  }
+
+  private syncCollapseAfterChange(previousLength: number): void {
+    if (this.pending.length <= 2) {
+      this.isCollapsed = false;
+    } else if (previousLength <= 2) {
+      this.isCollapsed = true;
+    }
+  }
+}

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -1232,29 +1232,117 @@ body.platform-darwin #files-title {
 
 #input-area {
   display: flex;
-  align-items: flex-end;
+  flex-direction: column;
+  align-items: stretch;
   gap: 8px;
   padding: 12px 16px 6px;
   border-top: 1px solid var(--border);
   background: var(--bg);
+  position: relative;
 }
 
-#queued-indicator {
-  position: absolute;
-  top: -20px;
-  left: 16px;
-  background: var(--accent-bg);
-  color: var(--accent);
-  border: 1px solid var(--accent);
+.queued-panel {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
   border-radius: var(--radius);
-  padding: 2px 8px;
-  font-size: 11px;
-  font-weight: 600;
-  animation: pulse 1.5s ease-in-out infinite;
-  pointer-events: none;
+  overflow: hidden;
 }
-#input-area {
-  position: relative;
+
+.queued-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 28px;
+  gap: 8px;
+  padding: 4px 6px 4px 10px;
+}
+
+.queued-toggle,
+.queued-clear,
+.queued-remove {
+  font: inherit;
+  border: 0;
+  background: transparent;
+  color: inherit;
+}
+
+.queued-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: var(--accent);
+  cursor: pointer;
+  font-family: var(--font);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.queued-clear {
+  flex-shrink: 0;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.queued-clear:hover {
+  color: var(--text-bright);
+  background: var(--bg-hover);
+}
+
+.queued-list {
+  border-top: 1px solid var(--border);
+}
+
+.queued-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 28px;
+  padding: 4px 8px 4px 10px;
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.queued-row + .queued-row {
+  border-top: 1px solid var(--border);
+}
+
+.queued-position {
+  color: var(--text-dim);
+}
+
+.queued-preview {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.queued-remove {
+  width: 20px;
+  height: 20px;
+  border-radius: 3px;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.queued-remove:hover {
+  color: var(--text-bright);
+  background: var(--bg-hover);
+}
+
+.composer-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  width: 100%;
 }
 
 /* Slash-command autocomplete popup. Positioned above the textarea. */

--- a/tests/prompt-queue.test.ts
+++ b/tests/prompt-queue.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { PromptQueue, queuedPreview } from "../app/src/renderer/prompt-queue.js";
+
+describe("PromptQueue", () => {
+  it("queues and flushes messages FIFO", () => {
+    const queue = new PromptQueue();
+
+    queue.enqueue("first");
+    queue.enqueue("second");
+    queue.enqueue("third");
+
+    expect(queue.items).toEqual(["first", "second", "third"]);
+    expect(queue.flushNext()).toBe("first");
+    expect(queue.flushNext()).toBe("second");
+    expect(queue.items).toEqual(["third"]);
+  });
+
+  it("removes one queued message without disturbing the rest", () => {
+    const queue = new PromptQueue();
+
+    queue.enqueue("first");
+    queue.enqueue("second");
+    queue.enqueue("third");
+    queue.remove(1);
+    queue.remove(99);
+
+    expect(queue.items).toEqual(["first", "third"]);
+  });
+
+  it("clears all queued messages for abort/error cleanup", () => {
+    const queue = new PromptQueue();
+
+    queue.enqueue("first");
+    queue.enqueue("second");
+    queue.enqueue("third");
+    queue.clear();
+
+    expect(queue.items).toEqual([]);
+    expect(queue.collapsed).toBe(false);
+    expect(queue.flushNext()).toBeUndefined();
+  });
+
+  it("auto-collapses only while the queue has more than two messages", () => {
+    const queue = new PromptQueue();
+
+    queue.enqueue("first");
+    queue.enqueue("second");
+    expect(queue.collapsed).toBe(false);
+
+    queue.enqueue("third");
+    expect(queue.collapsed).toBe(true);
+
+    queue.flushNext();
+    expect(queue.collapsed).toBe(false);
+  });
+
+  it("normalizes and truncates queue previews", () => {
+    const longText = `  ${"word ".repeat(30)}  `;
+
+    expect(queuedPreview(" first\n\nsecond\tthird ")).toBe("first second third");
+    expect(queuedPreview(longText)).toHaveLength(80);
+    expect(queuedPreview(longText)).toMatch(/\u2026$/);
+  });
+});


### PR DESCRIPTION
## Summary

- Fixed issue #60 
- replace the single pending prompt slot with a FIFO queue for prompts submitted while the agent is streaming
- add queued-message UI with collapse, remove, and clear controls
- preserve immediate handling for local slash commands while queuing agent-backed slash commands until the current turn ends

## Verification
- git diff --check
- npm run typecheck
- cd app && npm exec tsc -- --noEmit
- manual fake-agent browser review for multi-message queue, row removal, clear, error, and FIFO flush behavior
- manual fake-agent browser review for /help immediate handling plus queued /plan and /summarize behavior