### PR TITLE
Add beta feedback capture: "Send feedback" + /feedback -> capture worker

### DIFF
--- a/app/src/main/feedback.ts
+++ b/app/src/main/feedback.ts
@@ -1,0 +1,36 @@
+import { net } from "electron";
+import {
+  FEEDBACK_ROUTE,
+  FEEDBACK_ENDPOINT_URL,
+  FEEDBACK_KEY_HEADER,
+} from "../../../shared/feedback-contract.js";
+import type { FeedbackPayload } from "../../../shared/feedback-contract.js";
+
+// Endpoint is resolved in main (like the GitHub/releases URLs) so a compromised
+// renderer can't redirect it. LOOM_FEEDBACK_URL overrides the base for local dev.
+const ENDPOINT = (process.env.LOOM_FEEDBACK_URL || FEEDBACK_ENDPOINT_URL) + FEEDBACK_ROUTE;
+const TIMEOUT_MS = 10_000;
+
+export interface FeedbackResult {
+  ok: boolean;
+  status?: number;
+  id?: string;
+  error?: string;
+}
+
+export async function postFeedback(payload: FeedbackPayload): Promise<FeedbackResult> {
+  try {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (process.env.LOOM_FEEDBACK_KEY) headers[FEEDBACK_KEY_HEADER] = process.env.LOOM_FEEDBACK_KEY;
+    const res = await net.fetch(ENDPOINT, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+    const data = (await res.json().catch(() => ({}))) as { id?: string; error?: string };
+    return { ok: res.ok, status: res.status, id: data.id, error: data.error };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -9,6 +9,8 @@ import { loadConfig, saveConfig, type LoomConfig } from "./config.js";
 import { encryptSecret, isAvailable as safeStorageAvailable } from "./secure-config.js";
 import { getProviders, getModels } from "@earendil-works/pi-ai";
 import { checkLatestVersion } from "./version-check.js";
+import { postFeedback } from "./feedback.js";
+import type { FeedbackPayload } from "../../../shared/feedback-contract.js";
 import {
   getOAuthStatus,
   isOAuthProvider,
@@ -501,6 +503,14 @@ export function registerIpcHandlers(agent: AgentManager): void {
     const url = `https://github.com/galaxyproject/loom/issues/new?${params.toString()}`;
     await shell.openExternal(url);
     return { opened: true };
+  });
+
+  // Feedback capture: POST the payload to the orbit-feedback worker. The
+  // endpoint URL (and any shared secret) live in main only -- see feedback.ts --
+  // so a compromised renderer can't redirect it. Returns {ok,...} so the
+  // renderer can fall back to the GitHub-issue flow when the POST fails.
+  ipcMain.handle("feedback:submit", async (_e, payload: FeedbackPayload) => {
+    return await postFeedback(payload);
   });
 
   // Model registry — pulls from pi-ai's bundled list so the dropdown stays

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -113,6 +113,9 @@ export interface OrbitAPI {
     arch: string;
   }>;
   openIssueReport(payload: { title: string; body: string }): Promise<{ opened: boolean }>;
+  submitFeedback(
+    payload: import("../../../shared/feedback-contract.js").FeedbackPayload,
+  ): Promise<{ ok: boolean; status?: number; id?: string; error?: string }>;
   listAllModels(): Promise<
     | {
         ok: true;
@@ -229,6 +232,7 @@ const api: OrbitAPI = {
 
   getReportSysinfo: () => ipcRenderer.invoke("report:sysinfo"),
   openIssueReport: (payload) => ipcRenderer.invoke("report:open-issue", payload),
+  submitFeedback: (payload) => ipcRenderer.invoke("feedback:submit", payload),
 
   listAllModels: () => ipcRenderer.invoke("models:list-all"),
   checkVersion: () => ipcRenderer.invoke("version:check"),

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -7,6 +7,8 @@ import { FileViewer } from "./files/file-viewer.js";
 import { refreshGalaxyInvocations } from "./galaxy-invocations.js";
 import { LoomWidgetKey, decodeMarkdownWidget } from "../../../shared/loom-shell-contract.js";
 import { ALLOWED_SKILLS_PREFIX, isAllowedSkillUrl } from "../../../shared/loom-config.js";
+import { SCHEMA_VERSION } from "../../../shared/feedback-contract.js";
+import type { FeedbackPayload, FeedbackSysinfo } from "../../../shared/feedback-contract.js";
 
 declare global {
   interface Window {
@@ -3055,11 +3057,12 @@ const REPORT_URL_BUDGET = 7000;
 function openReportModal(): void {
   reportTitle.value = "";
   reportBody.value = "";
-  // Default to no auto-collected data. The destination is a public GitHub
-  // issue, so opt-in beats opt-out -- forces the user to read the
-  // disclosure before sharing logs or sysinfo.
-  reportIncludeSysinfo.checked = false;
-  reportIncludeLogs.checked = false;
+  // Default ON: the primary destination is Loom's private capture store, not a
+  // public issue, so opt-out is fine. The user can still uncheck before sending,
+  // and the public GitHub fallback (POST failure) sends text only -- no
+  // diagnostics -- so this never auto-publishes logs to a public issue.
+  reportIncludeSysinfo.checked = true;
+  reportIncludeLogs.checked = true;
   reportOverlay.classList.remove("hidden");
   reportTitle.focus();
 }
@@ -3067,79 +3070,91 @@ function closeReportModal(): void {
   reportOverlay.classList.add("hidden");
 }
 
-async function buildReportBody(userText: string): Promise<string> {
-  const sections: string[] = [userText.trim() || "(no description provided)"];
+// Cap a body on its URL-encoded length for the GitHub-issue fallback. The "new
+// issue" URL (~8KB) is the real limit and punctuation roughly triples under
+// encodeURIComponent, so trim raw chars until the encoded form fits.
+function capForGithubUrl(body: string): string {
+  if (encodeURIComponent(body).length <= REPORT_URL_BUDGET) return body;
+  const marker = "\n\n...(truncated)";
+  const markerCost = encodeURIComponent(marker).length;
+  let out = body;
+  while (encodeURIComponent(out).length + markerCost > REPORT_URL_BUDGET) {
+    out = out.slice(0, Math.floor(out.length * 0.9));
+  }
+  return out + marker;
+}
+
+// Assemble the structured feedback payload POSTed to the capture worker. Honors
+// the two opt-in checkboxes; never includes cwd, API keys, or raw activity
+// payloads (sysinfo strips cwd; the activity tail is summarized to one line per
+// event).
+async function buildFeedbackPayload(): Promise<FeedbackPayload> {
+  const title = reportTitle.value.trim();
+  const body = reportBody.value.trim();
+  let sysinfo: FeedbackSysinfo | undefined;
+  let activityTail: string | undefined;
+  let shellTail: string | undefined;
 
   if (reportIncludeSysinfo.checked) {
     try {
       const info = await window.orbit.getReportSysinfo();
       const cfg = (await window.orbit.getConfig()) as {
-        llm?: { provider?: string; model?: string };
+        llm?: { active?: string; providers?: Record<string, { model?: string }> };
         galaxy?: { active: string | null };
       };
-      // Deliberately not including cwd -- a path like /home/<user>/<project>
-      // leaks both username and project name to a public issue, and isn't
-      // useful for debugging.
-      sections.push(
-        `## System info\n` +
-          `- Orbit: ${info.appVersion}\n` +
-          `- Platform: ${info.platform} ${info.arch}\n` +
-          `- Electron: ${info.electronVersion}, Chrome: ${info.chromeVersion}, Node: ${info.nodeVersion}\n` +
-          `- LLM: ${cfg.llm?.provider ?? "(none)"} / ${cfg.llm?.model ?? "(none)"}\n` +
-          `- Galaxy: ${cfg.galaxy?.active ? "configured" : "not configured"}`,
-      );
-    } catch (err) {
-      sections.push(
-        `## System info\n(failed to collect: ${err instanceof Error ? err.message : String(err)})`,
-      );
+      const active = cfg.llm?.active;
+      sysinfo = {
+        appVersion: info.appVersion,
+        platform: info.platform,
+        arch: info.arch,
+        electron: info.electronVersion,
+        chrome: info.chromeVersion,
+        node: info.nodeVersion,
+        llmProvider: active,
+        llmModel: active ? cfg.llm?.providers?.[active]?.model : undefined,
+        galaxyConfigured: Boolean(cfg.galaxy?.active),
+      };
+    } catch {
+      /* skip sysinfo on failure */
     }
   }
 
   if (reportIncludeLogs.checked) {
-    // Activity tail — last 15 events, summarized to {timestamp} {kind}.
-    // The full payload column has stuffed-JSON tool results that explode
-    // 3–5× under URL-encoding and quickly blow GitHub's URL budget.
     try {
       const res = await window.orbit.readFile("activity.jsonl");
       if (res.ok) {
         const text = new TextDecoder("utf-8").decode(res.bytes);
-        const lines = text.split("\n").filter(Boolean).slice(-15);
-        const summarized = lines.map((line) => {
-          try {
-            const e = JSON.parse(line) as { timestamp?: string; kind?: string; source?: string };
-            return `${e.timestamp ?? "?"} ${e.kind ?? "?"}${e.source ? " (" + e.source + ")" : ""}`;
-          } catch {
-            return line.slice(0, 80);
-          }
-        });
-        sections.push(
-          "## activity.jsonl (last 15 events, summarized)\n```\n" + summarized.join("\n") + "\n```",
-        );
+        activityTail = text
+          .split("\n")
+          .filter(Boolean)
+          .slice(-15)
+          .map((line) => {
+            try {
+              const e = JSON.parse(line) as { timestamp?: string; kind?: string; source?: string };
+              return `${e.timestamp ?? "?"} ${e.kind ?? "?"}${e.source ? " (" + e.source + ")" : ""}`;
+            } catch {
+              return line.slice(0, 80);
+            }
+          })
+          .join("\n");
       }
     } catch {
-      /* file missing or unreadable — skip */
+      /* file missing or unreadable -- skip */
     }
-
-    // Shell tail (last ~80 lines of in-memory ShellPanel)
-    const shellTail = shell.tail(80);
-    if (shellTail.trim()) {
-      sections.push("## Shell stream (last ~80 lines)\n```\n" + shellTail + "\n```");
-    }
+    const t = shell.tail(80);
+    if (t.trim()) shellTail = t;
   }
 
-  let body = sections.join("\n\n");
-  // Cap on the URL-encoded length, not the raw length — a body full of
-  // backslash-quoted JSON expands ~3× under encodeURIComponent. Trim
-  // raw chars until the encoded form fits the budget.
-  if (encodeURIComponent(body).length > REPORT_URL_BUDGET) {
-    const marker = "\n\n…(truncated)";
-    const markerCost = encodeURIComponent(marker).length;
-    while (encodeURIComponent(body).length + markerCost > REPORT_URL_BUDGET) {
-      body = body.slice(0, Math.floor(body.length * 0.9));
-    }
-    body = body + marker;
-  }
-  return body;
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    source: "orbit",
+    title,
+    body,
+    sysinfo,
+    activityTail,
+    shellTail,
+    clientTs: new Date().toISOString(),
+  };
 }
 
 reportBtn.addEventListener("click", openReportModal);
@@ -3165,8 +3180,19 @@ reportSubmit.addEventListener("click", async () => {
   }
   reportSubmit.disabled = true;
   try {
-    const body = await buildReportBody(reportBody.value);
-    await window.orbit.openIssueReport({ title, body });
+    const payload = await buildFeedbackPayload();
+    const result = await window.orbit.submitFeedback(payload);
+    if (result.ok) {
+      closeReportModal();
+      return;
+    }
+    // Fallback: the private store was unreachable. Open a PUBLIC GitHub issue
+    // with ONLY the user's text -- never the auto-collected diagnostics.
+    const fallbackBody = capForGithubUrl(
+      (reportBody.value.trim() || "(no description provided)") +
+        "\n\n_(sent via fallback; diagnostics omitted -- the feedback service was unreachable)_",
+    );
+    await window.orbit.openIssueReport({ title, body: fallbackBody });
     closeReportModal();
   } finally {
     reportSubmit.disabled = false;

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -272,10 +272,10 @@
         <button
           id="report-issue-btn"
           class="footer-control is-interactive"
-          title="Report an issue"
-          aria-label="Report an issue"
+          title="Send feedback"
+          aria-label="Send feedback"
         >
-          Report
+          Feedback
         </button>
         <div
           id="exec-mode-toggle"
@@ -630,28 +630,25 @@
       </div>
     </div>
 
-    <!-- Report-issue modal -->
+    <!-- Send-feedback modal -->
     <div id="report-overlay" class="modal-overlay hidden">
       <div class="modal">
         <div class="modal-header">
-          <h2>Report an issue</h2>
+          <h2>Send feedback</h2>
           <button id="report-close" class="modal-close" title="Close" aria-label="Close">×</button>
         </div>
         <div class="modal-body">
           <div class="report-account-note">
-            You'll need a GitHub account to submit this — your default browser will open the
-            pre-filled issue page on
+            Your feedback goes straight to the Loom team's private feedback store — no GitHub
+            account needed. If that service is unreachable, Orbit falls back to opening a pre-filled
+            issue on
             <a
               href="https://github.com/galaxyproject/loom"
               target="_blank"
               rel="noopener noreferrer"
               >github.com/galaxyproject/loom</a
-            >, and you click <em>Submit</em> there. No GitHub account?
-            <a href="https://github.com/signup" target="_blank" rel="noopener noreferrer"
-              >Create one</a
             >
-            — if you're serious about data analysis, you'll want one anyway (code, notebooks,
-            collaboration all live there).
+            with only your title and description (no diagnostics), which you submit there.
           </div>
           <div class="prefs-row">
             <label for="report-title">Title</label>
@@ -670,27 +667,28 @@
             <label><input type="checkbox" id="report-include-logs" /> Include logs</label>
           </div>
           <details class="report-disclosure">
-            <summary>What's in this report?</summary>
+            <summary>What's included?</summary>
             <p>
               <b>System info:</b> Orbit version, OS, Electron/Node versions, LLM model + provider
               name (no API key), Galaxy connection state (no credentials).
             </p>
             <p>
-              <b>Logs:</b> last 30 lines of <code>activity.jsonl</code> (if present in the cwd) and
-              last ~150 lines of the in-app shell stream. These can include filenames, tool
-              arguments, and command output -- review the issue body on GitHub before you click
-              Submit there.
+              <b>Logs:</b> last 15 events of <code>activity.jsonl</code> (summarized to one line
+              each, no raw payloads) and the last ~80 lines of the in-app shell stream. These can
+              include filenames, tool arguments, and command output.
             </p>
             <p>
-              Both are off by default. Opt in only when you've decided you're OK sharing them on a
-              public issue.
+              Both are on by default for the beta so we get useful diagnostics. Feedback goes to
+              Loom's private feedback store; uncheck either box to leave it out. If the store is
+              unreachable and we fall back to a public GitHub issue, only your text is sent — never
+              these diagnostics.
             </p>
           </details>
         </div>
         <div class="modal-footer">
           <div class="modal-actions">
             <button id="report-cancel" class="plan-btn">Cancel</button>
-            <button id="report-submit" class="plan-btn primary">Open as GitHub issue</button>
+            <button id="report-submit" class="plan-btn primary">Send feedback</button>
           </div>
         </div>
       </div>

--- a/extensions/loom/feedback-command.ts
+++ b/extensions/loom/feedback-command.ts
@@ -1,0 +1,62 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { submitFeedback, buildBrainSysinfo, summarizeActivityTail } from "./feedback.js";
+import { getRecentActivityEvents } from "./activity.js";
+import { SCHEMA_VERSION } from "../../shared/feedback-contract.js";
+import type { FeedbackPayload } from "../../shared/feedback-contract.js";
+
+/**
+ * /feedback -- gather feedback inline via ctx.ui and POST it to the capture
+ * worker. Cross-shell: ctx.ui renders in Orbit and the Loom CLI alike. The
+ * brain cannot open Orbit's HTML modal (no plumbing), so this is the brain's
+ * own capture path. Guards on ctx.hasUI so it never POSTs an empty payload in
+ * non-interactive/RPC mode.
+ */
+export function registerFeedbackCommand(pi: ExtensionAPI): void {
+  pi.registerCommand("feedback", {
+    description: "Send feedback about Loom to the team (captures optional diagnostics).",
+    handler: async (args: string | undefined, ctx: ExtensionContext) => {
+      if (!ctx.hasUI) {
+        ctx.ui.notify(
+          "/feedback needs interactive mode. Re-run it in Orbit or an interactive CLI session.",
+          "warning",
+        );
+        return;
+      }
+
+      const title =
+        (args && args.trim()) || (await ctx.ui.input("Feedback -- short title", "Summarize it"));
+      if (!title || !title.trim()) return;
+
+      const body = (await ctx.ui.editor("What's the feedback?", "")) ?? "";
+
+      const includeDiagnostics = await ctx.ui.confirm(
+        "Include diagnostics?",
+        "Attach system info + a summarized recent-activity log to help us debug. No API keys or credentials are sent.",
+      );
+
+      const payload: FeedbackPayload = {
+        schemaVersion: SCHEMA_VERSION,
+        source: "loom-cli",
+        title: title.trim(),
+        body: body.trim(),
+        clientTs: new Date().toISOString(),
+        ...(includeDiagnostics
+          ? {
+              sysinfo: buildBrainSysinfo(),
+              activityTail: summarizeActivityTail(getRecentActivityEvents(15)),
+            }
+          : {}),
+      };
+
+      const res = await submitFeedback(payload);
+      if (res.ok) {
+        ctx.ui.notify("Thanks -- your feedback was sent.", "info");
+      } else {
+        ctx.ui.notify(
+          `Couldn't reach the feedback service (${res.error ?? "unknown error"}). Try again later or use Report in Orbit.`,
+          "error",
+        );
+      }
+    },
+  });
+}

--- a/extensions/loom/feedback-command.ts
+++ b/extensions/loom/feedback-command.ts
@@ -1,5 +1,11 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { submitFeedback, buildBrainSysinfo, summarizeActivityTail } from "./feedback.js";
+import {
+  submitFeedback,
+  buildBrainSysinfo,
+  summarizeActivityTail,
+  appendToOutbox,
+  readLoomVersion,
+} from "./feedback.js";
 import { getRecentActivityEvents } from "./activity.js";
 import { SCHEMA_VERSION } from "../../shared/feedback-contract.js";
 import type { FeedbackPayload } from "../../shared/feedback-contract.js";
@@ -31,9 +37,11 @@ export function registerFeedbackCommand(pi: ExtensionAPI): void {
 
       const includeDiagnostics = await ctx.ui.confirm(
         "Include diagnostics?",
-        "Attach system info + a summarized recent-activity log to help us debug. No API keys or credentials are sent.",
+        "Attach system info + a one-line-per-event activity summary (no command output or arguments), sent to the Loom team's private feedback store. No API keys or credentials are sent.",
       );
 
+      // The app version always rides along (non-sensitive build metadata) so every
+      // loom-cli row is filterable by release in triage, even without diagnostics.
       const payload: FeedbackPayload = {
         schemaVersion: SCHEMA_VERSION,
         source: "loom-cli",
@@ -45,18 +53,22 @@ export function registerFeedbackCommand(pi: ExtensionAPI): void {
               sysinfo: buildBrainSysinfo(),
               activityTail: summarizeActivityTail(getRecentActivityEvents(15)),
             }
-          : {}),
+          : { sysinfo: { appVersion: readLoomVersion() } }),
       };
 
       const res = await submitFeedback(payload);
       if (res.ok) {
         ctx.ui.notify("Thanks -- your feedback was sent.", "info");
-      } else {
-        ctx.ui.notify(
-          `Couldn't reach the feedback service (${res.error ?? "unknown error"}). Try again later or use Report in Orbit.`,
-          "error",
-        );
+        return;
       }
+      // Durability: never lose the user's note if the store is unreachable.
+      const saved = appendToOutbox(payload);
+      ctx.ui.notify(
+        saved
+          ? `Couldn't reach the feedback service (${res.error ?? "unknown error"}) -- saved locally, we'll pick it up later.`
+          : `Couldn't reach the feedback service (${res.error ?? "unknown error"}). Please try again later.`,
+        saved ? "warning" : "error",
+      );
     },
   });
 }

--- a/extensions/loom/feedback.ts
+++ b/extensions/loom/feedback.ts
@@ -6,18 +6,39 @@ import {
 } from "../../shared/feedback-contract.js";
 import type { FeedbackPayload, FeedbackSysinfo } from "../../shared/feedback-contract.js";
 import type { ActivityEvent } from "./activity.js";
-import { loadConfig } from "./config.js";
+import { loadConfig, getConfigDir } from "./config.js";
 import { loadProfiles } from "./profiles.js";
+import { appendFileSync, readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
 
 // Endpoint base is the shared constant; LOOM_FEEDBACK_URL overrides it for local
 // dev (point at http://localhost:8787 while running `wrangler dev`).
 const ENDPOINT = (process.env.LOOM_FEEDBACK_URL || FEEDBACK_ENDPOINT_URL) + FEEDBACK_ROUTE;
+const TIMEOUT_MS = 10_000;
 
 export interface FeedbackResult {
   ok: boolean;
   status?: number;
   id?: string;
   error?: string;
+}
+
+/**
+ * Best-effort read of the Loom package version so loom-cli rows carry a build for
+ * triage. Resolves the repo-root package.json the same way the brain resolves
+ * ../../shared at runtime. Returns undefined if it can't be read (safe fallback).
+ */
+export function readLoomVersion(): string | undefined {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const pkg = JSON.parse(readFileSync(join(here, "../../package.json"), "utf-8")) as {
+      version?: string;
+    };
+    return pkg.version;
+  } catch {
+    return undefined;
+  }
 }
 
 /**
@@ -37,6 +58,7 @@ export function buildBrainSysinfo(): FeedbackSysinfo {
   };
   const active = cfg.llm?.active;
   return {
+    appVersion: readLoomVersion(),
     platform: process.platform,
     arch: process.arch,
     node: process.versions.node,
@@ -54,11 +76,26 @@ export async function submitFeedback(payload: FeedbackPayload): Promise<Feedback
       method: "POST",
       headers,
       body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(TIMEOUT_MS),
     });
     const data = (await res.json().catch(() => ({}))) as { id?: string; error?: string };
     return { ok: res.ok, status: res.status, id: data.id, error: data.error };
   } catch (err) {
     return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Durability backstop: when a POST fails, append the payload to a local outbox so
+ * the feedback isn't lost. Returns the outbox path on success, null on failure.
+ */
+export function appendToOutbox(payload: FeedbackPayload): string | null {
+  try {
+    const outbox = join(getConfigDir(), "feedback-outbox.jsonl");
+    appendFileSync(outbox, JSON.stringify(payload) + "\n", "utf-8");
+    return outbox;
+  } catch {
+    return null;
   }
 }
 

--- a/extensions/loom/feedback.ts
+++ b/extensions/loom/feedback.ts
@@ -1,0 +1,65 @@
+import {
+  FEEDBACK_ROUTE,
+  FEEDBACK_ENDPOINT_URL,
+  FEEDBACK_KEY_HEADER,
+  SCHEMA_VERSION,
+} from "../../shared/feedback-contract.js";
+import type { FeedbackPayload, FeedbackSysinfo } from "../../shared/feedback-contract.js";
+import type { ActivityEvent } from "./activity.js";
+import { loadConfig } from "./config.js";
+import { loadProfiles } from "./profiles.js";
+
+// Endpoint base is the shared constant; LOOM_FEEDBACK_URL overrides it for local
+// dev (point at http://localhost:8787 while running `wrangler dev`).
+const ENDPOINT = (process.env.LOOM_FEEDBACK_URL || FEEDBACK_ENDPOINT_URL) + FEEDBACK_ROUTE;
+
+export interface FeedbackResult {
+  ok: boolean;
+  status?: number;
+  id?: string;
+  error?: string;
+}
+
+/**
+ * Summarize an activity tail to `timestamp kind (source)` lines only. Never ship
+ * raw event payloads -- they carry tool I/O (paths, prompts, dataset names).
+ */
+export function summarizeActivityTail(events: ActivityEvent[]): string {
+  return events
+    .map((e) => `${e.timestamp} ${e.kind}${e.source ? " (" + e.source + ")" : ""}`)
+    .join("\n");
+}
+
+/** Brain-side sysinfo. No Electron here (the brain is a Node child), no secrets. */
+export function buildBrainSysinfo(): FeedbackSysinfo {
+  const cfg = loadConfig() as {
+    llm?: { active?: string; providers?: Record<string, { model?: string }> };
+  };
+  const active = cfg.llm?.active;
+  return {
+    platform: process.platform,
+    arch: process.arch,
+    node: process.versions.node,
+    llmProvider: active,
+    llmModel: active ? cfg.llm?.providers?.[active]?.model : undefined,
+    galaxyConfigured: Boolean(loadProfiles().active),
+  };
+}
+
+export async function submitFeedback(payload: FeedbackPayload): Promise<FeedbackResult> {
+  try {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (process.env.LOOM_FEEDBACK_KEY) headers[FEEDBACK_KEY_HEADER] = process.env.LOOM_FEEDBACK_KEY;
+    const res = await fetch(ENDPOINT, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+    });
+    const data = (await res.json().catch(() => ({}))) as { id?: string; error?: string };
+    return { ok: res.ok, status: res.status, id: data.id, error: data.error };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export const FEEDBACK_SCHEMA_VERSION = SCHEMA_VERSION;

--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -16,6 +16,7 @@ import { setupUIBridge } from "./ui-bridge";
 import { registerSessionLifecycle } from "./session-lifecycle";
 import { registerActivityHooks } from "./activity-hooks";
 import { registerExecutionCommands } from "./execution-commands";
+import { registerFeedbackCommand } from "./feedback-command";
 import { registerTeamTools } from "./teams/tool";
 import { isTeamDispatchEnabled } from "./teams/is-enabled";
 import { registerSessionIndexTools } from "./session-index/tools";
@@ -44,6 +45,7 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
   registerNotebookSyncTools(pi);
   registerSyncCommand(pi);
   registerExecutionCommands(pi);
+  registerFeedbackCommand(pi);
   registerConfusablesHint(pi);
   if (isTeamDispatchEnabled()) {
     registerTeamTools(pi);

--- a/shared/feedback-contract.d.ts
+++ b/shared/feedback-contract.d.ts
@@ -1,0 +1,29 @@
+export declare const SCHEMA_VERSION: 1;
+export declare const FEEDBACK_ROUTE: "/feedback";
+export declare const FEEDBACK_KEY_HEADER: "X-Orbit-Feedback-Key";
+export declare const FEEDBACK_ENDPOINT_URL: string;
+
+export interface FeedbackSysinfo {
+  appVersion?: string;
+  platform?: string;
+  arch?: string;
+  electron?: string;
+  chrome?: string;
+  node?: string;
+  llmProvider?: string;
+  llmModel?: string;
+  galaxyConfigured?: boolean;
+}
+
+export interface FeedbackPayload {
+  schemaVersion: 1;
+  source: "orbit" | "loom-cli";
+  title: string;
+  body: string;
+  sysinfo?: FeedbackSysinfo;
+  activityTail?: string;
+  shellTail?: string;
+  clientTs: string;
+}
+
+export declare function validateFeedbackPayload(obj: unknown): obj is FeedbackPayload;

--- a/shared/feedback-contract.js
+++ b/shared/feedback-contract.js
@@ -10,7 +10,7 @@ export const FEEDBACK_KEY_HEADER = "X-Orbit-Feedback-Key";
 // Production endpoint base (no trailing slash). Set after `wrangler deploy` of
 // the orbit-feedback worker. Clients may override via the LOOM_FEEDBACK_URL env
 // var for local dev.
-export const FEEDBACK_ENDPOINT_URL = "https://orbit-feedback.PLACEHOLDER.workers.dev";
+export const FEEDBACK_ENDPOINT_URL = "https://orbit-feedback.dannon-baker.workers.dev";
 
 const SOURCES = new Set(["orbit", "loom-cli"]);
 

--- a/shared/feedback-contract.js
+++ b/shared/feedback-contract.js
@@ -1,0 +1,26 @@
+// Shared feedback wire contract. Dual-file (.js runtime + .d.ts types) to match
+// team-dispatch-contract: the brain resolves a real .js at runtime, so a single
+// .ts would risk a missing runtime file. No Node imports here -- this file is
+// renderer-safe and shared by the brain, Orbit main, and (by copy) the worker.
+
+export const SCHEMA_VERSION = 1;
+export const FEEDBACK_ROUTE = "/feedback";
+export const FEEDBACK_KEY_HEADER = "X-Orbit-Feedback-Key";
+
+// Production endpoint base (no trailing slash). Set after `wrangler deploy` of
+// the orbit-feedback worker. Clients may override via the LOOM_FEEDBACK_URL env
+// var for local dev.
+export const FEEDBACK_ENDPOINT_URL = "https://orbit-feedback.PLACEHOLDER.workers.dev";
+
+const SOURCES = new Set(["orbit", "loom-cli"]);
+
+export function validateFeedbackPayload(obj) {
+  if (typeof obj !== "object" || obj === null) return false;
+  const p = obj;
+  if (p.schemaVersion !== SCHEMA_VERSION) return false;
+  if (typeof p.source !== "string" || !SOURCES.has(p.source)) return false;
+  if (typeof p.title !== "string" || p.title.trim().length === 0) return false;
+  if (typeof p.body !== "string") return false;
+  if (typeof p.clientTs !== "string") return false;
+  return true;
+}

--- a/tests/feedback-command.test.ts
+++ b/tests/feedback-command.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const submitFeedback = vi.fn();
+vi.mock("../extensions/loom/feedback.js", () => ({
+  submitFeedback: (...a: unknown[]) => submitFeedback(...a),
+  buildBrainSysinfo: () => ({ platform: "darwin" }),
+  summarizeActivityTail: () => "t1 kind (src)",
+}));
+vi.mock("../extensions/loom/activity.js", () => ({ getRecentActivityEvents: () => [] }));
+
+const { registerFeedbackCommand } = await import("../extensions/loom/feedback-command.js");
+
+function makeApi() {
+  const commands = new Map<
+    string,
+    { handler: (a: string | undefined, ctx: any) => Promise<void> }
+  >();
+  const pi = { registerCommand: vi.fn((n: string, d: any) => commands.set(n, d)) };
+  return { pi, commands };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("/feedback", () => {
+  it("registers a feedback command", () => {
+    const { pi, commands } = makeApi();
+    registerFeedbackCommand(pi as any);
+    expect(commands.has("feedback")).toBe(true);
+  });
+
+  it("notifies and skips POST when there is no UI", async () => {
+    const { pi, commands } = makeApi();
+    registerFeedbackCommand(pi as any);
+    const notify = vi.fn();
+    await commands.get("feedback")!.handler(undefined, { hasUI: false, ui: { notify } });
+    expect(notify).toHaveBeenCalled();
+    expect(submitFeedback).not.toHaveBeenCalled();
+  });
+
+  it("gathers input and POSTs when UI is present", async () => {
+    submitFeedback.mockResolvedValue({ ok: true, id: "z" });
+    const { pi, commands } = makeApi();
+    registerFeedbackCommand(pi as any);
+    const ui = {
+      input: vi.fn().mockResolvedValue("My title"),
+      editor: vi.fn().mockResolvedValue("My body"),
+      confirm: vi.fn().mockResolvedValue(true),
+      notify: vi.fn(),
+    };
+    await commands.get("feedback")!.handler(undefined, { hasUI: true, ui });
+    expect(submitFeedback).toHaveBeenCalledOnce();
+    const payload = submitFeedback.mock.calls[0][0];
+    expect(payload.source).toBe("loom-cli");
+    expect(payload.title).toBe("My title");
+    expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("Thanks"), "info");
+  });
+
+  it("aborts if the user cancels the title", async () => {
+    const { pi, commands } = makeApi();
+    registerFeedbackCommand(pi as any);
+    const ui = {
+      input: vi.fn().mockResolvedValue(undefined),
+      editor: vi.fn(),
+      confirm: vi.fn(),
+      notify: vi.fn(),
+    };
+    await commands.get("feedback")!.handler(undefined, { hasUI: true, ui });
+    expect(submitFeedback).not.toHaveBeenCalled();
+  });
+});

--- a/tests/feedback-command.test.ts
+++ b/tests/feedback-command.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const submitFeedback = vi.fn();
+const appendToOutbox = vi.fn();
 vi.mock("../extensions/loom/feedback.js", () => ({
   submitFeedback: (...a: unknown[]) => submitFeedback(...a),
   buildBrainSysinfo: () => ({ platform: "darwin" }),
   summarizeActivityTail: () => "t1 kind (src)",
+  appendToOutbox: (...a: unknown[]) => appendToOutbox(...a),
+  readLoomVersion: () => "0.0.0-test",
 }));
 vi.mock("../extensions/loom/activity.js", () => ({ getRecentActivityEvents: () => [] }));
 
@@ -17,6 +20,16 @@ function makeApi() {
   >();
   const pi = { registerCommand: vi.fn((n: string, d: any) => commands.set(n, d)) };
   return { pi, commands };
+}
+
+function uiMock(overrides: Record<string, any> = {}) {
+  return {
+    input: vi.fn().mockResolvedValue("My title"),
+    editor: vi.fn().mockResolvedValue("My body"),
+    confirm: vi.fn().mockResolvedValue(true),
+    notify: vi.fn(),
+    ...overrides,
+  };
 }
 
 beforeEach(() => vi.clearAllMocks());
@@ -41,29 +54,52 @@ describe("/feedback", () => {
     submitFeedback.mockResolvedValue({ ok: true, id: "z" });
     const { pi, commands } = makeApi();
     registerFeedbackCommand(pi as any);
-    const ui = {
-      input: vi.fn().mockResolvedValue("My title"),
-      editor: vi.fn().mockResolvedValue("My body"),
-      confirm: vi.fn().mockResolvedValue(true),
-      notify: vi.fn(),
-    };
+    const ui = uiMock();
     await commands.get("feedback")!.handler(undefined, { hasUI: true, ui });
     expect(submitFeedback).toHaveBeenCalledOnce();
     const payload = submitFeedback.mock.calls[0][0];
     expect(payload.source).toBe("loom-cli");
     expect(payload.title).toBe("My title");
     expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("Thanks"), "info");
+    expect(appendToOutbox).not.toHaveBeenCalled();
+  });
+
+  it("stamps appVersion even when diagnostics are declined", async () => {
+    submitFeedback.mockResolvedValue({ ok: true, id: "z" });
+    const { pi, commands } = makeApi();
+    registerFeedbackCommand(pi as any);
+    const ui = uiMock({ confirm: vi.fn().mockResolvedValue(false) });
+    await commands.get("feedback")!.handler(undefined, { hasUI: true, ui });
+    const payload = submitFeedback.mock.calls[0][0];
+    expect(payload.sysinfo).toEqual({ appVersion: "0.0.0-test" });
+    expect(payload.activityTail).toBeUndefined();
+  });
+
+  it("saves to the outbox and warns when the POST fails", async () => {
+    submitFeedback.mockResolvedValue({ ok: false, error: "offline" });
+    appendToOutbox.mockReturnValue("/cfg/feedback-outbox.jsonl");
+    const { pi, commands } = makeApi();
+    registerFeedbackCommand(pi as any);
+    const ui = uiMock();
+    await commands.get("feedback")!.handler(undefined, { hasUI: true, ui });
+    expect(appendToOutbox).toHaveBeenCalledOnce();
+    expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("saved locally"), "warning");
+  });
+
+  it("renders 'unknown error' with an error toast when the outbox also fails", async () => {
+    submitFeedback.mockResolvedValue({ ok: false });
+    appendToOutbox.mockReturnValue(null);
+    const { pi, commands } = makeApi();
+    registerFeedbackCommand(pi as any);
+    const ui = uiMock();
+    await commands.get("feedback")!.handler(undefined, { hasUI: true, ui });
+    expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("unknown error"), "error");
   });
 
   it("aborts if the user cancels the title", async () => {
     const { pi, commands } = makeApi();
     registerFeedbackCommand(pi as any);
-    const ui = {
-      input: vi.fn().mockResolvedValue(undefined),
-      editor: vi.fn(),
-      confirm: vi.fn(),
-      notify: vi.fn(),
-    };
+    const ui = uiMock({ input: vi.fn().mockResolvedValue(undefined) });
     await commands.get("feedback")!.handler(undefined, { hasUI: true, ui });
     expect(submitFeedback).not.toHaveBeenCalled();
   });

--- a/tests/feedback-contract.test.ts
+++ b/tests/feedback-contract.test.ts
@@ -37,4 +37,12 @@ describe("feedback contract", () => {
     expect(validateFeedbackPayload(null)).toBe(false);
     expect(validateFeedbackPayload("nope")).toBe(false);
   });
+
+  it("rejects a wrong schemaVersion, non-string body, or missing clientTs", () => {
+    expect(validateFeedbackPayload({ ...valid, schemaVersion: 2 })).toBe(false);
+    expect(validateFeedbackPayload({ ...valid, body: 123 })).toBe(false);
+    expect(
+      validateFeedbackPayload({ schemaVersion: 1, source: "orbit", title: "t", body: "b" }),
+    ).toBe(false);
+  });
 });

--- a/tests/feedback-contract.test.ts
+++ b/tests/feedback-contract.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateFeedbackPayload,
+  SCHEMA_VERSION,
+  FEEDBACK_ROUTE,
+  FEEDBACK_KEY_HEADER,
+} from "../shared/feedback-contract.js";
+
+const valid = {
+  schemaVersion: 1,
+  source: "orbit",
+  title: "It crashed",
+  body: "Steps: ...",
+  clientTs: "2026-06-02T00:00:00.000Z",
+};
+
+describe("feedback contract", () => {
+  it("exposes stable wire constants", () => {
+    expect(SCHEMA_VERSION).toBe(1);
+    expect(FEEDBACK_ROUTE).toBe("/feedback");
+    expect(FEEDBACK_KEY_HEADER).toBe("X-Orbit-Feedback-Key");
+  });
+
+  it("accepts a minimal valid payload", () => {
+    expect(validateFeedbackPayload(valid)).toBe(true);
+  });
+
+  it("rejects missing title", () => {
+    expect(validateFeedbackPayload({ ...valid, title: "" })).toBe(false);
+  });
+
+  it("rejects an unknown source", () => {
+    expect(validateFeedbackPayload({ ...valid, source: "evil" })).toBe(false);
+  });
+
+  it("rejects a non-object", () => {
+    expect(validateFeedbackPayload(null)).toBe(false);
+    expect(validateFeedbackPayload("nope")).toBe(false);
+  });
+});

--- a/tests/feedback-helper.test.ts
+++ b/tests/feedback-helper.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { submitFeedback, summarizeActivityTail } from "../extensions/loom/feedback.js";
+
+describe("brain submitFeedback", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("summarizes activity events to timestamp+kind+source", () => {
+    const out = summarizeActivityTail([
+      { timestamp: "t1", kind: "tool_call", source: "galaxy", payload: { secret: "x" } },
+      { timestamp: "t2", kind: "message", source: "user", payload: {} },
+    ]);
+    expect(out).toBe("t1 tool_call (galaxy)\nt2 message (user)");
+    expect(out).not.toContain("secret");
+  });
+
+  it("POSTs the payload and returns ok+id", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ ok: true, id: "abc" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await submitFeedback({
+      schemaVersion: 1,
+      source: "loom-cli",
+      title: "t",
+      body: "b",
+      clientTs: "now",
+    });
+    expect(res.ok).toBe(true);
+    expect(res.id).toBe("abc");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(String(url)).toMatch(/\/feedback$/);
+    expect(opts.method).toBe("POST");
+  });
+
+  it("returns ok:false on network error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    const res = await submitFeedback({
+      schemaVersion: 1,
+      source: "loom-cli",
+      title: "t",
+      body: "b",
+      clientTs: "now",
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error).toContain("offline");
+  });
+});


### PR DESCRIPTION
## What this does

For the beta we want to actually capture feedback into a store we own, instead of leaning on the high-friction public-GitHub-issue path. This reworks the existing "Report an issue" flow and adds a brain command:

- **Orbit "Send feedback" modal** (was "Report an issue"): posts a structured payload to a private capture endpoint. Both "include system info" and "include logs" now **default ON** -- the destination is a private store, not a public issue. If the POST fails it falls back to the old pre-filled GitHub issue, but **text-only**, never the auto-collected diagnostics, so default-on logs can't land on a public issue.
- **`/feedback`** in the Loom brain: an always-on command that captures a title + body inline via `ctx.ui` (Orbit and the CLI alike), guarded on `hasUI`. On a failed POST it appends the payload to a local outbox so nothing is lost.
- **Shared `feedback-contract`**: one payload type + validator + wire constants that the brain, Orbit main, and the worker all bind to.

The endpoint is a small companion Cloudflare Worker + D1 (separate repo: https://github.com/dannon/orbit-feedback): `POST /feedback` validates, caps body size, rate-limits per hashed IP, and stores a row; `GET /admin/feedback` is Basic-auth'd.

## Notable details

- Fixes a latent bug in the old report code: it read `llm.provider`/`llm.model`, which don't exist on the masked config shape, so sysinfo always showed `(none)/(none)`. Now reads `llm.active` + `providers[active].model`.
- The activity tail is summarized to one line per event (timestamp/kind/source) -- never raw payloads. Sysinfo carries no API keys, credentials, or cwd. The endpoint URL and any key live in Orbit's main process only; the renderer just calls `submitFeedback`.

## Deployment

The companion worker is deployed (Cloudflare Worker + D1) and `FEEDBACK_ENDPOINT_URL` is wired to it; a live POST round-trips and lands a row in D1. Local dev still overrides the base via `LOOM_FEEDBACK_URL` against `wrangler dev`.

## Testing

Root suite green (new contract/helper/command tests); brain and Orbit typecheck clean; the worker has its own tests (payload validation, size cap, rate-limit 429, admin auth, bad JSON).
