### PR TITLE
feat(orbit): context-window fill indicator in the footer

### DIFF
--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -621,7 +621,7 @@ export function registerIpcHandlers(agent: AgentManager): void {
       "deepseek",
     ]);
     type Pricing = { input: number; output: number; cacheRead?: number; cacheWrite?: number };
-    type Entry = { id: string; label: string; pricing: Pricing };
+    type Entry = { id: string; label: string; pricing: Pricing; contextWindow?: number };
     const out: Record<string, Entry[]> = {};
     try {
       for (const provider of getProviders()) {
@@ -640,6 +640,9 @@ export function registerIpcHandlers(agent: AgentManager): void {
               cacheRead: m.cost.cacheRead,
               cacheWrite: m.cost.cacheWrite,
             },
+            // Model's max context window (tokens). Powers the renderer's
+            // context-fill indicator. May be undefined for some providers.
+            contextWindow: typeof m.contextWindow === "number" ? m.contextWindow : undefined,
           };
         });
       }

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -136,6 +136,7 @@ export interface OrbitAPI {
             id: string;
             label: string;
             pricing: { input: number; output: number; cacheRead?: number; cacheWrite?: number };
+            contextWindow?: number;
           }>
         >;
       }

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -115,30 +115,36 @@ let PRICING: Record<string, { in: number; out: number; cacheRead?: number; cache
     "qwen3:8b": { in: 0, out: 0 },
   };
 
-// Per-model context-window size (tokens). Fallback only — overwritten by
-// populateDynamicModelData() from pi-ai's registry. Powers the footer's
-// context-fill indicator. Honest-window caveat: the registry value for
-// openai-codex models (e.g. gpt-5.5 = 272000) reflects the API model's max,
-// which can exceed the ChatGPT-subscription endpoint's real limit, so the bar
-// may under-report on that path. Documented; not special-cased.
-let CONTEXT_WINDOWS: Record<string, number> = {
-  // Anthropic
-  "claude-opus-4-8": 200_000,
-  "claude-opus-4-7": 200_000,
-  "claude-opus-4-6": 200_000,
-  "claude-opus-4-5": 200_000,
-  "claude-sonnet-4-6": 200_000,
-  "claude-sonnet-4-5": 200_000,
-  "claude-haiku-4-5": 200_000,
-  // OpenAI
-  "gpt-4o": 128_000,
-  "gpt-4o-mini": 128_000,
-  "gpt-4-turbo": 128_000,
-  o1: 200_000,
-  "o1-mini": 128_000,
-  // Google
-  "gemini-2.5-pro": 1_048_576,
-  "gemini-2.5-flash": 1_048_576,
+// Per-model context-window size (tokens), keyed by provider then model id.
+// Fallback only — overwritten per provider by populateDynamicModelData() from
+// pi-ai's registry. Powers the footer's context-fill indicator. Keyed by
+// provider because pi-ai exposes the same model id under multiple providers
+// with different windows (e.g. gpt-5.2 is openai=400k but openai-codex=272k),
+// so a flat id→window map would let whichever provider loaded last win.
+// Honest-window caveat: a registry window (an openai-codex model, or Claude's
+// 1M tier) can exceed the endpoint's real usable limit, so the bar may
+// under-report on those paths. Documented; not special-cased.
+let CONTEXT_WINDOWS: Record<string, Record<string, number>> = {
+  anthropic: {
+    "claude-opus-4-8": 1_000_000,
+    "claude-opus-4-7": 1_000_000,
+    "claude-opus-4-6": 1_000_000,
+    "claude-opus-4-5": 200_000,
+    "claude-sonnet-4-6": 1_000_000,
+    "claude-sonnet-4-5": 200_000,
+    "claude-haiku-4-5": 200_000,
+  },
+  openai: {
+    "gpt-4o": 128_000,
+    "gpt-4o-mini": 128_000,
+    "gpt-4-turbo": 128_000,
+    o1: 200_000,
+    "o1-mini": 128_000,
+  },
+  google: {
+    "gemini-2.5-pro": 1_048_576,
+    "gemini-2.5-flash": 1_048_576,
+  },
 };
 
 interface Usage {
@@ -154,6 +160,11 @@ const turnUsage: Usage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 // produced them (the user can switch models mid-session).
 const perModelUsage = new Map<string, Usage>();
 let currentModel: string | null = null;
+// Active provider for currentModel. Tracked separately because pi-ai exposes
+// the same model id under multiple providers with different context windows,
+// and usage events carry only the model — so we set this at the explicit
+// model/provider change sites (startup, /model switch, prefs save).
+let currentProvider: string | null = null;
 
 // Current context occupancy: input + cacheRead of the LATEST assistant turn's
 // usage (the size of the last request sent to the model). This is NOT the
@@ -285,19 +296,44 @@ function renderUsage(): void {
   }
 }
 
-/** Resolve a model id to its context-window size (tokens), or null if unknown. */
-function contextWindowFor(model: string | null): number | null {
-  if (!model) return null;
-  const exact = CONTEXT_WINDOWS[model];
+/**
+ * Look up a model's window within one provider's table: exact, then date-suffix
+ * strip, then longest-key-first prefix requiring a delimiter boundary — so
+ * "gpt-5" can't swallow "gpt-5.4-pro" (a "." is not a boundary), while
+ * "claude-opus-4-8" still matches a dated "claude-opus-4-8-20250514".
+ */
+function windowFromTable(table: Record<string, number>, model: string): number | null {
+  const exact = table[model];
   if (typeof exact === "number" && exact > 0) return exact;
-  // Prefix match (e.g. claude-opus-4-8-20250514 → claude-opus-4-8).
-  for (const key of Object.keys(CONTEXT_WINDOWS)) {
-    if (model.startsWith(key)) {
-      const w = CONTEXT_WINDOWS[key];
-      if (w > 0) return w;
+  const stripped = model.replace(/-\d{8}$/, "");
+  if (typeof table[stripped] === "number" && table[stripped] > 0) return table[stripped];
+  for (const key of Object.keys(table).sort((a, b) => b.length - a.length)) {
+    if ((model.startsWith(`${key}-`) || model.startsWith(`${key}:`)) && table[key] > 0) {
+      return table[key];
     }
   }
   return null;
+}
+
+/**
+ * Resolve a model id to its context-window size (tokens), or null if unknown.
+ * Provider-qualified first (the same id can mean different windows on different
+ * providers); falls back to a provider-agnostic search when the provider is
+ * unknown or absent from the table, preferring the smallest match so the bar
+ * warns early rather than miss an overflow.
+ */
+function contextWindowFor(provider: string | null, model: string | null): number | null {
+  if (!model) return null;
+  if (provider && CONTEXT_WINDOWS[provider]) {
+    const w = windowFromTable(CONTEXT_WINDOWS[provider], model);
+    if (w !== null) return w;
+  }
+  let best: number | null = null;
+  for (const table of Object.values(CONTEXT_WINDOWS)) {
+    const w = windowFromTable(table, model);
+    if (w !== null && (best === null || w < best)) best = w;
+  }
+  return best;
 }
 
 // Context-fill indicator: shows how full the current model's context window is,
@@ -309,7 +345,7 @@ function contextWindowFor(model: string | null): number | null {
 function updateContextFill(): void {
   // Local is named windowSize (not `window`) to avoid shadowing the global
   // window object the renderer uses for window.orbit.* calls.
-  const windowSize = contextWindowFor(currentModel);
+  const windowSize = contextWindowFor(currentProvider, currentModel);
   if (!windowSize || contextTokens <= 0) {
     contextFillEl.classList.add("hidden");
     contextFillEl.classList.remove("warn", "danger");
@@ -326,7 +362,7 @@ function updateContextFill(): void {
   // null model, which the early return above already handled.
   contextFillEl.title =
     `Context: ${contextTokens.toLocaleString()} / ${windowSize.toLocaleString()} tokens (${pct}%)` +
-    `\nmodel: ${currentModel}`;
+    `\nmodel: ${currentModel}${currentProvider ? ` (${currentProvider})` : ""}`;
 }
 
 /** Format a long model id into a short display label, e.g. claude-sonnet-4-6 → "Sonnet 4.6". */
@@ -924,7 +960,8 @@ async function populateDynamicModelData(): Promise<void> {
           cacheWrite: e.pricing.cacheWrite,
         };
         if (typeof e.contextWindow === "number" && e.contextWindow > 0) {
-          newWindows[e.id] = e.contextWindow;
+          newWindows[provider] = newWindows[provider] ?? {};
+          newWindows[provider][e.id] = e.contextWindow;
         }
       }
     }
@@ -933,7 +970,13 @@ async function populateDynamicModelData(): Promise<void> {
     // IPC (e.g. deepseek before main process restarts) survive.
     MODELS_BY_PROVIDER = { ...MODELS_BY_PROVIDER, ...newModels };
     PRICING = { ...PRICING, ...newPricing };
-    CONTEXT_WINDOWS = { ...CONTEXT_WINDOWS, ...newWindows };
+    // Merge per provider so hardcoded providers/models not returned by the IPC
+    // survive (mirrors the MODELS/PRICING merge above).
+    const mergedWindows: typeof CONTEXT_WINDOWS = { ...CONTEXT_WINDOWS };
+    for (const [provider, table] of Object.entries(newWindows)) {
+      mergedWindows[provider] = { ...mergedWindows[provider], ...table };
+    }
+    CONTEXT_WINDOWS = mergedWindows;
     // A late registry load may add the current model's window → refresh.
     updateContextFill();
   } catch {
@@ -1045,6 +1088,7 @@ void (async () => {
     const model = activeProvider ? cfg.llm?.providers?.[activeProvider]?.model : undefined;
     if (model) {
       currentModel = model;
+      currentProvider = activeProvider ?? null;
       renderModelIndicator();
       // No request has been sent on this model yet → hide/reset the fill bar.
       contextTokens = 0;
@@ -1817,7 +1861,7 @@ async function switchModelByAlias(originalText: string, alias: string): Promise<
   chat.addUserMessage(originalText);
 
   const cfg = (await window.orbit.getConfig()) as { llm?: { active?: string } };
-  const currentProvider = cfg.llm?.active || "anthropic";
+  const prevProvider = cfg.llm?.active || "anthropic";
 
   // Search strategy: prefer current provider, then search all providers.
   // Within each provider: exact id match → id substring → label substring.
@@ -1833,13 +1877,13 @@ async function switchModelByAlias(originalText: string, alias: string): Promise<
   };
 
   // 1. Try current provider first (preserves user's existing setup)
-  const inCurrent = search(currentProvider);
+  const inCurrent = search(prevProvider);
   if (inCurrent) {
-    chosen = { provider: currentProvider, model: inCurrent };
+    chosen = { provider: prevProvider, model: inCurrent };
   } else {
     // 2. Fall back to searching every provider
     for (const p of Object.keys(MODELS_BY_PROVIDER)) {
-      if (p === currentProvider) continue;
+      if (p === prevProvider) continue;
       const m = search(p);
       if (m) {
         chosen = { provider: p, model: m };
@@ -1858,7 +1902,7 @@ async function switchModelByAlias(originalText: string, alias: string): Promise<
 
   // Partial update -- the reconciler preserves every other provider's
   // encrypted key + model and only overlays what we send.
-  const switchingProvider = chosen.provider !== currentProvider;
+  const switchingProvider = chosen.provider !== prevProvider;
   const update = {
     llm: {
       active: chosen.provider,
@@ -1872,6 +1916,7 @@ async function switchModelByAlias(originalText: string, alias: string): Promise<
   }
 
   currentModel = chosen.model.id;
+  currentProvider = chosen.provider;
   renderModelIndicator();
   // Manual switch: the stale request size is for the old model's window; reset
   // so the bar re-populates correctly on the new model's first turn.
@@ -3288,10 +3333,15 @@ async function savePreferences(): Promise<void> {
     void refreshGalaxyStatus();
     refreshSandboxBanner(prefsSandbox.checked);
     if (selectedModel) {
+      const modelChanged = selectedModel !== prevModel;
       currentModel = selectedModel;
+      currentProvider = activeProvider;
       renderModelIndicator();
-      // Manual switch: reset so the bar re-populates on the new model's next turn.
-      contextTokens = 0;
+      // Only zero the numerator when the model actually changed. Saving an
+      // unrelated pref restarts the agent with --continue (context preserved),
+      // so resetting here would needlessly hide the bar until the next turn.
+      // The window may still differ (provider change), so always recompute.
+      if (modelChanged) contextTokens = 0;
       updateContextFill();
     }
     // Info card, not a fake user prompt — was getting numbered as a real

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -45,6 +45,9 @@ const cwdPathEl = document.getElementById("cwd-path")!;
 const cwdChangeBtn = document.getElementById("cwd-change")!;
 const usageTokensEl = document.getElementById("usage-tokens")!;
 const usageCostEl = document.getElementById("usage-cost")!;
+const contextFillEl = document.getElementById("context-fill")!;
+const contextFillBarEl = document.getElementById("context-fill-bar")!;
+const contextFillPctEl = document.getElementById("context-fill-pct")!;
 const modelIndicatorEl = document.getElementById("model-indicator")!;
 const modelIndicatorNameEl = document.getElementById("model-indicator-name")!;
 
@@ -112,6 +115,32 @@ let PRICING: Record<string, { in: number; out: number; cacheRead?: number; cache
     "qwen3:8b": { in: 0, out: 0 },
   };
 
+// Per-model context-window size (tokens). Fallback only — overwritten by
+// populateDynamicModelData() from pi-ai's registry. Powers the footer's
+// context-fill indicator. Honest-window caveat: the registry value for
+// openai-codex models (e.g. gpt-5.5 = 272000) reflects the API model's max,
+// which can exceed the ChatGPT-subscription endpoint's real limit, so the bar
+// may under-report on that path. Documented; not special-cased.
+let CONTEXT_WINDOWS: Record<string, number> = {
+  // Anthropic
+  "claude-opus-4-8": 200_000,
+  "claude-opus-4-7": 200_000,
+  "claude-opus-4-6": 200_000,
+  "claude-opus-4-5": 200_000,
+  "claude-sonnet-4-6": 200_000,
+  "claude-sonnet-4-5": 200_000,
+  "claude-haiku-4-5": 200_000,
+  // OpenAI
+  "gpt-4o": 128_000,
+  "gpt-4o-mini": 128_000,
+  "gpt-4-turbo": 128_000,
+  o1: 200_000,
+  "o1-mini": 128_000,
+  // Google
+  "gemini-2.5-pro": 1_048_576,
+  "gemini-2.5-flash": 1_048_576,
+};
+
 interface Usage {
   input: number;
   output: number;
@@ -125,6 +154,12 @@ const turnUsage: Usage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 // produced them (the user can switch models mid-session).
 const perModelUsage = new Map<string, Usage>();
 let currentModel: string | null = null;
+
+// Current context occupancy: input + cacheRead of the LATEST assistant turn's
+// usage (the size of the last request sent to the model). This is NOT the
+// cumulative sessionUsage — it's the live "how full is the window right now"
+// numerator for the context-fill indicator. Reset on new session.
+let contextTokens = 0;
 
 // Pi's AssistantMessage.usage carries a `cost` object calculated upstream
 // from its authoritative rate table (`calculateCost` in pi-ai/models.js).
@@ -248,6 +283,50 @@ function renderUsage(): void {
     usageCostEl.textContent = "";
     usageCostEl.classList.add("hidden");
   }
+}
+
+/** Resolve a model id to its context-window size (tokens), or null if unknown. */
+function contextWindowFor(model: string | null): number | null {
+  if (!model) return null;
+  const exact = CONTEXT_WINDOWS[model];
+  if (typeof exact === "number" && exact > 0) return exact;
+  // Prefix match (e.g. claude-opus-4-8-20250514 → claude-opus-4-8).
+  for (const key of Object.keys(CONTEXT_WINDOWS)) {
+    if (model.startsWith(key)) {
+      const w = CONTEXT_WINDOWS[key];
+      if (w > 0) return w;
+    }
+  }
+  return null;
+}
+
+// Context-fill indicator: shows how full the current model's context window is,
+// so the user sees an impending overflow before it happens. The numerator is
+// the LATEST turn's request size (contextTokens), NOT cumulative sessionUsage.
+// Hidden when the window is unknown (no divide-by-zero / NaN). Honest-window
+// caveat: openai-codex models' registry window may exceed the real ChatGPT
+// endpoint limit, so the bar can under-report on that path (see CONTEXT_WINDOWS).
+function updateContextFill(): void {
+  // Local is named windowSize (not `window`) to avoid shadowing the global
+  // window object the renderer uses for window.orbit.* calls.
+  const windowSize = contextWindowFor(currentModel);
+  if (!windowSize || contextTokens <= 0) {
+    contextFillEl.classList.add("hidden");
+    contextFillEl.classList.remove("warn", "danger");
+    return;
+  }
+  const ratio = contextTokens / windowSize;
+  const pct = Math.min(100, Math.round(ratio * 100));
+  contextFillEl.classList.remove("hidden");
+  contextFillBarEl.style.width = `${Math.min(100, ratio * 100)}%`;
+  contextFillPctEl.textContent = `${pct}%`;
+  contextFillEl.classList.toggle("danger", ratio >= 0.9);
+  contextFillEl.classList.toggle("warn", ratio >= 0.7 && ratio < 0.9);
+  // currentModel is always non-null here: contextWindowFor returns null for a
+  // null model, which the early return above already handled.
+  contextFillEl.title =
+    `Context: ${contextTokens.toLocaleString()} / ${windowSize.toLocaleString()} tokens (${pct}%)` +
+    `\nmodel: ${currentModel}`;
 }
 
 /** Format a long model id into a short display label, e.g. claude-sonnet-4-6 → "Sonnet 4.6". */
@@ -834,6 +913,7 @@ async function populateDynamicModelData(): Promise<void> {
     if (!res.ok) return;
     const newModels: Record<string, ModelChoice[]> = {};
     const newPricing: typeof PRICING = {};
+    const newWindows: typeof CONTEXT_WINDOWS = {};
     for (const [provider, entries] of Object.entries(res.providers)) {
       newModels[provider] = entries.map((e) => ({ id: e.id, label: e.label }));
       for (const e of entries) {
@@ -843,6 +923,9 @@ async function populateDynamicModelData(): Promise<void> {
           cacheRead: e.pricing.cacheRead,
           cacheWrite: e.pricing.cacheWrite,
         };
+        if (typeof e.contextWindow === "number" && e.contextWindow > 0) {
+          newWindows[e.id] = e.contextWindow;
+        }
       }
     }
     if (Object.keys(newModels).length === 0) return; // never replace with empty
@@ -850,6 +933,9 @@ async function populateDynamicModelData(): Promise<void> {
     // IPC (e.g. deepseek before main process restarts) survive.
     MODELS_BY_PROVIDER = { ...MODELS_BY_PROVIDER, ...newModels };
     PRICING = { ...PRICING, ...newPricing };
+    CONTEXT_WINDOWS = { ...CONTEXT_WINDOWS, ...newWindows };
+    // A late registry load may add the current model's window → refresh.
+    updateContextFill();
   } catch {
     /* keep hardcoded fallback */
   }
@@ -864,6 +950,11 @@ function captureUsage(event: Record<string, unknown>): void {
   if (msg.model && typeof msg.model === "string" && msg.model !== currentModel) {
     currentModel = msg.model;
     renderModelIndicator();
+    // Window changed → the prior model's request size is meaningless for the new
+    // model, so reset and recompute (hides the bar until the new model's usage
+    // arrives, which on Anthropic lands in this same event below).
+    contextTokens = 0;
+    updateContextFill();
   }
 
   const u = msg.usage as (Partial<Usage> & { cost?: { total?: number } }) | undefined;
@@ -877,6 +968,23 @@ function captureUsage(event: Record<string, unknown>): void {
   // Pi's rolling cost for this message (authoritative, computed in pi-ai).
   if (typeof u.cost?.total === "number") {
     turnCostFromPi = u.cost.total;
+  }
+
+  // Current context occupancy = this turn's request (prompt) size. In pi-ai's
+  // Usage, input/cacheRead/cacheWrite are DISJOINT: input = uncached prompt,
+  // cacheRead = cache hits, cacheWrite = cache-creation tokens. The full prompt
+  // size is the sum of all three (pi-ai's totalTokens is this sum plus output).
+  // On a cache-creation turn (fresh session / first large prompt) the bulk lands
+  // in cacheWrite, so omitting it would under-report exactly the large turns this
+  // indicator must warn about. Update only when we have a usable signal so a
+  // partial event doesn't zero it.
+  if (
+    typeof u.input === "number" ||
+    typeof u.cacheRead === "number" ||
+    typeof u.cacheWrite === "number"
+  ) {
+    contextTokens = (u.input ?? 0) + (u.cacheRead ?? 0) + (u.cacheWrite ?? 0);
+    updateContextFill();
   }
 }
 
@@ -938,6 +1046,9 @@ void (async () => {
     if (model) {
       currentModel = model;
       renderModelIndicator();
+      // No request has been sent on this model yet → hide/reset the fill bar.
+      contextTokens = 0;
+      updateContextFill();
     }
   } catch {
     /* getConfig may not be available yet */
@@ -977,6 +1088,8 @@ function resetUiForFreshContext(opts: { clearPersistedCost?: boolean } = {}): vo
   turnUsage.cacheWrite = 0;
   perModelUsage.clear();
   sessionCostFromPi = null;
+  contextTokens = 0;
+  updateContextFill();
   if (clearPersistedCost) {
     try {
       clearCostState(cwdPathEl.textContent || "");
@@ -1760,6 +1873,10 @@ async function switchModelByAlias(originalText: string, alias: string): Promise<
 
   currentModel = chosen.model.id;
   renderModelIndicator();
+  // Manual switch: the stale request size is for the old model's window; reset
+  // so the bar re-populates correctly on the new model's first turn.
+  contextTokens = 0;
+  updateContextFill();
 
   if (switchingProvider) {
     chat.addInfoMessage(
@@ -3173,6 +3290,9 @@ async function savePreferences(): Promise<void> {
     if (selectedModel) {
       currentModel = selectedModel;
       renderModelIndicator();
+      // Manual switch: reset so the bar re-populates on the new model's next turn.
+      contextTokens = 0;
+      updateContextFill();
     }
     // Info card, not a fake user prompt — was getting numbered as a real
     // user submission and inflating the prompt counter.

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -359,6 +359,10 @@
           <span id="usage-tokens">0 tok</span>
           <span id="usage-cost"></span>
         </div>
+        <div id="context-fill" class="footer-control hidden" title="Context window usage">
+          <span id="context-fill-track"><span id="context-fill-bar"></span></span>
+          <span id="context-fill-pct">0%</span>
+        </div>
         <div id="cwd-bar" class="footer-control">
           <span id="cwd-path" title="Analysis directory">~</span>
           <button

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -836,6 +836,45 @@ body.platform-darwin #files-title {
   display: none;
 }
 
+/* Context-fill indicator: a small track + fill bar plus a percentage,
+   showing how full the current model's context window is. Color-only state
+   variants (warn/danger) atop the shared .footer-control base; dimensions
+   never change. Hidden via the .hidden convention when the window is unknown. */
+#context-fill.hidden {
+  display: none;
+}
+#context-fill-track {
+  display: inline-block;
+  width: 42px;
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.15);
+  overflow: hidden;
+}
+#context-fill-bar {
+  display: block;
+  height: 100%;
+  width: 0%;
+  border-radius: 3px;
+  background: var(--accent);
+  transition: width 0.2s;
+}
+#context-fill-pct {
+  white-space: nowrap;
+}
+#context-fill.warn #context-fill-bar {
+  background: var(--galaxy-gold-dark);
+}
+#context-fill.warn {
+  color: var(--galaxy-gold-dark);
+}
+#context-fill.danger #context-fill-bar {
+  background: #ff817b;
+}
+#context-fill.danger {
+  color: #ff817b;
+}
+
 /* Segmented Local|Cloud control — single rounded-rect container with two
    inner buttons, the active one filled with var(--accent). */
 .footer-control-segmented {


### PR DESCRIPTION
## Why

Long sessions silently approach the model's context window until the provider rejects a request with `context_length_exceeded` (we hit this on gpt-5.5 via the Codex subscription path). Nothing in the UI warned beforehand. This adds a footer indicator so you can see the window filling and act (compact / `/new` → Keep notebook / switch to a bigger-context model) before the wall.

## What ("Option A" — renderer-only, reuses data already flowing)

- **main** `models:list-all` IPC now forwards each pi-ai model's `contextWindow` (the `Entry` type and the preload `OrbitAPI.listAllModels()` type are extended to match).
- **renderer** captures it into a `CONTEXT_WINDOWS` map (hardcoded fallback + dynamic merge from the registry, mirroring the existing `PRICING` pattern).
- A footer `#context-fill` element (track + bar + %) shows **fill % = latest turn's request size / contextWindow(currentModel)**.
- Color thresholds: ok `<70%`, warn `70–89%`, danger `≥90%`. Tooltip: `X / Y tokens (Z%)` + model id.

## Correctness note (caught in review)

The numerator is `input + cacheRead + **cacheWrite**`. These three are **disjoint** in pi-ai's `Usage` — on a cache-*creation* turn (fresh session / first large prompt) the bulk of the prompt lands in `cacheWrite` while `input` is tiny. Summing only `input + cacheRead` would show ~0% on exactly the big turns the indicator exists to flag. The review phase flagged this; the fix is in.

Other safeguards: hidden when the window is unknown (no divide-by-zero/NaN); resets on new session, `/model`, preferences-save, and initial load; recomputes on late registry load and model switch. Honest-window caveat for `openai-codex` models (registry window may exceed the ChatGPT-subscription endpoint's real limit) is documented in-code, not special-cased.

## Process

Built with a multi-agent workflow: implement → 3-lens review (correctness / conventions-UI / edge-cases) → test+fix. The review caught the `cacheWrite` omission.

## Validation

- `npm run typecheck` (root) + `app` `tsc --noEmit` — clean
- `npm test` — 419 passed

## Follow-up

This pairs with the `/compact` PR (#154) and is "Option A"; the more authoritative "Option B" (Pi's own `ctx.getContextUsage()` pushed from the extension, which accounts for the system prompt + reserve) is a natural upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)