### PR TITLE
feedback: attach optional testerId to submissions

### DIFF
--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -578,7 +578,10 @@ export function registerIpcHandlers(agent: AgentManager): void {
   // so a compromised renderer can't redirect it. Returns {ok,...} so the
   // renderer can fall back to the GitHub-issue flow when the POST fails.
   ipcMain.handle("feedback:submit", async (_e, payload: FeedbackPayload) => {
-    return await postFeedback(payload);
+    // Stamp the opaque tester code from config in main (authoritative; the
+    // renderer never sets it). Non-secret; lets the team attribute the report.
+    const testerId = loadConfig().testerId || process.env.LOOM_TESTER_ID;
+    return await postFeedback(testerId ? { ...payload, testerId } : payload);
   });
 
   // Model registry — pulls from pi-ai's bundled list so the dropdown stays

--- a/extensions/loom/feedback-command.ts
+++ b/extensions/loom/feedback-command.ts
@@ -7,6 +7,7 @@ import {
   readLoomVersion,
 } from "./feedback.js";
 import { getRecentActivityEvents } from "./activity.js";
+import { loadConfig } from "./config.js";
 import { SCHEMA_VERSION } from "../../shared/feedback-contract.js";
 import type { FeedbackPayload } from "../../shared/feedback-contract.js";
 
@@ -40,6 +41,10 @@ export function registerFeedbackCommand(pi: ExtensionAPI): void {
         "Attach system info + a one-line-per-event activity summary (no command output or arguments), sent to the Loom team's private feedback store. No API keys or credentials are sent.",
       );
 
+      // Opaque tester code (config, env override) -- non-secret; lets the team
+      // attribute the report. Omitted from the payload when unset.
+      const testerId = loadConfig().testerId || process.env.LOOM_TESTER_ID;
+
       // The app version always rides along (non-sensitive build metadata) so every
       // loom-cli row is filterable by release in triage, even without diagnostics.
       const payload: FeedbackPayload = {
@@ -48,6 +53,7 @@ export function registerFeedbackCommand(pi: ExtensionAPI): void {
         title: title.trim(),
         body: body.trim(),
         clientTs: new Date().toISOString(),
+        ...(testerId ? { testerId } : {}),
         ...(includeDiagnostics
           ? {
               sysinfo: buildBrainSysinfo(),

--- a/shared/feedback-contract.d.ts
+++ b/shared/feedback-contract.d.ts
@@ -18,6 +18,12 @@ export interface FeedbackSysinfo {
 export interface FeedbackPayload {
   schemaVersion: 1;
   source: "orbit" | "loom-cli";
+  /**
+   * Opaque beta-tester code (e.g. "orbit-007"), copied from LoomConfig.testerId.
+   * MUST stay top-level: the orbit-feedback worker maps `payload.testerId` to a
+   * first-class `tester_id` column. Optional + additive, so schemaVersion stays 1.
+   */
+  testerId?: string;
   title: string;
   body: string;
   sysinfo?: FeedbackSysinfo;

--- a/shared/feedback-contract.js
+++ b/shared/feedback-contract.js
@@ -22,5 +22,7 @@ export function validateFeedbackPayload(obj) {
   if (typeof p.title !== "string" || p.title.trim().length === 0) return false;
   if (typeof p.body !== "string") return false;
   if (typeof p.clientTs !== "string") return false;
+  // testerId is optional; when present it must be a string (opaque tester code).
+  if (p.testerId !== undefined && typeof p.testerId !== "string") return false;
   return true;
 }

--- a/shared/loom-config.d.ts
+++ b/shared/loom-config.d.ts
@@ -8,6 +8,13 @@ export interface LlmProviderConfig {
 }
 
 export interface LoomConfig {
+  /**
+   * Opaque beta-tester code (e.g. "orbit-007"). When set, it rides along on
+   * feedback submissions so the team can attribute reports to a tester. Not a
+   * secret and not PII -- the code<->identity map lives outside the app. Also
+   * settable per-session via the LOOM_TESTER_ID env var.
+   */
+  testerId?: string;
   llm?: {
     /** Name of the currently-active provider, e.g. "anthropic". */
     active: string;

--- a/tests/feedback-command.test.ts
+++ b/tests/feedback-command.test.ts
@@ -10,6 +10,7 @@ vi.mock("../extensions/loom/feedback.js", () => ({
   readLoomVersion: () => "0.0.0-test",
 }));
 vi.mock("../extensions/loom/activity.js", () => ({ getRecentActivityEvents: () => [] }));
+vi.mock("../extensions/loom/config.js", () => ({ loadConfig: () => ({ testerId: "orbit-007" }) }));
 
 const { registerFeedbackCommand } = await import("../extensions/loom/feedback-command.js");
 
@@ -62,6 +63,14 @@ describe("/feedback", () => {
     expect(payload.title).toBe("My title");
     expect(ui.notify).toHaveBeenCalledWith(expect.stringContaining("Thanks"), "info");
     expect(appendToOutbox).not.toHaveBeenCalled();
+  });
+
+  it("stamps the testerId from config onto the payload", async () => {
+    submitFeedback.mockResolvedValue({ ok: true, id: "z" });
+    const { pi, commands } = makeApi();
+    registerFeedbackCommand(pi as any);
+    await commands.get("feedback")!.handler(undefined, { hasUI: true, ui: uiMock() });
+    expect(submitFeedback.mock.calls[0][0].testerId).toBe("orbit-007");
   });
 
   it("stamps appVersion even when diagnostics are declined", async () => {

--- a/tests/feedback-contract.test.ts
+++ b/tests/feedback-contract.test.ts
@@ -45,4 +45,9 @@ describe("feedback contract", () => {
       validateFeedbackPayload({ schemaVersion: 1, source: "orbit", title: "t", body: "b" }),
     ).toBe(false);
   });
+
+  it("accepts an optional string testerId and rejects a non-string one", () => {
+    expect(validateFeedbackPayload({ ...valid, testerId: "orbit-007" })).toBe(true);
+    expect(validateFeedbackPayload({ ...valid, testerId: 7 })).toBe(false);
+  });
 });


### PR DESCRIPTION
## What

Adds an optional, opaque **`testerId`** (e.g. `orbit-007`) to feedback submissions so the team can attribute reports to a specific beta tester — without sending any secret or PII.

## Why

We're onboarding external testers, each issued private API keys and expected to file feedback. Today the feedback payload carries no identity (`title`, `body`, `clientTs`, `sysinfo`), so reports can't be tied to a tester. A short opaque code in config closes that gap; the code↔identity map lives outside the app.

## Changes

- **`LoomConfig.testerId`** — set in `~/.loom/config.json`, or per-session via the `LOOM_TESTER_ID` env var.
- **`FeedbackPayload.testerId`** — **top-level**, optional, additive (so `schemaVersion` stays `1`). Top-level is deliberate: the deployed `orbit-feedback` worker maps `payload.testerId` → a first-class `tester_id` column. (Nesting it under `sysinfo` would leave that column NULL.)
- **CLI** (`feedback-command.ts`): stamped from `loadConfig().testerId || LOOM_TESTER_ID`.
- **Orbit** (`ipc-handlers.ts` `feedback:submit`): stamped **authoritatively in main** — the renderer never sets it (same hardening rationale as the endpoint URL).
- **`validateFeedbackPayload`**: enforces optional-string type.
- Tests for both contract and command paths.

## Privacy

`testerId` is a non-secret opaque code, not PII. No API keys or credentials are added to the payload. Omitted entirely when unset, so non-tester builds are unchanged.

## Verification

- `npm run typecheck` — clean
- `npm test` — 386 passed (incl. new contract + command tests)
- `prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)