### PR TITLE
Don't gate every write when the analysis workspace lives under ~/.loom

### DIFF
--- a/extensions/loom/exec-guard/policy.ts
+++ b/extensions/loom/exec-guard/policy.ts
@@ -110,14 +110,11 @@ export function decide(req: PolicyRequest, deps: PolicyDeps): PolicyResult {
       return finalizeAsk(req, "write:sensitive", `write to sensitive path ${p}`);
     }
     // Gated even inside the jail: a script under .git/hooks runs on the next git
-    // operation, and .loom/ is Loom's own state -- the README promises these
-    // always prompt, so they must, regardless of being in the workspace. Scoped to
-    // the workspace root so an analysis filed under ~/.loom/analyses doesn't gate
-    // its own notebook on the incidental ancestor .loom segment. Resolve cwd through
-    // the same resolver as `resolved` so both are realpath'd -- otherwise a symlinked
-    // ~/.loom would put them in different spaces and the scoping would silently miss.
-    const workspaceRoot = deps.resolver.contains(req.cwd).resolved;
-    if (isProtectedWritePath(resolved, workspaceRoot)) {
+    // operation, and .loom/ is Loom's own state -- these always prompt, regardless
+    // of being in the workspace. The lone carve-out is the $HOME/.loom/analyses
+    // tree (Orbit's default cwd), where the analysis's own files are work product;
+    // a .git/.loom nested inside an analysis still gates. See isProtectedWritePath.
+    if (isProtectedWritePath(resolved, deps.home)) {
       return finalizeAsk(req, "write:protected", `write to protected path ${p}`);
     }
     if (inside)

--- a/extensions/loom/exec-guard/policy.ts
+++ b/extensions/loom/exec-guard/policy.ts
@@ -111,8 +111,13 @@ export function decide(req: PolicyRequest, deps: PolicyDeps): PolicyResult {
     }
     // Gated even inside the jail: a script under .git/hooks runs on the next git
     // operation, and .loom/ is Loom's own state -- the README promises these
-    // always prompt, so they must, regardless of being in the workspace.
-    if (isProtectedWritePath(resolved)) {
+    // always prompt, so they must, regardless of being in the workspace. Scoped to
+    // the workspace root so an analysis filed under ~/.loom/analyses doesn't gate
+    // its own notebook on the incidental ancestor .loom segment. Resolve cwd through
+    // the same resolver as `resolved` so both are realpath'd -- otherwise a symlinked
+    // ~/.loom would put them in different spaces and the scoping would silently miss.
+    const workspaceRoot = deps.resolver.contains(req.cwd).resolved;
+    if (isProtectedWritePath(resolved, workspaceRoot)) {
       return finalizeAsk(req, "write:protected", `write to protected path ${p}`);
     }
     if (inside)

--- a/extensions/loom/exec-guard/sensitive-read.ts
+++ b/extensions/loom/exec-guard/sensitive-read.ts
@@ -29,21 +29,41 @@ export function isSensitivePath(absPath: string, home: string): boolean {
   return false;
 }
 
+// Case-folded path-segment membership. macOS HFS+ is case-insensitive and
+// realpath does not normalize case there, so `.Git` / `.LOOM` would otherwise
+// dodge the check. Folding may over-match a literal `.Git` dir on case-sensitive
+// Linux, but that errs toward protection.
+function hasSegment(p: string, name: string): boolean {
+  return p.split(path.sep).some((s) => s.toLowerCase() === name);
+}
+
 // Write targets gated even inside the workspace jail. A file under `.git`
 // (hooks run on the next git operation; config can redirect hooksPath) or under
 // `.loom` (Loom's own session state) should never be written by the model
 // silently -- it uses git commands for repo ops, not the write tool.
 //
-// `workspaceRoot` matters because Orbit's default workspace is ~/.loom/analyses/<name>,
-// so the workspace's own ancestry already contains a `.loom` segment. Only `.git`/`.loom`
-// at or below the workspace root should gate; an ancestor `.loom` (the path *to* the
-// workspace) is incidental and must not flag every write. When the path is inside the
-// workspace we evaluate segments relative to its root; otherwise we check the absolute
-// path so escapes to some other repo's .git / Loom's home state stay gated.
-export function isProtectedWritePath(absPath: string, workspaceRoot?: string): boolean {
+// `home` enables the one carve-out we need: Orbit files analyses under
+// $HOME/.loom/analyses/<name>/, so those workspaces sit under a `.loom` segment
+// yet are the agent's actual work product, not Loom state. Writes there are
+// allowed -- but a *nested* `.git`/`.loom` inside an analysis (a real repo's
+// hooks, or the per-workspace activity log) stays protected. Everything else
+// with a `.git`/`.loom` segment -- Loom's home state, some other repo's .git, a
+// per-workspace .loom outside the analyses tree, or a path whose cwd happens to
+// sit inside a .git/.loom dir -- stays gated. `.git` is never carved out: a
+// workspace is never legitimately inside one. Pass home="" for the plain
+// absolute check (callers without a home / the unit tests).
+export function isProtectedWritePath(absPath: string, home = ""): boolean {
   const norm = path.normalize(absPath);
-  const considered =
-    workspaceRoot && within(norm, workspaceRoot) ? path.relative(workspaceRoot, norm) : norm;
-  const segments = considered.split(path.sep);
-  return segments.includes(".git") || segments.includes(".loom");
+  if (hasSegment(norm, ".git")) return true;
+  if (!hasSegment(norm, ".loom")) return false;
+  // A `.loom` segment is present. It's benign only as the $HOME/.loom/analyses
+  // ancestor of a user workspace; a `.loom` anywhere below that (or outside it)
+  // is real Loom state. (home is compared un-realpath'd, matching isSensitivePath.)
+  if (home) {
+    const analyses = path.join(home, ".loom", "analyses");
+    if (within(norm, analyses) && !hasSegment(path.relative(analyses, norm), ".loom")) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/extensions/loom/exec-guard/sensitive-read.ts
+++ b/extensions/loom/exec-guard/sensitive-read.ts
@@ -33,7 +33,17 @@ export function isSensitivePath(absPath: string, home: string): boolean {
 // (hooks run on the next git operation; config can redirect hooksPath) or under
 // `.loom` (Loom's own session state) should never be written by the model
 // silently -- it uses git commands for repo ops, not the write tool.
-export function isProtectedWritePath(absPath: string): boolean {
-  const segments = path.normalize(absPath).split(path.sep);
+//
+// `workspaceRoot` matters because Orbit's default workspace is ~/.loom/analyses/<name>,
+// so the workspace's own ancestry already contains a `.loom` segment. Only `.git`/`.loom`
+// at or below the workspace root should gate; an ancestor `.loom` (the path *to* the
+// workspace) is incidental and must not flag every write. When the path is inside the
+// workspace we evaluate segments relative to its root; otherwise we check the absolute
+// path so escapes to some other repo's .git / Loom's home state stay gated.
+export function isProtectedWritePath(absPath: string, workspaceRoot?: string): boolean {
+  const norm = path.normalize(absPath);
+  const considered =
+    workspaceRoot && within(norm, workspaceRoot) ? path.relative(workspaceRoot, norm) : norm;
+  const segments = considered.split(path.sep);
   return segments.includes(".git") || segments.includes(".loom");
 }

--- a/tests/exec-guard-policy.test.ts
+++ b/tests/exec-guard-policy.test.ts
@@ -113,10 +113,8 @@ describe("decide", () => {
   it("write/edit to a sensitive path is floored even inside the jail", () => {
     // id_rsa lives inside the workspace here, but its credential shape must win.
     expect(
-      decide(
-        req({ toolName: "write", toolInput: { path: "/home/alice/project/id_rsa" } }),
-        deps,
-      ).decision,
+      decide(req({ toolName: "write", toolInput: { path: "/home/alice/project/id_rsa" } }), deps)
+        .decision,
     ).toBe("ask");
     expect(
       decide(
@@ -127,7 +125,11 @@ describe("decide", () => {
     // weak model downgrades the ask to a deny, same as a sensitive read.
     expect(
       decide(
-        req({ toolName: "write", modelTier: "weak", toolInput: { path: "/home/alice/project/.env" } }),
+        req({
+          toolName: "write",
+          modelTier: "weak",
+          toolInput: { path: "/home/alice/project/.env" },
+        }),
         deps,
       ).decision,
     ).toBe("deny");
@@ -146,6 +148,34 @@ describe("decide", () => {
       decide(
         req({ toolName: "edit", toolInput: { path: "/home/alice/project/.loom/config.json" } }),
         deps,
+      ).decision,
+    ).toBe("ask");
+  });
+  it("allows writes when the workspace itself lives under ~/.loom (Orbit default cwd)", () => {
+    // Orbit's DEFAULT_CWD is ~/.loom/analyses, so the analysis workspace sits
+    // under a .loom segment. The notebook the agent edits constantly must be
+    // allowed, while .loom/.git state *inside* the workspace still prompts.
+    const wcwd = "/home/alice/.loom/analyses/proj";
+    const wresolver: PathResolver = {
+      contains: (p) => ({ resolved: p, inside: p.startsWith(wcwd) || p.startsWith("/tmp") }),
+    };
+    const wdeps = { resolver: wresolver, home: HOME };
+    expect(
+      decide(
+        req({ cwd: wcwd, toolName: "edit", toolInput: { path: `${wcwd}/notebook.md` } }),
+        wdeps,
+      ).decision,
+    ).toBe("allow");
+    expect(
+      decide(
+        req({ cwd: wcwd, toolName: "write", toolInput: { path: `${wcwd}/.loom/activity.jsonl` } }),
+        wdeps,
+      ).decision,
+    ).toBe("ask");
+    expect(
+      decide(
+        req({ cwd: wcwd, toolName: "write", toolInput: { path: `${wcwd}/.git/hooks/pre-commit` } }),
+        wdeps,
       ).decision,
     ).toBe("ask");
   });
@@ -209,5 +239,4 @@ describe("decide", () => {
       decide(req({ toolInput: { command: "cat /home/alice/project/notes.txt" } }), deps).decision,
     ).toBe("allow");
   });
-
 });

--- a/tests/exec-guard-policy.test.ts
+++ b/tests/exec-guard-policy.test.ts
@@ -179,6 +179,33 @@ describe("decide", () => {
       ).decision,
     ).toBe("ask");
   });
+  it("gates a .git write even when cwd is inside the .git dir (no carve-away)", () => {
+    // adversarial-review regression: the protected floor must not relativize a
+    // real .git away just because the session cwd happens to sit inside it.
+    const gcwd = "/home/alice/project/.git";
+    const gres: PathResolver = {
+      contains: (p) => ({ resolved: p, inside: p.startsWith(gcwd) }),
+    };
+    expect(
+      decide(
+        req({ cwd: gcwd, toolName: "write", toolInput: { path: `${gcwd}/hooks/pre-commit` } }),
+        { resolver: gres, home: HOME },
+      ).decision,
+    ).toBe("ask");
+  });
+  it("gates Loom state when cwd is a .loom dir outside the analyses tree", () => {
+    // regression B: a .loom state dir as cwd must not carve its own .loom away.
+    const lcwd = "/home/alice/.loom/sessions/s1";
+    const lres: PathResolver = {
+      contains: (p) => ({ resolved: p, inside: p.startsWith(lcwd) }),
+    };
+    expect(
+      decide(req({ cwd: lcwd, toolName: "write", toolInput: { path: `${lcwd}/activity.jsonl` } }), {
+        resolver: lres,
+        home: HOME,
+      }).decision,
+    ).toBe("ask");
+  });
   it("unknown bash -> ask (trusted) / deny (weak)", () => {
     expect(decide(req({ toolInput: { command: "python x.py" } }), deps).decision).toBe("ask");
     expect(

--- a/tests/exec-guard-sensitive-read.test.ts
+++ b/tests/exec-guard-sensitive-read.test.ts
@@ -43,4 +43,26 @@ describe("isProtectedWritePath", () => {
     // not fooled by a substring -- only a real path segment counts
     expect(isProtectedWritePath("/home/alice/project/gitignore.md")).toBe(false);
   });
+
+  // Orbit's default workspace is ~/.loom/analyses/<name>, so the workspace's own
+  // ancestry contains a .loom segment. That ancestor must NOT make every write
+  // "protected" -- only .git/.loom state at or below the workspace root counts.
+  it("ignores a .git/.loom that is merely an ancestor of the workspace", () => {
+    const ws = "/home/alice/.loom/analyses/proj";
+    expect(isProtectedWritePath("/home/alice/.loom/analyses/proj/notebook.md", ws)).toBe(false);
+    expect(isProtectedWritePath("/home/alice/.loom/analyses/proj/src/run.py", ws)).toBe(false);
+  });
+  it("still flags .git/.loom state INSIDE such a workspace", () => {
+    const ws = "/home/alice/.loom/analyses/proj";
+    expect(isProtectedWritePath("/home/alice/.loom/analyses/proj/.loom/activity.jsonl", ws)).toBe(
+      true,
+    );
+    expect(isProtectedWritePath("/home/alice/.loom/analyses/proj/.git/hooks/pre-commit", ws)).toBe(
+      true,
+    );
+  });
+  it("with no workspace root, falls back to the absolute-path check", () => {
+    expect(isProtectedWritePath("/home/alice/.loom/analyses/proj/notebook.md")).toBe(true);
+    expect(isProtectedWritePath("/home/alice/project/.git/config")).toBe(true);
+  });
 });

--- a/tests/exec-guard-sensitive-read.test.ts
+++ b/tests/exec-guard-sensitive-read.test.ts
@@ -44,24 +44,40 @@ describe("isProtectedWritePath", () => {
     expect(isProtectedWritePath("/home/alice/project/gitignore.md")).toBe(false);
   });
 
-  // Orbit's default workspace is ~/.loom/analyses/<name>, so the workspace's own
+  // Orbit files analyses under $HOME/.loom/analyses/<name>, so the workspace's own
   // ancestry contains a .loom segment. That ancestor must NOT make every write
-  // "protected" -- only .git/.loom state at or below the workspace root counts.
-  it("ignores a .git/.loom that is merely an ancestor of the workspace", () => {
-    const ws = "/home/alice/.loom/analyses/proj";
-    expect(isProtectedWritePath("/home/alice/.loom/analyses/proj/notebook.md", ws)).toBe(false);
-    expect(isProtectedWritePath("/home/alice/.loom/analyses/proj/src/run.py", ws)).toBe(false);
+  // "protected" -- only real Loom state / git dirs should gate.
+  it("allows analysis work product under ~/.loom/analyses (ancestor .loom carved out)", () => {
+    expect(isProtectedWritePath("/home/alice/.loom/analyses/proj/notebook.md", HOME)).toBe(false);
+    expect(isProtectedWritePath("/home/alice/.loom/analyses/proj/src/run.py", HOME)).toBe(false);
   });
-  it("still flags .git/.loom state INSIDE such a workspace", () => {
-    const ws = "/home/alice/.loom/analyses/proj";
-    expect(isProtectedWritePath("/home/alice/.loom/analyses/proj/.loom/activity.jsonl", ws)).toBe(
+  it("still flags .git/.loom state nested inside an analysis", () => {
+    expect(isProtectedWritePath("/home/alice/.loom/analyses/proj/.loom/activity.jsonl", HOME)).toBe(
       true,
     );
-    expect(isProtectedWritePath("/home/alice/.loom/analyses/proj/.git/hooks/pre-commit", ws)).toBe(
-      true,
-    );
+    expect(
+      isProtectedWritePath("/home/alice/.loom/analyses/proj/.git/hooks/pre-commit", HOME),
+    ).toBe(true);
   });
-  it("with no workspace root, falls back to the absolute-path check", () => {
+  it("flags Loom home state OUTSIDE the analyses tree", () => {
+    expect(isProtectedWritePath("/home/alice/.loom/sessions/s1/activity.jsonl", HOME)).toBe(true);
+    expect(isProtectedWritePath("/home/alice/.loom/cache/skills/x.md", HOME)).toBe(true);
+    expect(isProtectedWritePath("/home/alice/.loom/config.json", HOME)).toBe(true);
+  });
+  // regression (adversarial review): a .git must never be relativized/carved away,
+  // even when the cwd itself sits inside a .git dir -- hook injection stays gated.
+  it("flags a real .git even when it is the cwd's own ancestor", () => {
+    expect(isProtectedWritePath("/home/alice/project/.git/hooks/pre-commit", HOME)).toBe(true);
+  });
+  // regression: a per-workspace .loom for a normal (non-analyses) cwd still gates.
+  it("flags a per-workspace .loom outside the analyses tree", () => {
+    expect(isProtectedWritePath("/home/alice/myproj/.loom/activity.jsonl", HOME)).toBe(true);
+  });
+  it("folds case on the .git/.loom segment (macOS HFS+)", () => {
+    expect(isProtectedWritePath("/home/alice/project/.Git/hooks/x", HOME)).toBe(true);
+    expect(isProtectedWritePath("/home/alice/.loom/analyses/proj/.LOOM/x", HOME)).toBe(true);
+  });
+  it("with no home, falls back to the absolute-path check", () => {
     expect(isProtectedWritePath("/home/alice/.loom/analyses/proj/notebook.md")).toBe(true);
     expect(isProtectedWritePath("/home/alice/project/.git/config")).toBe(true);
   });


### PR DESCRIPTION
## What's wrong

In a stock Orbit session every file write prompts for permission -- including `notebook.md`, the file the agent edits constantly. The "Allow ... to edit ..." dialog fires on writes that are squarely inside the working directory, which the write-jail is supposed to allow silently.

## Why

The exec-guard protected-write floor (`isProtectedWritePath`) gates any path with a `.git` or `.loom` segment, so the model can't quietly drop a git hook or rewrite Loom's own session state. That's correct on its own. The collision is that **Orbit's default working directory is `~/.loom/analyses/<name>`** (`app/src/main/main.ts`, `DEFAULT_CWD = path.join(LOOM_DIR, "analyses")`). So the workspace's *own ancestry* contains a `.loom` segment, and every write under it -- notebook included -- matches the floor and gets prompted. The jail's "writes inside the working dir are allowed" path never gets a chance to run, because the protected check sits in front of it and short-circuits to `ask`.

It's not just the notebook; it's every write in a default analysis. The notebook is just where it's most visible.

## The fix

Scope the protected-write check to the workspace root. A `.git` or `.loom` *at or below* `cwd` still prompts -- hook-injection and per-workspace session state (`<cwd>/.loom/activity.jsonl`) stay protected -- but an ancestor `.loom` that's merely *where analyses are filed* no longer counts. When the target is inside the workspace we evaluate the segments relative to the workspace root; otherwise we fall back to the absolute-path check, so escapes to some other repo's `.git` or Loom's home state stay gated.

`cwd` is resolved through the same path resolver as the write target, so a symlinked `~/.loom` can't put the two in different realpath spaces and silently defeat the scoping.

What stays gated:
- `<cwd>/.git/hooks/pre-commit` -> still prompts (hook injection)
- `<cwd>/.loom/activity.jsonl` -> still prompts (don't let the model corrupt the audit log)
- `~/.loom/config.json` -> still caught independently by the sensitive-path floor (`write:sensitive`)
- writes outside the workspace -> unchanged (absolute check)

Auto-commit is unaffected -- it runs `git` commands, not the write tool.

## Tests

Added coverage at both levels:
- `isProtectedWritePath` unit: an ancestor `.git`/`.loom` (workspace under `~/.loom`) is ignored, but `.git`/`.loom` state *inside* the workspace still flags; absolute fallback unchanged when no workspace root is given.
- `decide` policy integration: with `cwd` under `~/.loom`, the notebook write is `allow` while `<cwd>/.loom` and `<cwd>/.git` writes stay `ask`.

359 root tests green, brain typecheck clean.
