### PR TITLE
Bump bundled galaxy-mcp floor to >=1.6.0

### DIFF
--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -205,7 +205,7 @@ function pruneNodeBundle(): void {
   }
 }
 
-// Bundle uv/uvx so Galaxy MCP (`uvx galaxy-mcp>=1.4.0`) doesn't need a
+// Bundle uv/uvx so Galaxy MCP (`uvx galaxy-mcp>=1.6.0`) doesn't need a
 // system-installed uv. Pulls the latest release tarball from astral-sh/uv.
 // "latest" resolves to a specific tag at fetch time -- the cached tarball
 // won't auto-refresh; remove `.loom-stage/cache/` to pick up newer uv.

--- a/bin/loom.js
+++ b/bin/loom.js
@@ -256,7 +256,7 @@ if (!isInformationalCommand) {
   if (hasGalaxyCredentials) {
     mcpConfig.mcpServers.galaxy = {
       command: "uvx",
-      args: ["galaxy-mcp>=1.4.0"],
+      args: ["galaxy-mcp>=1.6.0"],
       directTools: true,
       env: {
         GALAXY_URL: galaxyUrl,


### PR DESCRIPTION
Raises the floor on the bundled `uvx galaxy-mcp` from `>=1.4.0` to `>=1.6.0` so loom picks up the agent-experience work that landed across the 1.5.x line:

- **Self-correcting tool inputs** -- when the agent calls a Galaxy tool with the wrong arguments, the server now returns the real input schema and a corrected template instead of an opaque error, so the model can fix the call itself.
- **Agent-facing usage guidance** -- the server surfaces usage instructions to the client via FastMCP instructions, giving the model better grounding on how to drive Galaxy.
- **Progressive tool discovery** -- tools are tagged by domain/access/tier and filtered by a visibility middleware, with an opt-in discovery mode, so the agent isn't swamped by the full tool surface.
- `get_tool_input_template` for constructing valid tool calls up front.

1.6.0 is just the current release that bundles all of the above (plus a dependency/security refresh); `uvx` already resolves to latest, so this only guarantees the minimum.

Touches two spots: the `uvx` args in `bin/loom.js` and the matching comment in `app/forge.config.ts`.