### PR TITLE
Decouple the Intel mac build from the release critical path

### DIFF
--- a/.github/actions/make-orbit/action.yml
+++ b/.github/actions/make-orbit/action.yml
@@ -1,0 +1,129 @@
+name: Make Orbit installer
+description: >-
+  Build a platform-specific Orbit installer with electron-forge -- including
+  optional macOS Developer ID signing + notarization -- and upload it as a
+  workflow artifact named Orbit-<platform>-<arch>. Shared by the release
+  workflow's required-platform matrix and its best-effort Intel mac job so the
+  signing setup can never drift between the two macOS builds.
+
+inputs:
+  platform:
+    description: electron-forge --platform value (darwin or linux).
+    required: true
+  arch:
+    description: electron-forge --arch value (arm64 or x64).
+    required: true
+  # macOS signing/notarization secrets are passed in (composite actions can't
+  # read the secrets context). All optional: when empty -- on a fork, or before
+  # the secrets are configured -- the build simply runs unsigned, exactly as it
+  # does on the required-platform path. See docs/macos-codesigning.md.
+  macos-certificate-base64:
+    description: Base64-encoded Developer ID Application cert (.p12). Empty -> unsigned.
+    required: false
+    default: ""
+  macos-certificate-password:
+    description: Password for the .p12 certificate.
+    required: false
+    default: ""
+  apple-signing-identity:
+    description: Developer ID identity string; presence enables osxSign.
+    required: false
+    default: ""
+  apple-api-key-base64:
+    description: Base64-encoded App Store Connect API key (.p8). Empty -> not notarized.
+    required: false
+    default: ""
+  apple-api-key-id:
+    description: App Store Connect API key ID.
+    required: false
+    default: ""
+  apple-api-issuer:
+    description: App Store Connect API issuer ID.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install Linux packaging deps
+      if: inputs.platform == 'linux'
+      shell: bash
+      run: sudo apt-get update -qq && sudo apt-get install -y fakeroot rpm
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        cache: npm
+        cache-dependency-path: |
+          package-lock.json
+          app/package-lock.json
+
+    - name: Install root deps
+      shell: bash
+      run: npm ci
+
+    - name: Install app deps
+      shell: bash
+      working-directory: app
+      run: npm ci
+
+    # Imports the Developer ID Application cert into a throwaway keychain so
+    # codesign (via electron-forge's osxSign) can find the identity. Skipped
+    # entirely when the cert secret isn't set -> unsigned build.
+    - name: Import Apple signing certificate
+      if: inputs.platform == 'darwin' && inputs.macos-certificate-base64 != ''
+      shell: bash
+      env:
+        MACOS_CERTIFICATE_BASE64: ${{ inputs.macos-certificate-base64 }}
+        MACOS_CERTIFICATE_PASSWORD: ${{ inputs.macos-certificate-password }}
+      run: |
+        CERT_PATH="$RUNNER_TEMP/developer-id.p12"
+        KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+        KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+        echo "$MACOS_CERTIFICATE_BASE64" | base64 --decode > "$CERT_PATH"
+        security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+        security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+        security import "$CERT_PATH" -P "$MACOS_CERTIFICATE_PASSWORD" \
+          -t cert -f pkcs12 -k "$KEYCHAIN_PATH" \
+          -T /usr/bin/codesign -T /usr/bin/security
+        security set-key-partition-list -S apple-tool:,apple:,codesign: \
+          -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+        # Prepend our keychain to the user search list so codesign sees it.
+        security list-keychains -d user -s "$KEYCHAIN_PATH" \
+          $(security list-keychains -d user | sed 's/"//g')
+        rm -f "$CERT_PATH"
+
+    # Decodes the App Store Connect API key (.p8) to a file and exports its
+    # path; forge.config.ts reads APPLE_API_KEY_PATH to enable notarization.
+    # Skipped when the key secret isn't set -> signed-but-not-notarized.
+    - name: Stage notarization API key
+      if: inputs.platform == 'darwin' && inputs.apple-api-key-base64 != ''
+      shell: bash
+      env:
+        APPLE_API_KEY_BASE64: ${{ inputs.apple-api-key-base64 }}
+      run: |
+        KEY_PATH="$RUNNER_TEMP/asc-api-key.p8"
+        echo "$APPLE_API_KEY_BASE64" | base64 --decode > "$KEY_PATH"
+        echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+
+    - name: Make Orbit (${{ inputs.platform }}-${{ inputs.arch }})
+      shell: bash
+      working-directory: app
+      # APPLE_API_KEY_PATH comes from the staging step via $GITHUB_ENV.
+      env:
+        APPLE_SIGNING_IDENTITY: ${{ inputs.apple-signing-identity }}
+        APPLE_API_KEY_ID: ${{ inputs.apple-api-key-id }}
+        APPLE_API_ISSUER: ${{ inputs.apple-api-issuer }}
+      run: npx electron-forge make --arch=${{ inputs.arch }} --platform=${{ inputs.platform }}
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: Orbit-${{ inputs.platform }}-${{ inputs.arch }}
+        path: |
+          app/out/make/**/*.dmg
+          app/out/make/**/*.zip
+          app/out/make/**/*.deb
+          app/out/make/**/*.rpm
+        if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ name: release
 # Builds platform-specific Orbit installers and attaches them to a draft
 # GitHub Release (promote the draft manually), and publishes the @galaxyproject/loom
 # npm package via OIDC trusted publishing (no token, no 2FA prompt).
+#
+# Critical-path split: `build` covers the platforms whose runner fleets
+# schedule reliably (arm64 mac + linux) and is the only thing `publish` waits
+# on, so the draft Release is never held hostage to runner availability. The
+# Intel mac build runs off to the side in `build-intel` and is attached after
+# the fact by `publish-intel` -- see those jobs for why.
 
 on:
   push:
@@ -23,6 +29,9 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Required platforms. `publish` needs this job and only this job, so the
+  # release blocks solely on fleets we trust to schedule quickly. Intel mac is
+  # deliberately not here -- see build-intel.
   build:
     strategy:
       fail-fast: false
@@ -32,11 +41,6 @@ jobs:
           - os: macos-latest
             arch: arm64
             platform: darwin
-          # Intel macs (macos-13) are intentionally omitted: GitHub's x64 mac
-          # fleet is so starved that the job sat queued for 19h on the alpha.1
-          # cut and never picked up a runner, wedging the whole release behind
-          # it. Apple Silicon is the overwhelming majority of the target
-          # audience; re-add a macos-13 entry here if Intel demand justifies it.
           # Linux x64 — produces .deb, .rpm, and .zip. Works natively on
           # Linux and inside WSL2 (with WSLg) on Windows 11.
           - os: ubuntu-latest
@@ -58,6 +62,36 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           arch: ${{ matrix.arch }}
+          macos-certificate-base64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
+          macos-certificate-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          apple-signing-identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          apple-api-key-base64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          apple-api-key-id: ${{ secrets.APPLE_API_KEY_ID }}
+          apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
+
+  # Best-effort Intel (x64) mac build, deliberately OUT of publish's `needs`
+  # graph. GitHub's Intel mac fleet is small and shared across the whole org,
+  # so this can sit queued a long time -- on the alpha.1 cut the old macos-13
+  # job sat ~19h before GitHub queue-cancelled it. A queued job blocks `needs`
+  # until it reaches a terminal state, so if publish depended on this a busy-org
+  # day would stall the whole release. Instead it runs alongside `build`;
+  # publish-intel attaches the installer to the already-created draft if/when it
+  # lands, and nothing ever waits on it.
+  #
+  # macos-26-intel is the newest standard Intel runner (free for public repos).
+  # GitHub keeps only the latest two macOS versions: macos-13 already retired,
+  # and macos-15-intel will follow when macOS 27 lands -- macos-26 is also
+  # expected to be the last Intel-capable macOS, so this is the longest-lived
+  # Intel label there'll be. Bump as newer -intel labels appear.
+  build-intel:
+    runs-on: macos-26-intel
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/make-orbit
+        with:
+          platform: darwin
+          arch: x64
           macos-certificate-base64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
           macos-certificate-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
           apple-signing-identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
@@ -94,6 +128,35 @@ jobs:
             artifacts/**/*.deb
             artifacts/**/*.rpm
           fail_on_unmatched_files: true
+
+  # Attach the best-effort Intel installer to the draft once it exists. needs
+  # `publish` (so the draft is already created -- this never blocks it) and
+  # `build-intel` (the artifact). If build-intel failed or got queue-cancelled
+  # after 24h, `needs` isn't satisfied and this job is simply skipped -- the
+  # release ships with arm64 + linux and no Intel build, rather than waiting.
+  # Uses `gh release upload`, which adds assets without touching the release's
+  # draft/prerelease/notes state; --clobber makes a re-run idempotent.
+  publish-intel:
+    needs: [build-intel, publish]
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Orbit-darwin-x64
+          path: artifacts
+
+      - name: Attach Intel build to draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mapfile -t files < <(find artifacts -type f \( -name '*.dmg' -o -name '*.zip' \))
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No Intel installer found to attach" >&2
+            exit 1
+          fi
+          printf 'Attaching: %s\n' "${files[@]}"
+          gh release upload "${{ github.ref_name }}" "${files[@]}" --clobber
 
   # Publish the @galaxyproject/loom npm package (the Loom CLI -- not Orbit) via
   # OIDC trusted publishing. No NPM_TOKEN and no 2FA OTP: GitHub mints a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,90 +43,27 @@ jobs:
             arch: x64
             platform: linux
     runs-on: ${{ matrix.os }}
-    # macOS signing/notarization secrets surfaced as env so steps can gate on
-    # their presence (`env.X != ''`). When they're all empty -- e.g. before the
-    # secrets are added, or on a fork -- the build simply runs unsigned, exactly
-    # as it does today. Populate these in repo Settings -> Secrets to turn on
-    # Developer ID signing + notarization. See docs/macos-codesigning.md.
-    env:
-      MACOS_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
-      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-      APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY_BASE64 }}
-      APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Assert version lockstep
         run: node scripts/check-version-lockstep.mjs
 
-      - name: Install Linux packaging deps
-        if: matrix.platform == 'linux'
-        run: sudo apt-get update -qq && sudo apt-get install -y fakeroot rpm
-
-      - uses: actions/setup-node@v4
+      # Build, sign, notarize, package, and upload live in the make-orbit
+      # composite action so the security-sensitive macOS codesigning setup has
+      # exactly one copy. Apple secrets are passed in; when empty -- on a fork,
+      # or before they're configured -- the build runs unsigned, exactly as
+      # before. See docs/macos-codesigning.md.
+      - uses: ./.github/actions/make-orbit
         with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            app/package-lock.json
-
-      - name: Install root deps
-        run: npm ci
-
-      - name: Install app deps
-        working-directory: app
-        run: npm ci
-
-      # Imports the Developer ID Application cert into a throwaway keychain so
-      # codesign (via electron-forge's osxSign) can find the identity. Skipped
-      # entirely when the cert secret isn't set -> unsigned build.
-      - name: Import Apple signing certificate
-        if: matrix.platform == 'darwin' && env.MACOS_CERTIFICATE_BASE64 != ''
-        run: |
-          CERT_PATH="$RUNNER_TEMP/developer-id.p12"
-          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
-          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
-          echo "$MACOS_CERTIFICATE_BASE64" | base64 --decode > "$CERT_PATH"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security import "$CERT_PATH" -P "$MACOS_CERTIFICATE_PASSWORD" \
-            -t cert -f pkcs12 -k "$KEYCHAIN_PATH" \
-            -T /usr/bin/codesign -T /usr/bin/security
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
-          # Prepend our keychain to the user search list so codesign sees it.
-          security list-keychains -d user -s "$KEYCHAIN_PATH" \
-            $(security list-keychains -d user | sed 's/"//g')
-          rm -f "$CERT_PATH"
-
-      # Decodes the App Store Connect API key (.p8) to a file and exports its
-      # path; forge.config.ts reads APPLE_API_KEY_PATH to enable notarization.
-      # Skipped when the key secret isn't set -> signed-but-not-notarized.
-      - name: Stage notarization API key
-        if: matrix.platform == 'darwin' && env.APPLE_API_KEY_BASE64 != ''
-        run: |
-          KEY_PATH="$RUNNER_TEMP/asc-api-key.p8"
-          echo "$APPLE_API_KEY_BASE64" | base64 --decode > "$KEY_PATH"
-          echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
-
-      - name: Make Orbit (${{ matrix.platform }}-${{ matrix.arch }})
-        working-directory: app
-        run: npx electron-forge make --arch=${{ matrix.arch }} --platform=${{ matrix.platform }}
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: Orbit-${{ matrix.platform }}-${{ matrix.arch }}
-          path: |
-            app/out/make/**/*.dmg
-            app/out/make/**/*.zip
-            app/out/make/**/*.deb
-            app/out/make/**/*.rpm
-          if-no-files-found: error
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
+          macos-certificate-base64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
+          macos-certificate-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          apple-signing-identity: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          apple-api-key-base64: ${{ secrets.APPLE_API_KEY_BASE64 }}
+          apple-api-key-id: ${{ secrets.APPLE_API_KEY_ID }}
+          apple-api-issuer: ${{ secrets.APPLE_API_ISSUER }}
 
   # Only attach a draft Release on a real tag (or a dispatch re-run against a
   # tag). A workflow_dispatch on a branch is a build-only test run -- the signed


### PR DESCRIPTION
## What

Re-adds an Intel (x64) macOS build to the release, structured so it can never block a tagged release.

- **Commit 1** extracts the build/sign/package/upload steps into a `make-orbit` composite action. Behavior-preserving -- the arm64 mac and linux matrix legs now call it instead of inlining ~70 lines of setup + macOS codesigning. One copy of the signing setup so the two macOS builds can't drift.
- **Commit 2** adds a best-effort `build-intel` job + `publish-intel`.

## Why

The old matrix put every platform in one `build` job that `publish` depends on. A GitHub job that can't get a runner sits *queued* (not running) for up to 24h before GitHub cancels it, and `needs` waits for it the whole time. GitHub's Intel mac fleet is small and shared org-wide -- on the alpha.1 cut the x64 job sat ~19h and wedged the release. So Intel-in-the-matrix means the draft Release is held hostage to Intel runner availability.

Things that look like they'd fix it but don't, for the record:

- `timeout-minutes` only counts *running* time -- a job that never starts ignores it.
- `continue-on-error` only helps a job that *runs and fails* -- a queued job still blocks `needs` until it terminates.
- `needs` can't depend on a single matrix combination, only a whole job.

So the only real fix is to take Intel out of `publish`'s `needs` graph, which means a separate job.

## How it behaves

- `publish` needs **only** `build` (arm64 + linux) -> the draft Release is cut as soon as those finish.
- `build-intel` runs on `macos-15-intel` alongside, off the critical path.
- `publish-intel` needs `[build-intel, publish]` -> attaches the Intel installer to the already-created draft via `gh release upload --clobber` (which adds assets without touching the release's draft/prerelease/notes state). If `build-intel` stalls, fails, or gets queue-cancelled, it's skipped and the release ships arm64 + linux without Intel.

`macos-15-intel` because GitHub retired `macos-13` (they keep only the latest two macOS versions).

## Validation

- `actionlint` clean; YAML validated; composite-action inputs cross-checked against the workflow.
- The composite refactor sits on the critical path (arm64 + linux route through it), so it's worth a build-only `workflow_dispatch` before merge to confirm those still build. Note end-to-end runs are currently slow -- the galaxyproject org's Actions capacity is saturated by Galaxy CI.
