### PR TITLE
feat: add Opus 4.8 to the model list

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -91,6 +91,7 @@ let streaming = false;
 let PRICING: Record<string, { in: number; out: number; cacheRead?: number; cacheWrite?: number }> =
   {
     // Anthropic
+    "claude-opus-4-8": { in: 15, out: 75, cacheRead: 1.5, cacheWrite: 18.75 },
     "claude-opus-4-7": { in: 15, out: 75, cacheRead: 1.5, cacheWrite: 18.75 },
     "claude-opus-4-6": { in: 15, out: 75, cacheRead: 1.5, cacheWrite: 18.75 },
     "claude-opus-4-5": { in: 15, out: 75, cacheRead: 1.5, cacheWrite: 18.75 },
@@ -2616,9 +2617,10 @@ interface ModelChoice {
 }
 let MODELS_BY_PROVIDER: Record<string, ModelChoice[]> = {
   anthropic: [
-    { id: "claude-opus-4-7", label: "Opus 4.7 — $15/$75 (most capable)" },
+    { id: "claude-opus-4-8", label: "Opus 4.8 — $15/$75 (most capable)" },
     { id: "claude-sonnet-4-6", label: "Sonnet 4.6 — $3/$15 (recommended)" },
     { id: "claude-haiku-4-5", label: "Haiku 4.5 — $1/$5 (cheapest)" },
+    { id: "claude-opus-4-7", label: "Opus 4.7 — $15/$75" },
     { id: "claude-opus-4-6", label: "Opus 4.6 — $15/$75" },
     { id: "claude-sonnet-4-5", label: "Sonnet 4.5 — $3/$15" },
     { id: "claude-opus-4-5", label: "Opus 4.5 — $15/$75" },


### PR DESCRIPTION
Adds **Claude Opus 4.8** to the Orbit model picker.

`pi-ai`'s bundled registry currently tops out at Opus 4.7, so `populateDynamicModelData()` won't surface 4.8 at startup — the static fallback list is the only place it appears. So this hand-edit is required to offer 4.8 in the UI.

- Picker (`MODELS_BY_PROVIDER.anthropic`): `claude-opus-4-8` becomes the top "most capable" entry; 4.7 demoted to a plain entry.
- Fallback pricing (`PRICING`): `claude-opus-4-8` at the Opus tier ($15/$75, cacheRead 1.5, cacheWrite 18.75).

The short-label formatter is generic (`claude-opus-4-8` → "Opus 4.8"), so no other changes needed.

Validation: `app` `tsc --noEmit` clean; root `npm test` 355 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)