### PR TITLE
chore: cut 0.3.0 -- update mechanism (CLI notice + Orbit auto-update), Opus 4.8 + pi 0.78

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orbit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orbit",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orbit",
   "productName": "Orbit",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Electron desktop shell for the Loom agent runtime (Galaxy bioinformatics)",
   "license": "MIT",
   "main": ".vite/build/main.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@galaxyproject/loom",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@galaxyproject/loom",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "^0.0.52",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galaxyproject/loom",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "description": "AI co-scientist for Galaxy bioinformatics, built on Pi.dev",
   "keywords": [


### PR DESCRIPTION
Version-only bump 0.2.0 -> 0.3.0 to cut the 0.3.0 release. Once this lands, tagging v0.3.0 triggers the release workflow (npm publish to the latest dist-tag + signed installers attached to a draft GitHub release).

Included since v0.2.0:

- Update mechanism -- #160 (CLI update-available notice, `--version` fix, `loom update`) and #161 (Orbit macOS in-place auto-update + CI prerelease/version-lockstep guards)
- Models & pricing -- #155 (Opus 4.8), #159 (Opus pricing corrected to $5/$25), #162 (pi 0.75.4 -> 0.78.0: native Opus 4.8 + shutdown/compaction fixes)
- Other -- #141 (orbit-handoff), #157 (protected-write workspace-relative fix), #143 (Galaxy tool-input docs), #158 (feedback tester-id)