### PR TITLE
Orbit: macOS in-place auto-update + CI update-feed guards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Assert version lockstep
+        run: node scripts/check-version-lockstep.mjs
+
       - name: Install Linux packaging deps
         if: matrix.platform == 'linux'
         run: sudo apt-get update -qq && sudo apt-get install -y fakeroot rpm
@@ -146,6 +149,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           draft: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true
           files: |
             artifacts/**/*.dmg

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -16,7 +16,8 @@
         "dompurify": "^3.4.1",
         "marked": "^18.0.0",
         "react": "^19.2.5",
-        "react-dom": "^19.2.5"
+        "react-dom": "^19.2.5",
+        "update-electron-app": "^3.2.0"
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.11.1",
@@ -5894,6 +5895,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/github-url-to-object": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/github-url-to-object/-/github-url-to-object-4.0.6.tgz",
+      "integrity": "sha512-NaqbYHMUAlPcmWFdrAB7bcxrNIiiJWJe8s/2+iOc9vlcHlwHqSGrPk+Yi3nu6ebTwgsZEa7igz+NH2vEq3gYwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-url": "^1.1.0"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -6352,6 +6362,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "4.0.10",
@@ -9056,6 +9072,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/update-electron-app": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/update-electron-app/-/update-electron-app-3.2.0.tgz",
+      "integrity": "sha512-l2e7bzsW+rw70pfyyQeA9E/ofpNY2ZS99XuYxD2qWL4fEy3qMjpqwwgB0me7ESpGogIQE1CM0SaDvKGsK4Jg3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "github-url-to-object": "^4.0.4",
+        "ms": "^2.1.1"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/app/package.json
+++ b/app/package.json
@@ -20,7 +20,8 @@
     "dompurify": "^3.4.1",
     "marked": "^18.0.0",
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "update-electron-app": "^3.2.0"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.11.1",

--- a/app/src/main/auto-update-policy.ts
+++ b/app/src/main/auto-update-policy.ts
@@ -1,0 +1,19 @@
+// Pure decision for whether Orbit should run the in-place auto-updater.
+// macOS only: the forge-native path (Electron autoUpdater + update.electronjs.org)
+// supports macOS/Windows only, and Orbit ships no native Windows -- so Linux
+// stays on the GitHub-releases notify-link banner. No electron imports here so
+// the decision is unit-testable from the root Vitest suite.
+
+export interface AutoUpdateInputs {
+  platform: NodeJS.Platform | string;
+  isPackaged: boolean;
+  updateCheck: boolean;
+}
+
+export function shouldEnableAutoUpdate({
+  platform,
+  isPackaged,
+  updateCheck,
+}: AutoUpdateInputs): boolean {
+  return platform === "darwin" && isPackaged && updateCheck;
+}

--- a/app/src/main/auto-update.ts
+++ b/app/src/main/auto-update.ts
@@ -1,0 +1,42 @@
+import { app, autoUpdater, BrowserWindow } from "electron";
+import { updateElectronApp, UpdateSourceType } from "update-electron-app";
+import { loadConfig } from "../../../shared/loom-config.js";
+import { shouldEnableAutoUpdate } from "./auto-update-policy.js";
+
+// Wires Orbit's macOS in-place auto-update via Electron's built-in autoUpdater
+// + update.electronjs.org. Explicit repo: app/package.json has no `repository`
+// field, so auto-detection would mis-target. The service ignores draft +
+// prerelease releases, which preserves the manual promote-the-draft QA gate.
+export function initAutoUpdate(): void {
+  // Read once at startup; toggling updateCheck takes effect on the next launch
+  // (consistent with how Orbit picks up other config changes).
+  const enabled = shouldEnableAutoUpdate({
+    platform: process.platform,
+    isPackaged: app.isPackaged,
+    updateCheck: loadConfig().updateCheck !== false,
+  });
+  if (!enabled) return;
+
+  updateElectronApp({
+    updateSource: {
+      type: UpdateSourceType.ElectronPublicUpdateService,
+      repo: "galaxyproject/loom",
+    },
+    updateInterval: "1 hour",
+    notifyUser: false, // we render our own banner instead of the default dialog
+  });
+
+  autoUpdater.on("update-downloaded", (_event, _notes, releaseName) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send("update:downloaded", { version: releaseName ?? "" });
+    }
+  });
+
+  autoUpdater.on("error", (err) => {
+    // Don't leave the user with nothing: tell the renderer so it can fall back
+    // to the existing GitHub-releases notify-link banner.
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send("update:error", { message: String(err?.message ?? err) });
+    }
+  });
+}

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -314,6 +314,7 @@ export function registerIpcHandlers(agent: AgentManager): void {
     "condaBin",
     "experiments",
     "guardian",
+    "updateCheck",
   ]);
 
   function sanitizeConfig(input: unknown): LoomConfig {

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { ipcMain, dialog, BrowserWindow, shell, app } from "electron";
+import { ipcMain, dialog, BrowserWindow, shell, app, autoUpdater } from "electron";
 import type { AgentManager } from "./agent.js";
 import { startFilesWatcher, resolveWithin } from "./files-handler.js";
 import { loadSessionHistory } from "./session-replay.js";
@@ -560,6 +560,13 @@ export function registerIpcHandlers(agent: AgentManager): void {
         : releasesPage;
     await shell.openExternal(target);
     return { opened: true };
+  });
+
+  // Apply a downloaded macOS update + relaunch. autoUpdater.quitAndInstall is a
+  // no-op unless an update was actually downloaded, so this is safe to call.
+  ipcMain.handle("update:restart", () => {
+    autoUpdater.quitAndInstall();
+    return { restarting: true };
   });
 
   // Issue reporter: opens a pre-filled GitHub "new issue" URL in the user's

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -21,6 +21,7 @@ import { ProcMonitor } from "./proc-monitor.js";
 import { migratePlaintextSecrets, isAvailable as safeStorageAvailable } from "./secure-config.js";
 import { getConfigDir, getConfigPath } from "../../../shared/loom-config.js";
 import { parseCliArgs, type CliArgs } from "./cli-args.js";
+import { initAutoUpdate } from "./auto-update.js";
 
 // Workaround for systems where chrome-sandbox isn't suid root
 app.commandLine.appendSwitch("no-sandbox");
@@ -490,6 +491,7 @@ app.whenReady().then(() => {
   const cwd = getDefaultCwd(cliArgs);
   log("cwd:", cwd);
   createWindow(cwd);
+  initAutoUpdate();
 
   powerMonitor.on("suspend", () => log("[diag] powerMonitor suspend"));
   powerMonitor.on("resume", () => {

--- a/app/src/main/version-check.ts
+++ b/app/src/main/version-check.ts
@@ -2,6 +2,7 @@ import { app, net } from "electron";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { isNewer } from "../../../shared/version-compare.js";
 
 const RELEASES_API = "https://api.github.com/repos/galaxyproject/loom/releases/latest";
 const RELEASES_PAGE = "https://github.com/galaxyproject/loom/releases/latest";
@@ -26,66 +27,6 @@ export interface VersionCheckResult {
 type CacheShape =
   | { fetchedAt: number; failed: true }
   | { fetchedAt: number; failed?: false; latest: string; releaseUrl: string };
-
-interface SemverParts {
-  major: number;
-  minor: number;
-  patch: number;
-  pre: string;
-}
-
-function parseSemver(v: string): SemverParts | null {
-  const m = v.replace(/^v/, "").match(/^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/);
-  if (!m) return null;
-  return {
-    major: parseInt(m[1], 10),
-    minor: parseInt(m[2], 10),
-    patch: parseInt(m[3], 10),
-    pre: m[4] ?? "",
-  };
-}
-
-// Compares two prerelease tags per semver precedence rules. Numeric segments
-// compare numerically (so alpha.10 > alpha.9, which a plain string compare
-// gets wrong). Avoids pulling in a semver dependency for one feature.
-// Returns negative when a < b, positive when a > b, zero when equal.
-function comparePre(a: string, b: string): number {
-  if (a === b) return 0;
-  // A version without a prerelease tag has higher precedence than the same
-  // version with one (1.0.0 > 1.0.0-alpha).
-  if (!a) return 1;
-  if (!b) return -1;
-  const ap = a.split(".");
-  const bp = b.split(".");
-  const len = Math.min(ap.length, bp.length);
-  for (let i = 0; i < len; i++) {
-    const x = ap[i];
-    const y = bp[i];
-    const xn = /^\d+$/.test(x);
-    const yn = /^\d+$/.test(y);
-    if (xn && yn) {
-      const dx = parseInt(x, 10);
-      const dy = parseInt(y, 10);
-      if (dx !== dy) return dx < dy ? -1 : 1;
-    } else if (xn !== yn) {
-      // Numeric identifiers have lower precedence than alphanumeric ones.
-      return xn ? -1 : 1;
-    } else if (x !== y) {
-      return x < y ? -1 : 1;
-    }
-  }
-  return ap.length === bp.length ? 0 : ap.length < bp.length ? -1 : 1;
-}
-
-function isNewer(current: string, candidate: string): boolean {
-  const a = parseSemver(current);
-  const b = parseSemver(candidate);
-  if (!a || !b) return false;
-  if (b.major !== a.major) return b.major > a.major;
-  if (b.minor !== a.minor) return b.minor > a.minor;
-  if (b.patch !== a.patch) return b.patch > a.patch;
-  return comparePre(a.pre, b.pre) < 0;
-}
 
 function readCache(): CacheShape | null {
   try {

--- a/app/src/main/version-check.ts
+++ b/app/src/main/version-check.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { isNewer } from "../../../shared/version-compare.js";
+import { loadConfig } from "../../../shared/loom-config.js";
 
 const RELEASES_API = "https://api.github.com/repos/galaxyproject/loom/releases/latest";
 const RELEASES_PAGE = "https://github.com/galaxyproject/loom/releases/latest";
@@ -77,6 +78,7 @@ async function fetchLatestFromGitHub(): Promise<{ latest: string; releaseUrl: st
 }
 
 export async function checkLatestVersion(): Promise<VersionCheckResult | null> {
+  if (loadConfig().updateCheck === false) return null;
   const current = app.getVersion();
   const cached = readCache();
   if (cached?.failed) return null;

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -144,6 +144,10 @@ export interface OrbitAPI {
     releaseUrl: string;
   } | null>;
   openReleasePage(url?: string): Promise<{ opened: boolean }>;
+  restartToUpdate(): Promise<{ restarting: boolean }>;
+  onUpdateDownloaded(cb: (info: { version: string }) => void): void;
+  onUpdateError(cb: (info: { message: string }) => void): void;
+  platform: string;
 }
 
 const api: OrbitAPI = {
@@ -245,6 +249,14 @@ const api: OrbitAPI = {
   listAllModels: () => ipcRenderer.invoke("models:list-all"),
   checkVersion: () => ipcRenderer.invoke("version:check"),
   openReleasePage: (url) => ipcRenderer.invoke("version:open-release", url),
+  restartToUpdate: () => ipcRenderer.invoke("update:restart"),
+  onUpdateDownloaded: (cb) => {
+    ipcRenderer.on("update:downloaded", (_e, info) => cb(info));
+  },
+  onUpdateError: (cb) => {
+    ipcRenderer.on("update:error", (_e, info) => cb(info));
+  },
+  platform: process.platform,
   onSessionHistory: (callback) => {
     const handler = (_e: unknown, history: ReplaySegment[]) => callback(history);
     ipcRenderer.on("agent:session-history", handler);

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -3554,6 +3554,10 @@ window.orbit.onProcUpdate((procs) => {
   const updateVersionEl = document.getElementById("update-banner-version");
   const updateLinkBtn = document.getElementById("update-banner-link");
   const updateDismissBtn = document.getElementById("update-banner-dismiss");
+  const linkText = document.getElementById("update-banner-text-link");
+  const restartText = document.getElementById("update-banner-text-restart");
+  const restartVersionEl = document.getElementById("update-banner-restart-version");
+  const restartBtn = document.getElementById("update-banner-restart");
 
   const DISMISSED_KEY = "orbit:update-dismissed-version";
   let currentReleaseUrl: string | null = null;
@@ -3564,14 +3568,16 @@ window.orbit.onProcUpdate((procs) => {
     });
     updateDismissBtn.addEventListener("click", () => {
       updateBanner.classList.add("hidden");
-      if (updateVersionEl.textContent) {
+      const v = updateVersionEl.textContent || restartVersionEl?.textContent;
+      if (v) {
         try {
-          localStorage.setItem(DISMISSED_KEY, updateVersionEl.textContent);
+          localStorage.setItem(DISMISSED_KEY, v);
         } catch {}
       }
     });
+    restartBtn?.addEventListener("click", () => void window.orbit.restartToUpdate());
 
-    void (async () => {
+    const showNotifyLinkBanner = async () => {
       try {
         const info = await window.orbit.checkVersion();
         if (!info || !info.hasUpdate) return;
@@ -3579,14 +3585,31 @@ window.orbit.onProcUpdate((procs) => {
         try {
           dismissed = localStorage.getItem(DISMISSED_KEY);
         } catch {}
-        // Dismissal is per-version: once a newer release lands, the banner
-        // reappears.
         if (dismissed === info.latest) return;
         updateVersionEl.textContent = info.latest;
         currentReleaseUrl = info.releaseUrl;
+        linkText?.classList.remove("hidden");
+        updateLinkBtn.classList.remove("hidden");
         updateBanner.classList.remove("hidden");
       } catch {}
-    })();
+    };
+
+    // macOS: in-place auto-update. Show the "restart to install" banner once a
+    // download completes; fall back to the notify-link banner on updater error.
+    if (window.orbit.platform === "darwin") {
+      window.orbit.onUpdateDownloaded((info) => {
+        if (restartVersionEl) restartVersionEl.textContent = info.version;
+        linkText?.classList.add("hidden");
+        updateLinkBtn.classList.add("hidden");
+        restartText?.classList.remove("hidden");
+        restartBtn?.classList.remove("hidden");
+        updateBanner.classList.remove("hidden");
+      });
+      window.orbit.onUpdateError(() => void showNotifyLinkBanner());
+    } else {
+      // Linux (and any non-darwin): the GitHub-releases notify-link banner.
+      void showNotifyLinkBanner();
+    }
   }
 }
 

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -26,11 +26,17 @@
            and finds a newer tag than app.getVersion(). No auto-install for
            unsigned macOS builds; clicking the link opens the Releases page. -->
       <div id="update-banner" class="hidden" role="status" aria-live="polite">
-        <span class="update-banner-text">
+        <span class="update-banner-text" id="update-banner-text-link">
           A new Orbit release is available (<span id="update-banner-version"></span>).
+        </span>
+        <span class="update-banner-text hidden" id="update-banner-text-restart">
+          Orbit <span id="update-banner-restart-version"></span> downloaded.
         </span>
         <button id="update-banner-link" class="update-banner-link" type="button">
           Open release page
+        </button>
+        <button id="update-banner-restart" class="update-banner-link hidden" type="button">
+          Restart to install
         </button>
         <button
           id="update-banner-dismiss"
@@ -52,7 +58,9 @@
       <!-- Bash-sandbox indicator. Shown when guardian.sandbox is on (opt-in).
            Informational (a good state), not a warning. -->
       <div id="sandbox-banner" class="hidden" role="status" aria-live="polite">
-        <span class="sandbox-banner-text">Bash sandbox on -- bash confined to the workspace; network limited.</span>
+        <span class="sandbox-banner-text"
+          >Bash sandbox on -- bash confined to the workspace; network limited.</span
+        >
       </div>
       <div id="app-main">
         <!-- Left pane: File tree sidebar -->
@@ -537,7 +545,11 @@
             <div class="prefs-row prefs-hint">
               <span></span>
               <span class="prefs-hint-text">
-                Runs the AI's bash commands inside an OS sandbox: bash writes are confined to your analysis directory and its network is limited. Off by default because it restricts bash network access (e.g. some downloads). Takes effect after Save (restarts the session). Your file edits are confined to the analysis directory regardless of this setting.
+                Runs the AI's bash commands inside an OS sandbox: bash writes are confined to your
+                analysis directory and its network is limited. Off by default because it restricts
+                bash network access (e.g. some downloads). Takes effect after Save (restarts the
+                session). Your file edits are confined to the analysis directory regardless of this
+                setting.
               </span>
             </div>
           </section>

--- a/bin/loom.js
+++ b/bin/loom.js
@@ -9,6 +9,9 @@ import {
   loadConfig as loadLoomConfig,
   saveConfig as saveLoomConfig,
 } from "../shared/loom-config.js";
+import { spawn } from "child_process";
+import { getLoomVersion, detectInstall } from "./update-check.js";
+import { pickChannel } from "../shared/version-compare.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -21,6 +24,8 @@ const extensionPath = resolve(__dirname, "../extensions/loom");
 // CLI-shell hand-off glue (the /orbit command). Kept out of the loom brain so
 // the brain stays shell-neutral; the command no-ops when embedded in Orbit.
 const orbitHandoffPath = resolve(__dirname, "../extensions/orbit-handoff");
+const cliUpdatePath = resolve(__dirname, "../extensions/cli-update");
+const updateCheckScript = resolve(__dirname, "update-check.js");
 
 // pi-mcp-adapter is what teaches Pi how to use MCP servers from mcp.json
 // pi-web-access provides web_search, fetch_content, and code_search tools
@@ -49,11 +54,15 @@ if (userArgs.includes("--safe")) {
 if (userArgs.includes("--sandbox")) {
   process.env.LOOM_SANDBOX = "1";
 }
+if (userArgs.includes("--no-update-check")) {
+  process.env.LOOM_NO_UPDATE_CHECK = "1";
+}
 for (let i = userArgs.length - 1; i >= 0; i--) {
   if (
     userArgs[i] === "--dangerously-bypass-permissions" ||
     userArgs[i] === "--safe" ||
-    userArgs[i] === "--sandbox"
+    userArgs[i] === "--sandbox" ||
+    userArgs[i] === "--no-update-check"
   ) {
     userArgs.splice(i, 1);
   }
@@ -64,6 +73,11 @@ function hasArg(flag) {
 }
 
 const isInformationalCommand = ["--help", "-h", "--version", "--list-models"].some(hasArg);
+
+// Config opt-out feeds the same single signal the extension + refresh read.
+try {
+  if (loadLoomConfig().updateCheck === false) process.env.LOOM_NO_UPDATE_CHECK = "1";
+} catch {}
 
 if (
   !isInformationalCommand &&
@@ -94,7 +108,7 @@ async function handleInformationalCommand() {
 
   if (hasArg("--version")) {
     const { VERSION } = await import(pathToFileURL(piConfigModulePath).href);
-    console.log(VERSION);
+    console.log(`loom ${getLoomVersion()} (pi-coding-agent ${VERSION})`);
     return true;
   }
 
@@ -503,6 +517,8 @@ const args = [
   extensionPath,
   "-e",
   orbitHandoffPath,
+  "-e",
+  cliUpdatePath,
   ...providerArgs,
   ...userArgs,
 ];
@@ -511,54 +527,91 @@ if (await handleInformationalCommand()) {
   process.exit(0);
 }
 
-checkLLMProvider();
-
-// Resolve pi-coding-agent's own version by walking up from its entry point to
-// the package root. Used to pin the changelog watermark below.
-function resolvePiVersion() {
-  let dir = dirname(piEntryPointPath);
-  for (let i = 0; i < 6; i++) {
-    const pkgPath = join(dir, "package.json");
-    if (existsSync(pkgPath)) {
-      try {
-        const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-        if (pkg.name === "@earendil-works/pi-coding-agent") return pkg.version;
-      } catch {}
-    }
-    const parent = dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
+if (userArgs[0] === "update") {
+  if (process.env.LOOM_SHELL_KIND === "orbit") {
+    console.error("Orbit manages its own updates -- update from the Orbit app, not the CLI.");
+    process.exit(0);
   }
-  return null;
-}
+  const channel = pickChannel(getLoomVersion());
+  const { kind, cmd } = detectInstall(channel);
+  if (!cmd) {
+    console.error(
+      `Loom looks like a source checkout, not an npm install -- can't self-update.\n` +
+        `To upgrade an installed copy: npm install -g @galaxyproject/loom@${channel}`,
+    );
+    process.exit(0);
+  }
+  console.error(`Updating Loom (${kind}) -- ${cmd}`);
+  const [bin, ...rest] = cmd.split(" ");
+  const child = spawn(bin, rest, { stdio: "inherit" });
+  child.on("error", (err) => {
+    console.error(`Failed to run "${cmd}": ${err.message}`);
+    process.exit(1);
+  });
+  child.on("exit", (code) => process.exit(code ?? 0));
+} else {
+  checkLLMProvider();
 
-// Suppress Pi's keybinding banner, resource listing, and "What's New"
-// changelog. Loom is the product identity -- users shouldn't see Pi internals
-// unless they pass --verbose. The changelog draws from pi-coding-agent's own
-// CHANGELOG.md and is gated on lastChangelogVersion; pinning that to Pi's
-// current version means getNewEntries() never finds anything newer to show.
-if (!hasArg("--verbose")) {
-  const piSettingsPath = join(agentDir, "settings.json");
-  try {
-    let piSettings = {};
-    if (existsSync(piSettingsPath)) {
-      piSettings = JSON.parse(readFileSync(piSettingsPath, "utf-8"));
+  // Resolve pi-coding-agent's own version by walking up from its entry point to
+  // the package root. Used to pin the changelog watermark below.
+  function resolvePiVersion() {
+    let dir = dirname(piEntryPointPath);
+    for (let i = 0; i < 6; i++) {
+      const pkgPath = join(dir, "package.json");
+      if (existsSync(pkgPath)) {
+        try {
+          const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+          if (pkg.name === "@earendil-works/pi-coding-agent") return pkg.version;
+        } catch {}
+      }
+      const parent = dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
     }
-    let changed = false;
-    if (!piSettings.quietStartup) {
-      piSettings.quietStartup = true;
-      changed = true;
-    }
-    const piVersion = resolvePiVersion();
-    if (piVersion && piSettings.lastChangelogVersion !== piVersion) {
-      piSettings.lastChangelogVersion = piVersion;
-      changed = true;
-    }
-    if (changed) {
-      mkdirSync(dirname(piSettingsPath), { recursive: true });
-      writeFileSync(piSettingsPath, JSON.stringify(piSettings, null, 2));
-    }
-  } catch {}
-}
+    return null;
+  }
 
-main(args);
+  // Suppress Pi's keybinding banner, resource listing, and "What's New"
+  // changelog. Loom is the product identity -- users shouldn't see Pi internals
+  // unless they pass --verbose. The changelog draws from pi-coding-agent's own
+  // CHANGELOG.md and is gated on lastChangelogVersion; pinning that to Pi's
+  // current version means getNewEntries() never finds anything newer to show.
+  if (!hasArg("--verbose")) {
+    const piSettingsPath = join(agentDir, "settings.json");
+    try {
+      let piSettings = {};
+      if (existsSync(piSettingsPath)) {
+        piSettings = JSON.parse(readFileSync(piSettingsPath, "utf-8"));
+      }
+      let changed = false;
+      if (!piSettings.quietStartup) {
+        piSettings.quietStartup = true;
+        changed = true;
+      }
+      const piVersion = resolvePiVersion();
+      if (piVersion && piSettings.lastChangelogVersion !== piVersion) {
+        piSettings.lastChangelogVersion = piVersion;
+        changed = true;
+      }
+      if (changed) {
+        mkdirSync(dirname(piSettingsPath), { recursive: true });
+        writeFileSync(piSettingsPath, JSON.stringify(piSettings, null, 2));
+      }
+    } catch {}
+  }
+
+  // Refresh the update-check cache in a fully detached child so the network call
+  // never delays startup, holds the TUI, or is killed mid-write. The notice the
+  // user sees this run comes from the cache; this updates it for next run.
+  if (process.env.LOOM_SHELL_KIND !== "orbit" && process.env.LOOM_NO_UPDATE_CHECK !== "1") {
+    try {
+      const refresh = spawn(process.execPath, [updateCheckScript, "--refresh"], {
+        detached: true,
+        stdio: "ignore",
+      });
+      refresh.unref();
+    } catch {}
+  }
+
+  main(args);
+}

--- a/bin/update-check.d.ts
+++ b/bin/update-check.d.ts
@@ -1,0 +1,15 @@
+// Mirrors the discriminated union in update-check.js: a failure entry carries
+// no latest/channel; a success entry requires both.
+export type Cache =
+  | { fetchedAt: number; failed: true }
+  | { fetchedAt: number; failed?: false; latest: string; channel: string };
+export function getLoomVersion(): string;
+export function parseCache(raw: string, now: number): Cache | null;
+export function noticeFor(current: string, cache: Cache | null): string | null;
+export function readCache(): Cache | null;
+export function readNotice(): string | null;
+export function refreshCache(): Promise<void>;
+export function detectInstall(channel: string): {
+  kind: "global" | "local" | "unknown";
+  cmd: string | null;
+};

--- a/bin/update-check.js
+++ b/bin/update-check.js
@@ -1,0 +1,135 @@
+// CLI-owned update-check helper. Queries the npm registry for the newest
+// version on the user's channel, caches the answer in ~/.loom/, and exposes a
+// notice string for the CLI-shell glue extension to surface in-session. The
+// network refresh runs as a detached child (see bin/loom.js) so it never
+// blocks startup or is killed mid-write. Pure helpers (parseCache, noticeFor)
+// are unit-tested; the I/O wrappers are thin.
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import { execSync } from "node:child_process";
+import { isNewer, pickChannel } from "../shared/version-compare.js";
+
+const PKG = "@galaxyproject/loom";
+const REGISTRY = "https://registry.npmjs.org/@galaxyproject/loom";
+const CACHE_FILE = path.join(os.homedir(), ".loom", "version-check.json");
+const SUCCESS_TTL_MS = 24 * 60 * 60 * 1000;
+const FAILURE_TTL_MS = 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 5000;
+
+// This file lives at <pkg>/bin/update-check.js, so the package root is one up.
+const PKG_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/** @returns {string} the installed Loom version, from this package's package.json. */
+export function getLoomVersion() {
+  const pkg = JSON.parse(fs.readFileSync(path.join(PKG_ROOT, "package.json"), "utf-8"));
+  return pkg.version;
+}
+
+/**
+ * @typedef {{ fetchedAt: number, failed: true } | { fetchedAt: number, failed?: false, latest: string, channel: string }} Cache
+ */
+
+/** Parse + TTL-validate a cache file's contents. Pure.
+ * @param {string} raw @param {number} now @returns {Cache | null} */
+export function parseCache(raw, now) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed.fetchedAt !== "number") return null;
+  const failed = parsed.failed === true;
+  if (now - parsed.fetchedAt > (failed ? FAILURE_TTL_MS : SUCCESS_TTL_MS)) return null;
+  if (failed) return { fetchedAt: parsed.fetchedAt, failed: true };
+  if (typeof parsed.latest !== "string" || typeof parsed.channel !== "string") return null;
+  return { fetchedAt: parsed.fetchedAt, latest: parsed.latest, channel: parsed.channel };
+}
+
+/** Build the notice string, or null if up to date / no usable cache. Pure.
+ * @param {string} current @param {Cache | null} cache @returns {string | null} */
+export function noticeFor(current, cache) {
+  if (!cache || cache.failed) return null;
+  if (!isNewer(current, cache.latest)) return null;
+  return `loom ${cache.latest} is available (you have ${current}) -- run: npm i -g ${PKG}@${cache.channel}`;
+}
+
+/** Read + validate the cache from disk. @returns {Cache | null} */
+export function readCache() {
+  try {
+    return parseCache(fs.readFileSync(CACHE_FILE, "utf-8"), Date.now());
+  } catch {
+    return null;
+  }
+}
+
+/** The in-session notice for the current install, or null. @returns {string | null} */
+export function readNotice() {
+  try {
+    return noticeFor(getLoomVersion(), readCache());
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(entry) {
+  try {
+    fs.mkdirSync(path.dirname(CACHE_FILE), { recursive: true });
+    fs.writeFileSync(CACHE_FILE, JSON.stringify(entry));
+  } catch {}
+}
+
+/** Query the npm registry for the newest version on the install's channel and
+ * cache it. Best-effort: a failure writes a short-TTL failure marker. */
+export async function refreshCache() {
+  if (readCache()) return; // still fresh; nothing to do
+  const channel = pickChannel(getLoomVersion());
+  try {
+    const res = await fetch(REGISTRY, {
+      headers: { Accept: "application/vnd.npm.install-v1+json" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) throw new Error(`registry ${res.status}`);
+    const body = await res.json();
+    // dist-tags is present in the abbreviated install manifest too, so the
+    // lightweight Accept header above is enough -- no full packument needed.
+    const latest = body["dist-tags"]?.[channel];
+    if (typeof latest !== "string") throw new Error("no dist-tag");
+    writeCache({ fetchedAt: Date.now(), latest, channel });
+  } catch {
+    writeCache({ fetchedAt: Date.now(), failed: true });
+  }
+}
+
+/** Resolve how Loom was installed, for `loom update`.
+ * @param {string} channel @returns {{ kind: "global" | "local" | "unknown", cmd: string | null }} */
+export function detectInstall(channel) {
+  // A git checkout run via tsx isn't an npm install -- don't try to npm-update it.
+  if (fs.existsSync(path.join(PKG_ROOT, ".git"))) {
+    return { kind: "unknown", cmd: null };
+  }
+  let globalRoot = "";
+  try {
+    globalRoot = execSync("npm root -g", { encoding: "utf-8" }).trim();
+  } catch {}
+  // Compare on a path boundary so "/x/node_modules" doesn't match a sibling
+  // like "/x/node_modules-vendor/...".
+  const isGlobal = Boolean(globalRoot) && PKG_ROOT.startsWith(globalRoot + path.sep);
+  const flag = isGlobal ? "-g " : "";
+  return {
+    kind: isGlobal ? "global" : "local",
+    cmd: `npm install ${flag}${PKG}@${channel}`,
+  };
+}
+
+// Detached-refresh entrypoint: `node bin/update-check.js --refresh`.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href &&
+  process.argv.includes("--refresh")
+) {
+  refreshCache().finally(() => process.exit(0));
+}

--- a/extensions/cli-update/index.ts
+++ b/extensions/cli-update/index.ts
@@ -1,0 +1,31 @@
+/**
+ * CLI update notice -- terminal-CLI shell glue, NOT part of the loom brain.
+ *
+ * Surfaces the cached "update available" notice (computed by bin/update-check.js)
+ * once per session via ctx.ui.notify. Lives here, alongside orbit-handoff, so
+ * extensions/loom/ stays shell-neutral. No-ops inside Orbit (which owns its own
+ * updates) and when update checks are disabled.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+// bin/ is a sibling of extensions/; this resolves to <pkg>/bin/update-check.js.
+import { readNotice } from "../../bin/update-check.js";
+
+export default function cliUpdateExtension(pi: ExtensionAPI): void {
+  let shown = false;
+  pi.on("before_agent_start", async (_event, ctx: ExtensionContext) => {
+    if (shown) return;
+    shown = true;
+    // Orbit owns updates for its embedded brain; the bundled CLI copy can't be
+    // npm-updated. LOOM_NO_UPDATE_CHECK is set by bin/loom.js from the config
+    // flag / --no-update-check.
+    if (process.env.LOOM_SHELL_KIND === "orbit") return;
+    if (process.env.LOOM_NO_UPDATE_CHECK === "1") return;
+    try {
+      const notice = readNotice();
+      if (notice) ctx.ui.notify(notice, "info");
+    } catch {
+      // A notice must never break a session.
+    }
+  });
+}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "test:watch": "vitest",
     "evals": "tsx evals/run.ts",
     "typecheck": "tsc --noEmit",
+    "check:versions": "node scripts/check-version-lockstep.mjs",
     "smoke:pack": "node scripts/smoke-pack.mjs",
     "prepublishOnly": "npm run typecheck && npm test && npm run smoke:pack"
   },

--- a/scripts/check-version-lockstep.mjs
+++ b/scripts/check-version-lockstep.mjs
@@ -1,0 +1,16 @@
+// Fail the release if root and app/ package.json versions disagree -- the CLI's
+// --version must never report a different number than the Orbit build shipped
+// alongside it.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const rootV = JSON.parse(readFileSync(join(root, "package.json"), "utf-8")).version;
+const appV = JSON.parse(readFileSync(join(root, "app", "package.json"), "utf-8")).version;
+
+if (rootV !== appV) {
+  console.error(`Version mismatch: root package.json is ${rootV} but app/package.json is ${appV}.`);
+  process.exit(1);
+}
+console.log(`Versions in lockstep: ${rootV}`);

--- a/shared/loom-config.d.ts
+++ b/shared/loom-config.d.ts
@@ -28,6 +28,8 @@ export interface LoomConfig {
     >;
   };
   defaultCwd?: string;
+  /** When false, all update checks (CLI notice + Orbit auto-update/banner) are disabled. Default true. */
+  updateCheck?: boolean;
   /**
    * Execution mode gate. Independent of whether Galaxy credentials are
    * configured.

--- a/shared/loom-config.js
+++ b/shared/loom-config.js
@@ -114,6 +114,11 @@ export function loadConfig() {
         : null,
     sandbox: g.sandbox === true,
   };
+  // Update checks are on by default; an explicit false (set in config or via
+  // the CLI's --no-update-check) silences the CLI notice + Orbit's checks.
+  if (typeof raw.updateCheck !== "boolean") {
+    raw.updateCheck = true;
+  }
   return raw;
 }
 

--- a/shared/version-compare.d.ts
+++ b/shared/version-compare.d.ts
@@ -1,0 +1,10 @@
+export interface SemverParts {
+  major: number;
+  minor: number;
+  patch: number;
+  pre: string;
+}
+export function parseSemver(v: string): SemverParts | null;
+export function comparePre(a: string, b: string): number;
+export function isNewer(current: string, candidate: string): boolean;
+export function pickChannel(version: string): string;

--- a/shared/version-compare.js
+++ b/shared/version-compare.js
@@ -1,0 +1,74 @@
+// Shared, shell-neutral semver helpers. Used by the Orbit version-check banner
+// and the CLI update notice so there's one implementation of precedence rules.
+// Deliberately dependency-free (no `semver` package) for one small feature.
+
+/**
+ * @typedef {{ major: number, minor: number, patch: number, pre: string }} SemverParts
+ */
+
+/** @param {string} v @returns {SemverParts | null} */
+export function parseSemver(v) {
+  const m = String(v)
+    .replace(/^v/, "")
+    .match(/^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/);
+  if (!m) return null;
+  return {
+    major: parseInt(m[1], 10),
+    minor: parseInt(m[2], 10),
+    patch: parseInt(m[3], 10),
+    pre: m[4] ?? "",
+  };
+}
+
+// Compares two prerelease tags per semver precedence. Numeric segments compare
+// numerically (alpha.10 > alpha.9, which a string compare gets wrong). Returns
+// negative when a < b, positive when a > b, zero when equal.
+/** @param {string} a @param {string} b @returns {number} */
+export function comparePre(a, b) {
+  if (a === b) return 0;
+  // No prerelease tag outranks the same version with one (1.0.0 > 1.0.0-alpha).
+  if (!a) return 1;
+  if (!b) return -1;
+  const ap = a.split(".");
+  const bp = b.split(".");
+  const len = Math.min(ap.length, bp.length);
+  for (let i = 0; i < len; i++) {
+    const x = ap[i];
+    const y = bp[i];
+    const xn = /^\d+$/.test(x);
+    const yn = /^\d+$/.test(y);
+    if (xn && yn) {
+      const dx = parseInt(x, 10);
+      const dy = parseInt(y, 10);
+      if (dx !== dy) return dx < dy ? -1 : 1;
+    } else if (xn !== yn) {
+      // Numeric identifiers have lower precedence than alphanumeric ones.
+      return xn ? -1 : 1;
+    } else if (x !== y) {
+      return x < y ? -1 : 1;
+    }
+  }
+  return ap.length === bp.length ? 0 : ap.length < bp.length ? -1 : 1;
+}
+
+/** True when `candidate` is a strictly newer version than `current`.
+ * @param {string} current @param {string} candidate @returns {boolean} */
+export function isNewer(current, candidate) {
+  const a = parseSemver(current);
+  const b = parseSemver(candidate);
+  if (!a || !b) return false;
+  if (b.major !== a.major) return b.major > a.major;
+  if (b.minor !== a.minor) return b.minor > a.minor;
+  if (b.patch !== a.patch) return b.patch > a.patch;
+  return comparePre(a.pre, b.pre) < 0;
+}
+
+// Maps an installed version to the npm dist-tag / release channel it tracks.
+// Mirrors release.yml: prerelease -> first prerelease identifier (alpha/beta/
+// rc), plain semver -> latest. So an alpha user hears about alphas, not stable.
+/** @param {string} version @returns {string} */
+export function pickChannel(version) {
+  const parsed = parseSemver(version);
+  if (!parsed || !parsed.pre) return "latest";
+  return parsed.pre.split(".")[0] || "latest";
+}

--- a/tests/cli-update-check.test.ts
+++ b/tests/cli-update-check.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { parseCache, noticeFor } from "../bin/update-check.js";
+
+describe("parseCache", () => {
+  const now = 1_000_000_000_000;
+  it("returns a fresh success entry", () => {
+    const raw = JSON.stringify({ fetchedAt: now - 1000, latest: "0.3.0", channel: "latest" });
+    expect(parseCache(raw, now)).toEqual({
+      fetchedAt: now - 1000,
+      latest: "0.3.0",
+      channel: "latest",
+    });
+  });
+  it("drops a success entry past the 24h TTL", () => {
+    const raw = JSON.stringify({
+      fetchedAt: now - 25 * 3600_000,
+      latest: "0.3.0",
+      channel: "latest",
+    });
+    expect(parseCache(raw, now)).toBeNull();
+  });
+  it("drops a failure entry past the 1h TTL but keeps a fresh one", () => {
+    const fresh = JSON.stringify({ fetchedAt: now - 1000, failed: true });
+    expect(parseCache(fresh, now)).toEqual({ fetchedAt: now - 1000, failed: true });
+    const stale = JSON.stringify({ fetchedAt: now - 2 * 3600_000, failed: true });
+    expect(parseCache(stale, now)).toBeNull();
+  });
+  it("keeps an entry exactly at the TTL boundary and drops it 1ms past", () => {
+    const atBoundary = JSON.stringify({
+      fetchedAt: now - 24 * 3600_000,
+      latest: "0.3.0",
+      channel: "latest",
+    });
+    expect(parseCache(atBoundary, now)).not.toBeNull();
+    const justPast = JSON.stringify({
+      fetchedAt: now - 24 * 3600_000 - 1,
+      latest: "0.3.0",
+      channel: "latest",
+    });
+    expect(parseCache(justPast, now)).toBeNull();
+  });
+  it("returns null for garbage", () => {
+    expect(parseCache("{not json", now)).toBeNull();
+    expect(parseCache(JSON.stringify({ nope: 1 }), now)).toBeNull();
+  });
+});
+
+describe("noticeFor", () => {
+  it("returns a message when the cached version is newer", () => {
+    const cache = { fetchedAt: 1, latest: "0.3.0", channel: "latest" };
+    const msg = noticeFor("0.2.0", cache);
+    expect(msg).toContain("0.3.0");
+    expect(msg).toContain("0.2.0");
+    expect(msg).toContain("npm i -g @galaxyproject/loom@latest");
+  });
+  it("uses the cached channel in the install hint", () => {
+    const cache = { fetchedAt: 1, latest: "0.3.0-alpha.5", channel: "alpha" };
+    expect(noticeFor("0.3.0-alpha.4", cache)).toContain("@galaxyproject/loom@alpha");
+  });
+  it("returns null when up to date, ahead of cache, on failure, or no cache", () => {
+    expect(noticeFor("0.3.0", { fetchedAt: 1, latest: "0.3.0", channel: "latest" })).toBeNull();
+    expect(noticeFor("0.4.0", { fetchedAt: 1, latest: "0.3.0", channel: "latest" })).toBeNull();
+    expect(noticeFor("0.2.0", { fetchedAt: 1, failed: true })).toBeNull();
+    expect(noticeFor("0.2.0", null)).toBeNull();
+  });
+});

--- a/tests/loom-config-update-check.test.ts
+++ b/tests/loom-config-update-check.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// loadConfig reads ~/.loom/config.json via os.homedir(). Point homedir at a
+// temp dir so the test never touches the real config.
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "loom-cfg-"));
+  vi.spyOn(os, "homedir").mockReturnValue(tmp);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("loadConfig updateCheck default", () => {
+  it("defaults updateCheck to true when absent", async () => {
+    const { loadConfig } = await import("../shared/loom-config.js");
+    expect(loadConfig().updateCheck).toBe(true);
+  });
+  it("preserves an explicit false", async () => {
+    fs.mkdirSync(path.join(tmp, ".loom"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, ".loom", "config.json"),
+      JSON.stringify({ updateCheck: false }),
+    );
+    const { loadConfig } = await import("../shared/loom-config.js");
+    expect(loadConfig().updateCheck).toBe(false);
+  });
+});

--- a/tests/orbit-auto-update-policy.test.ts
+++ b/tests/orbit-auto-update-policy.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { shouldEnableAutoUpdate } from "../app/src/main/auto-update-policy.js";
+
+describe("shouldEnableAutoUpdate", () => {
+  it("enables only on packaged darwin with checks on", () => {
+    expect(
+      shouldEnableAutoUpdate({ platform: "darwin", isPackaged: true, updateCheck: true }),
+    ).toBe(true);
+  });
+  it("is off in dev (unpackaged)", () => {
+    expect(
+      shouldEnableAutoUpdate({ platform: "darwin", isPackaged: false, updateCheck: true }),
+    ).toBe(false);
+  });
+  it("is off on non-darwin (Linux uses the notify-link banner)", () => {
+    expect(shouldEnableAutoUpdate({ platform: "linux", isPackaged: true, updateCheck: true })).toBe(
+      false,
+    );
+  });
+  it("is off when the user opted out", () => {
+    expect(
+      shouldEnableAutoUpdate({ platform: "darwin", isPackaged: true, updateCheck: false }),
+    ).toBe(false);
+  });
+});

--- a/tests/version-compare.test.ts
+++ b/tests/version-compare.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { parseSemver, comparePre, isNewer, pickChannel } from "../shared/version-compare.js";
+
+describe("parseSemver", () => {
+  it("parses plain and prerelease versions, tolerating a v prefix", () => {
+    expect(parseSemver("v1.2.3")).toEqual({ major: 1, minor: 2, patch: 3, pre: "" });
+    expect(parseSemver("0.3.0-alpha.10")).toEqual({
+      major: 0,
+      minor: 3,
+      patch: 0,
+      pre: "alpha.10",
+    });
+  });
+  it("returns null for garbage", () => {
+    expect(parseSemver("not-a-version")).toBeNull();
+  });
+});
+
+describe("isNewer", () => {
+  it("compares core version components", () => {
+    expect(isNewer("0.2.0", "0.3.0")).toBe(true);
+    expect(isNewer("0.3.0", "0.2.0")).toBe(false);
+    expect(isNewer("0.3.0", "0.3.0")).toBe(false);
+  });
+  it("honors prerelease precedence", () => {
+    expect(isNewer("1.0.0-alpha", "1.0.0")).toBe(true);
+    expect(isNewer("1.0.0", "1.0.0-alpha")).toBe(false);
+    expect(isNewer("1.0.0-alpha.9", "1.0.0-alpha.10")).toBe(true);
+    expect(isNewer("1.0.0-alpha.10", "1.0.0-alpha.9")).toBe(false);
+  });
+  it("returns false for unparseable input", () => {
+    expect(isNewer("garbage", "1.0.0")).toBe(false);
+  });
+});
+
+describe("comparePre", () => {
+  it("treats an absent prerelease as higher precedence than any prerelease", () => {
+    expect(comparePre("", "alpha")).toBeGreaterThan(0);
+    expect(comparePre("alpha", "")).toBeLessThan(0);
+    expect(comparePre("", "")).toBe(0);
+  });
+  it("ranks numeric identifiers below alphanumeric ones", () => {
+    expect(comparePre("1", "alpha")).toBeLessThan(0);
+    expect(comparePre("alpha", "1")).toBeGreaterThan(0);
+  });
+  it("gives a longer prerelease higher precedence when all preceding fields tie", () => {
+    expect(comparePre("alpha", "alpha.1")).toBeLessThan(0);
+    expect(comparePre("alpha.1", "alpha")).toBeGreaterThan(0);
+  });
+  it("returns zero for identical prerelease tags", () => {
+    expect(comparePre("alpha.1", "alpha.1")).toBe(0);
+  });
+});
+
+describe("pickChannel", () => {
+  it("maps a plain version to latest and a prerelease to its identifier", () => {
+    expect(pickChannel("0.3.0")).toBe("latest");
+    expect(pickChannel("0.3.0-alpha.4")).toBe("alpha");
+    expect(pickChannel("1.2.3-beta.1")).toBe("beta");
+    expect(pickChannel("2.0.0-rc.1")).toBe("rc");
+  });
+});


### PR DESCRIPTION
True in-app auto-update for Orbit on macOS via `update-electron-app` + update.electronjs.org (the forge-native path). Linux stays on the existing GitHub-releases notify-link banner, now scoped to non-darwin (so mac doesn't double-notify) and honoring the shared opt-out. On download, Orbit shows a "restart to install" banner reusing the existing banner, wired through `update:downloaded` / `update:restart` / `update:error` IPC.

The free service ignores draft + prerelease releases, so the manual promote-the-draft QA gate is preserved for free -- with a CI fix to mark prerelease tags as GitHub prereleases (`prerelease: ${{ contains(github.ref_name, '-') }}`) so an alpha is never served to stable users, plus a root/app version-lockstep assertion on every release build. macOS is already signed + notarized, which is what Squirrel.Mac needs.

The decision to keep Linux on notify-link is deliberate: the forge-native updater is macOS/Windows-only and Orbit ships no native Windows, so Linux true auto-update would mean an electron-builder migration + AppImage -- deferred until there's demand.

**Ship gate:** macOS auto-update can only be fully verified by a real signed N->N+1 Squirrel.Mac update on a packaged build (the bundled Node/uv/native-module layout). Validate that before promoting a release that enables it.

---
Stacked on #160 -- until that merges, this PR's diff includes #160's commits; it will recompute to just the Orbit changes once #160 lands.