### PR TITLE
feat: cut per-turn context tokens (cache-stable prompt + /compact)

### DIFF
--- a/docs/agent/commands.md
+++ b/docs/agent/commands.md
@@ -24,11 +24,11 @@ There are no `analysis_*` plan tools. Plans are markdown sections.
 
 ## Slash commands
 
-| Command                   | What it does                                                           |
-| ------------------------- | ---------------------------------------------------------------------- |
-| `/notebook`               | View current notebook content                                          |
-| `/status`                 | Galaxy connection + notebook path summary                              |
-| `/connect [name]`         | Connect to Galaxy (prompts for credentials, or switches profile)       |
-| `/profiles`               | List saved Galaxy server profiles                                      |
-| `/execute` (alias `/run`) | Tell the agent to run the next pending step in the latest plan section |
-| `/compact [instructions]` | Compact the conversation to reclaim context; optional summary steer    |
+| Command                   | What it does                                                                                                                                      |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/notebook`               | View current notebook content                                                                                                                     |
+| `/status`                 | Galaxy connection + notebook path summary                                                                                                         |
+| `/connect [name]`         | Connect to Galaxy (prompts for credentials, or switches profile)                                                                                  |
+| `/profiles`               | List saved Galaxy server profiles                                                                                                                 |
+| `/execute` (alias `/run`) | Tell the agent to run the next pending step in the latest plan section                                                                            |
+| `/compact [instructions]` | Compact the conversation to reclaim context; optional summary steer (Orbit defaults to a notebook-aware summary; terminal CLI uses pi's built-in) |

--- a/docs/agent/commands.md
+++ b/docs/agent/commands.md
@@ -31,3 +31,4 @@ There are no `analysis_*` plan tools. Plans are markdown sections.
 | `/connect [name]`         | Connect to Galaxy (prompts for credentials, or switches profile)       |
 | `/profiles`               | List saved Galaxy server profiles                                      |
 | `/execute` (alias `/run`) | Tell the agent to run the next pending step in the latest plan section |
+| `/compact [instructions]` | Compact the conversation to reclaim context; optional summary steer    |

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -12,14 +12,12 @@ import * as fs from "fs";
 import { getState, getNotebookPath } from "./state";
 import { isTeamDispatchEnabled } from "./teams/is-enabled";
 import { isSessionIndexEnabled } from "./session-index/is-enabled";
-import { getRecentActivityEvents } from "./activity";
 import { loadConfig } from "./config";
 import { listEnabledSkillRepos } from "./skills";
 import { findGalaxyPageBlocks } from "./galaxy-page-binding";
 
 const NOTEBOOK_HEAD_MAX_CHARS = 2000;
 const NOTEBOOK_TAIL_MAX_CHARS = 4000;
-const ACTIVITY_TAIL_COUNT = 10;
 
 /**
  * Read the user-curated notebook.md from disk and return a head + tail
@@ -106,22 +104,6 @@ Use \`notebook_push_to_galaxy\` to share progress with the user (creates a new
 revision of the Galaxy page). Use \`notebook_pull_from_galaxy\` to fetch
 updates the user made on the Galaxy side -- only when the user explicitly
 asks for it, since pull discards local edits since the last sync.
-`;
-}
-
-/**
- * Last few activity events for continuity across restarts.
- */
-function buildRecentActivityBlock(): string {
-  const events = getRecentActivityEvents(ACTIVITY_TAIL_COUNT);
-  if (events.length === 0) return "";
-  const lines = events.map((e) => `- ${e.timestamp} · ${e.kind}`);
-  return `
-## Recent activity
-
-Last ${events.length} event(s):
-
-${lines.join("\n")}
 `;
 }
 
@@ -979,6 +961,13 @@ function isLlama4Family(model: { id?: string; provider?: string } | undefined): 
 
 export function setupContextInjection(pi: ExtensionAPI): void {
   pi.on("before_agent_start", async (_event, ctx) => {
+    // The system prompt is sent as one cached block (Anthropic cache_control
+    // sits on the whole system text). Anything that changes turn-to-turn busts
+    // that cache for the entire ~8K-token prefix. So we keep the blocks below
+    // stable within a session — they only change when their inputs do (notebook
+    // edits, model/connection switch). The live activity tail (timestamps that
+    // changed every turn) was deliberately dropped from here; it stays in the
+    // Activity pane and activity.jsonl. The notebook is the durable record.
     const omitAnchors = isLlama4Family(ctx.model);
     const systemPrompt = [
       buildActiveModelBlock(),
@@ -994,7 +983,6 @@ export function setupContextInjection(pi: ExtensionAPI): void {
       buildLocalEnvContext(),
       buildNotebookExcerptBlock(),
       buildGalaxyPageBindingBlock(),
-      buildRecentActivityBlock(),
       buildTeamDispatchContext(),
       buildSessionIndexContext(),
     ]

--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -248,6 +248,36 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
   });
 
   // ─────────────────────────────────────────────────────────────────────────────
+  // /compact — manually compact the conversation to reclaim context
+  // ─────────────────────────────────────────────────────────────────────────────
+  pi.registerCommand("compact", {
+    description:
+      "Compact the conversation to free up context. Optional: /compact <instructions> to steer the summary.",
+    handler: async (args, ctx) => {
+      const before = ctx.getContextUsage();
+      const beforeStr = before?.tokens != null ? `${before.tokens.toLocaleString()} tokens` : "?";
+      // The notebook is the durable record (snapshotted on session_before_compact),
+      // so the summary can drop verbose tool chatter without losing project state.
+      const customInstructions =
+        args.trim() ||
+        "Preserve the current analysis plan, decisions, and Galaxy invocation state. " +
+          "Verbose tool outputs and dataset previews can be dropped — the notebook holds the durable record.";
+      ctx.ui.notify(`Compacting (was ${beforeStr})…`, "info");
+      ctx.compact({
+        customInstructions,
+        onComplete: () => {
+          const after = ctx.getContextUsage();
+          const afterStr = after?.tokens != null ? `${after.tokens.toLocaleString()} tokens` : "?";
+          ctx.ui.notify(`✅ Compacted: ${beforeStr} → ${afterStr}`, "info");
+        },
+        onError: (err) => {
+          ctx.ui.notify(`Compaction failed: ${err.message}`, "error");
+        },
+      });
+    },
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────────
   // Tool execution lifecycle: show status when Galaxy tools run
   // ─────────────────────────────────────────────────────────────────────────────
   const toolStartTimes = new Map<string, number>();

--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -250,10 +250,33 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
   // ─────────────────────────────────────────────────────────────────────────────
   // /compact — manually compact the conversation to reclaim context
   // ─────────────────────────────────────────────────────────────────────────────
+  // Guards a second Loom /compact from racing the first: pi's compact() has no
+  // internal concurrency guard (it just resets its abort controller), so a
+  // concurrent call orphans the in-flight run. This only covers Loom-initiated
+  // compactions -- pi's own auto-compaction isn't observable from an extension
+  // (ExtensionContext exposes no isCompacting), so that race is left to pi.
+  // Cleared in both completion callbacks and on a synchronous compact() throw.
+  let compactionInFlight = false;
   pi.registerCommand("compact", {
     description:
       "Compact the conversation to free up context. Optional: /compact <instructions> to steer the summary.",
     handler: async (args, ctx) => {
+      // No UI (e.g. headless RPC consumers) -> skip notifications; still compact.
+      // Wrapped because ctx.ui/hasUI assert an active context and can throw if the
+      // session was swapped while a compaction was in flight; a dropped toast is fine.
+      const notify = (msg: string, level: "info" | "warning" | "error") => {
+        try {
+          if (ctx.hasUI) ctx.ui.notify(msg, level);
+        } catch {
+          /* stale context after a session swap -- nothing to show */
+        }
+      };
+
+      if (compactionInFlight) {
+        notify("A compaction is already running.", "warning");
+        return;
+      }
+
       const before = ctx.getContextUsage();
       const beforeStr = before?.tokens != null ? `${before.tokens.toLocaleString()} tokens` : "?";
       // The notebook is the durable record (snapshotted on session_before_compact),
@@ -262,18 +285,33 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
         args.trim() ||
         "Preserve the current analysis plan, decisions, and Galaxy invocation state. " +
           "Verbose tool outputs and dataset previews can be dropped — the notebook holds the durable record.";
-      ctx.ui.notify(`Compacting (was ${beforeStr})…`, "info");
-      ctx.compact({
-        customInstructions,
-        onComplete: () => {
-          const after = ctx.getContextUsage();
-          const afterStr = after?.tokens != null ? `${after.tokens.toLocaleString()} tokens` : "?";
-          ctx.ui.notify(`✅ Compacted: ${beforeStr} → ${afterStr}`, "info");
-        },
-        onError: (err) => {
-          ctx.ui.notify(`Compaction failed: ${err.message}`, "error");
-        },
-      });
+
+      compactionInFlight = true;
+      notify(`Compacting (was ${beforeStr})…`, "info");
+      try {
+        ctx.compact({
+          customInstructions,
+          onComplete: (result) => {
+            compactionInFlight = false;
+            // getContextUsage() reads null right after compaction (pi only learns the
+            // new size on the next model response), so report the authoritative
+            // before-count from the result; the footer shows the new size next turn.
+            notify(
+              `✅ Compacted (was ${result.tokensBefore.toLocaleString()} tokens). New size shows after the next turn.`,
+              "info",
+            );
+          },
+          onError: (err) => {
+            compactionInFlight = false;
+            notify(`Compaction failed: ${err.message}`, "error");
+          },
+        });
+      } catch (err) {
+        // ctx.compact() asserts an active context synchronously and can throw
+        // before either callback runs; reset the guard so /compact isn't wedged.
+        compactionInFlight = false;
+        notify(`Compaction failed: ${err instanceof Error ? err.message : String(err)}`, "error");
+      }
     },
   });
 


### PR DESCRIPTION
## Why

Orbit is token-hungry. The dominant cost isn't the notebook or tool outputs (both already lean — notebook is head+tail capped, Galaxy results are metadata-only) — it's the **~8K-token system prompt, rebuilt and re-injected on every turn** via `before_agent_start` (`context.ts setupContextInjection`).

That would be cheap *if it cached*. But Pi sends the system prompt as **one block with a single `cache_control` marker at its end** (`pi-ai/providers/anthropic.js`). Anthropic caches it as one unit, so any turn-to-turn change in the string busts the cache for the entire prefix — and `buildRecentActivityBlock` stamped **live timestamps** into the prompt every turn, guaranteeing a miss even when nothing else changed. Net effect: the full ~8K prefix was re-billed at full input price every turn on Anthropic/DeepSeek/OpenAI.

## What

1. **Drop `buildRecentActivityBlock` from the system prompt.** It was the sole *gratuitous* per-turn cache-buster (timestamps + event kinds, redundant with the notebook tail). The activity data is unchanged — it still lives in the Activity pane and `activity.jsonl` (`getActivityEvents` via listeners is untouched). Now the prompt is **byte-identical across turns where the notebook is unchanged**, so the prefix actually caches and reads at ~0.1× instead of missing.

2. **Add `/compact`.** Manual context compaction via `ctx.compact()`, with notebook-aware default instructions (the notebook is the durable record, snapshotted on `session_before_compact`, so the summary can drop verbose tool chatter) and a before→after token report. `/compact <instructions>` to steer the summary. Added to `docs/agent/commands.md`.

## Validation

- `npm test` — 355 passed
- `npm run typecheck` + `app` `tsc --noEmit` — clean

## Follow-ups (deliberately out of scope — want maintainer input)

- **Fully static system prompt.** The notebook excerpt still busts the cache on turns it's edited. Making the prompt fully static (notebook via on-demand `Read` instead of per-turn injection) would cache the whole prefix *every* turn — but it's a behavior change to the "notebook always in context" model, so flagging rather than doing. The accumulating-`message` channel is **not** a viable relocation target (custom messages from `before_agent_start` persist to the session and pile up one snapshot per turn).
- **`buildLocalEnvContext` (~1.4K tok) is injected even in Galaxy/cloud mode.** It was *deliberately* un-gated ("Always relevant; no longer mode-gated"), so left as-is — but it's the #2 static sink if re-gating or shrinking is on the table.
- These caching wins only help providers with prompt caching (Anthropic/DeepSeek/OpenAI). For TACC/llama, shrinking the static blocks + compaction are the levers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)