### PR TITLE
Keep tool detail in the feedback activity tail

### DIFF
--- a/app/src/main/files-handler.ts
+++ b/app/src/main/files-handler.ts
@@ -269,6 +269,14 @@ export function registerFilesIpc(getCwd: () => string): void {
       if (!stat.isFile()) return { ok: false, error: "Not a regular file" };
 
       // Tail preview requested: bypass full read and read from the end.
+      //
+      // Known beta limitation: a single physical line longer than the budget
+      // (activity.jsonl persists uncapped user-prompt text and tool args -- only
+      // result summaries are capped at the source) can't be recovered whole. When
+      // the newest line exceeds the budget we drop it as a partial first line, so
+      // that event is omitted from the preview rather than shipped truncated. The
+      // feedback tail degrades gracefully (missing event, never corrupt bytes); a
+      // real fix is a source-side cap in activity-hooks, tracked separately.
       if (opts?.tail) {
         const readSize = Math.min(stat.size, PREVIEW_BYTE_BUDGET);
         const offset = stat.size - readSize;
@@ -278,18 +286,22 @@ export function registerFilesIpc(getCwd: () => string): void {
           const { bytesRead } = await fd.read(tailBuf, 0, readSize, offset);
           const tail = tailBuf.subarray(0, bytesRead).toString("utf-8");
           const lines = tail.split("\n");
+          // A non-zero offset means we started mid-file, so the first element is a
+          // partial line (or a multibyte boundary fragment) -- drop it.
           if (offset > 0 && lines.length > 1) {
             lines.shift();
           }
-          const previewText = lines.slice(-200).join("\n");
+          const kept = lines.slice(-200);
+          const previewText = kept.join("\n");
           return {
             ok: true,
             size: stat.size,
             bytes: Buffer.from(previewText, "utf-8"),
             preview: {
               kind: "tail" as const,
-              lineCount: lines.length,
-              byteBudgetHit: readSize === PREVIEW_BYTE_BUDGET,
+              // Describe the bytes actually returned, not the raw window.
+              lineCount: kept.length,
+              byteBudgetHit: stat.size > PREVIEW_BYTE_BUDGET,
             },
           };
         } finally {

--- a/app/src/main/files-handler.ts
+++ b/app/src/main/files-handler.ts
@@ -261,12 +261,41 @@ export function registerFilesIpc(getCwd: () => string): void {
     }
   });
 
-  ipcMain.handle("files:read", async (_e, relPath: string) => {
+  ipcMain.handle("files:read", async (_e, relPath: string, opts?: { tail?: boolean }) => {
     const cwd = getCwd();
     try {
       const abs = resolveWithin(cwd, relPath);
       const stat = await fsp.stat(abs);
       if (!stat.isFile()) return { ok: false, error: "Not a regular file" };
+
+      // Tail preview requested: bypass full read and read from the end.
+      if (opts?.tail) {
+        const readSize = Math.min(stat.size, PREVIEW_BYTE_BUDGET);
+        const offset = stat.size - readSize;
+        const fd = await fsp.open(abs, "r");
+        try {
+          const tailBuf = Buffer.alloc(readSize);
+          const { bytesRead } = await fd.read(tailBuf, 0, readSize, offset);
+          const tail = tailBuf.subarray(0, bytesRead).toString("utf-8");
+          const lines = tail.split("\n");
+          if (offset > 0 && lines.length > 1) {
+            lines.shift();
+          }
+          const previewText = lines.slice(-200).join("\n");
+          return {
+            ok: true,
+            size: stat.size,
+            bytes: Buffer.from(previewText, "utf-8"),
+            preview: {
+              kind: "tail" as const,
+              lineCount: lines.length,
+              byteBudgetHit: readSize === PREVIEW_BYTE_BUDGET,
+            },
+          };
+        } finally {
+          await fd.close();
+        }
+      }
 
       // Full read up to MAX_READ_BYTES.
       if (stat.size <= MAX_READ_BYTES) {

--- a/app/src/main/files-handler.ts
+++ b/app/src/main/files-handler.ts
@@ -291,18 +291,12 @@ export function registerFilesIpc(getCwd: () => string): void {
           if (offset > 0 && lines.length > 1) {
             lines.shift();
           }
-          const kept = lines.slice(-200);
-          const previewText = kept.join("\n");
           return {
             ok: true,
             size: stat.size,
-            bytes: Buffer.from(previewText, "utf-8"),
-            preview: {
-              kind: "tail" as const,
-              // Describe the bytes actually returned, not the raw window.
-              lineCount: kept.length,
-              byteBudgetHit: stat.size > PREVIEW_BYTE_BUDGET,
-            },
+            // No preview metadata on the tail path: the only caller (the feedback
+            // payload builder) reads bytes + size and ignores it.
+            bytes: Buffer.from(lines.slice(-200).join("\n"), "utf-8"),
           };
         } finally {
           await fd.close();

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -57,13 +57,18 @@ export interface OrbitAPI {
   listFiles(opts?: {
     includeHidden?: boolean;
   }): Promise<{ ok: true; root: FileNode; cwd: string } | { ok: false; error: string }>;
-  readFile(relPath: string): Promise<
+  readFile(
+    relPath: string,
+    opts?: { tail?: boolean },
+  ): Promise<
     | {
         ok: true;
         size: number;
         bytes: Uint8Array;
-        // Set when bytes is a head-only excerpt of a file too large for full read.
-        preview?: { kind: "head"; lineCount: number; byteBudgetHit: boolean };
+        // Set when bytes is a head- or tail-only excerpt of a file too large for full read.
+        preview?:
+          | { kind: "head"; lineCount: number; byteBudgetHit: boolean }
+          | { kind: "tail"; lineCount: number; byteBudgetHit: boolean };
       }
     | { ok: false; error: string; size?: number }
   >;
@@ -162,7 +167,7 @@ const api: OrbitAPI = {
   getCwd: () => ipcRenderer.invoke("agent:get-cwd"),
   openFile: (filePath) => ipcRenderer.invoke("file:open", filePath),
   listFiles: (opts) => ipcRenderer.invoke("files:list", opts),
-  readFile: (relPath) => ipcRenderer.invoke("files:read", relPath),
+  readFile: (relPath, opts) => ipcRenderer.invoke("files:read", relPath, opts),
   writeFile: (relPath, content) => ipcRenderer.invoke("files:write", relPath, content),
   onFilesChanged: (callback) => {
     const handler = () => callback();

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -65,10 +65,8 @@ export interface OrbitAPI {
         ok: true;
         size: number;
         bytes: Uint8Array;
-        // Set when bytes is a head- or tail-only excerpt of a file too large for full read.
-        preview?:
-          | { kind: "head"; lineCount: number; byteBudgetHit: boolean }
-          | { kind: "tail"; lineCount: number; byteBudgetHit: boolean };
+        // Set when bytes is a head-only excerpt of a file too large for full read.
+        preview?: { kind: "head"; lineCount: number; byteBudgetHit: boolean };
       }
     | { ok: false; error: string; size?: number }
   >;

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -8,7 +8,11 @@ import { refreshGalaxyInvocations } from "./galaxy-invocations.js";
 import { PromptQueue, queuedPreview } from "./prompt-queue.js";
 import { LoomWidgetKey, decodeMarkdownWidget } from "../../../shared/loom-shell-contract.js";
 import { ALLOWED_SKILLS_PREFIX, isAllowedSkillUrl } from "../../../shared/loom-config.js";
-import { SCHEMA_VERSION, formatActivityTail, capFeedbackPayload } from "../../../shared/feedback-contract.js";
+import {
+  SCHEMA_VERSION,
+  formatActivityTail,
+  capFeedbackPayload,
+} from "../../../shared/feedback-contract.js";
 import type { FeedbackPayload, FeedbackSysinfo } from "../../../shared/feedback-contract.js";
 
 declare global {
@@ -72,7 +76,14 @@ async function openFileFromTree(relPath: string): Promise<void> {
     chat.addErrorMessage(`Failed to open ${relPath}${sizeHint}: ${res.error}`);
     return;
   }
-  const proceed = fileViewer.open(relPath, res.bytes, res.size, res.preview);
+  // The viewer only renders head excerpts; a tail preview is a feedback-only
+  // concept and never reaches this path, so drop it defensively.
+  const proceed = fileViewer.open(
+    relPath,
+    res.bytes,
+    res.size,
+    res.preview?.kind === "head" ? res.preview : undefined,
+  );
   if (proceed) {
     artifacts.showFileTab();
     setArtifactCollapsed(false);
@@ -3343,7 +3354,7 @@ async function buildFeedbackPayload(): Promise<FeedbackPayload> {
 
   if (reportIncludeLogs.checked) {
     try {
-      const res = await window.orbit.readFile("activity.jsonl");
+      const res = await window.orbit.readFile("activity.jsonl", { tail: true });
       if (res.ok) {
         const text = new TextDecoder("utf-8").decode(res.bytes);
         const events = text
@@ -3359,7 +3370,12 @@ async function buildFeedbackPayload(): Promise<FeedbackPayload> {
                 payload?: Record<string, unknown>;
               };
             } catch {
-              return { timestamp: "?", kind: "?", source: "", payload: { text: line.slice(0, 80) } };
+              return {
+                timestamp: "?",
+                kind: "?",
+                source: "",
+                payload: { text: line.slice(0, 80) },
+              };
             }
           });
         activityTail = formatActivityTail(events);

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -8,7 +8,7 @@ import { refreshGalaxyInvocations } from "./galaxy-invocations.js";
 import { PromptQueue, queuedPreview } from "./prompt-queue.js";
 import { LoomWidgetKey, decodeMarkdownWidget } from "../../../shared/loom-shell-contract.js";
 import { ALLOWED_SKILLS_PREFIX, isAllowedSkillUrl } from "../../../shared/loom-config.js";
-import { SCHEMA_VERSION } from "../../../shared/feedback-contract.js";
+import { SCHEMA_VERSION, formatActivityTail, capFeedbackPayload } from "../../../shared/feedback-contract.js";
 import type { FeedbackPayload, FeedbackSysinfo } from "../../../shared/feedback-contract.js";
 
 declare global {
@@ -3307,9 +3307,9 @@ function capForGithubUrl(body: string): string {
 }
 
 // Assemble the structured feedback payload POSTed to the capture worker. Honors
-// the two opt-in checkboxes; never includes cwd, API keys, or raw activity
-// payloads (sysinfo strips cwd; the activity tail is summarized to one line per
-// event).
+// the two opt-in checkboxes; never includes cwd or raw credentials (sysinfo
+// strips cwd; the activity tail renders one line per event with already-redacted
+// args and a truncated result).
 async function buildFeedbackPayload(): Promise<FeedbackPayload> {
   const title = reportTitle.value.trim();
   const body = reportBody.value.trim();
@@ -3346,28 +3346,32 @@ async function buildFeedbackPayload(): Promise<FeedbackPayload> {
       const res = await window.orbit.readFile("activity.jsonl");
       if (res.ok) {
         const text = new TextDecoder("utf-8").decode(res.bytes);
-        activityTail = text
+        const events = text
           .split("\n")
           .filter(Boolean)
-          .slice(-15)
+          .slice(-60)
           .map((line) => {
             try {
-              const e = JSON.parse(line) as { timestamp?: string; kind?: string; source?: string };
-              return `${e.timestamp ?? "?"} ${e.kind ?? "?"}${e.source ? " (" + e.source + ")" : ""}`;
+              return JSON.parse(line) as {
+                timestamp: string;
+                kind: string;
+                source: string;
+                payload?: Record<string, unknown>;
+              };
             } catch {
-              return line.slice(0, 80);
+              return { timestamp: "?", kind: "?", source: "", payload: { text: line.slice(0, 80) } };
             }
-          })
-          .join("\n");
+          });
+        activityTail = formatActivityTail(events);
       }
     } catch {
       /* file missing or unreadable -- skip */
     }
-    const t = shell.tail(80);
+    const t = shell.tail(200);
     if (t.trim()) shellTail = t;
   }
 
-  return {
+  return capFeedbackPayload({
     schemaVersion: SCHEMA_VERSION,
     source: "orbit",
     title,
@@ -3376,7 +3380,7 @@ async function buildFeedbackPayload(): Promise<FeedbackPayload> {
     activityTail,
     shellTail,
     clientTs: new Date().toISOString(),
-  };
+  });
 }
 
 reportBtn.addEventListener("click", openReportModal);

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -76,14 +76,7 @@ async function openFileFromTree(relPath: string): Promise<void> {
     chat.addErrorMessage(`Failed to open ${relPath}${sizeHint}: ${res.error}`);
     return;
   }
-  // The viewer only renders head excerpts; a tail preview is a feedback-only
-  // concept and never reaches this path, so drop it defensively.
-  const proceed = fileViewer.open(
-    relPath,
-    res.bytes,
-    res.size,
-    res.preview?.kind === "head" ? res.preview : undefined,
-  );
+  const proceed = fileViewer.open(relPath, res.bytes, res.size, res.preview);
   if (proceed) {
     artifacts.showFileTab();
     setArtifactCollapsed(false);

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -791,9 +791,10 @@
               name (no API key), Galaxy connection state (no credentials).
             </p>
             <p>
-              <b>Logs:</b> last 15 events of <code>activity.jsonl</code> (summarized to one line
-              each, no raw payloads) and the last ~80 lines of the in-app shell stream. These can
-              include filenames, tool arguments, and command output.
+              <b>Logs:</b> last 60 events of <code>activity.jsonl</code> (one line each: tool name,
+              arguments, and a truncated result -- credentials and API keys redacted) and the last
+              ~200 lines of the in-app shell stream. These can include filenames, tool arguments,
+              and command output.
             </p>
             <p>
               Both are on by default for the beta so we get useful diagnostics. Feedback goes to

--- a/extensions/loom/feedback-command.ts
+++ b/extensions/loom/feedback-command.ts
@@ -1,13 +1,12 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import {
-  submitFeedback,
-  buildBrainSysinfo,
-  appendToOutbox,
-  readLoomVersion,
-} from "./feedback.js";
+import { submitFeedback, buildBrainSysinfo, appendToOutbox, readLoomVersion } from "./feedback.js";
 import { getRecentActivityEvents } from "./activity.js";
 import { loadConfig } from "./config.js";
-import { SCHEMA_VERSION, formatActivityTail, capFeedbackPayload } from "../../shared/feedback-contract.js";
+import {
+  SCHEMA_VERSION,
+  formatActivityTail,
+  capFeedbackPayload,
+} from "../../shared/feedback-contract.js";
 import type { FeedbackPayload } from "../../shared/feedback-contract.js";
 
 /**

--- a/extensions/loom/feedback-command.ts
+++ b/extensions/loom/feedback-command.ts
@@ -2,13 +2,12 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import {
   submitFeedback,
   buildBrainSysinfo,
-  summarizeActivityTail,
   appendToOutbox,
   readLoomVersion,
 } from "./feedback.js";
 import { getRecentActivityEvents } from "./activity.js";
 import { loadConfig } from "./config.js";
-import { SCHEMA_VERSION } from "../../shared/feedback-contract.js";
+import { SCHEMA_VERSION, formatActivityTail, capFeedbackPayload } from "../../shared/feedback-contract.js";
 import type { FeedbackPayload } from "../../shared/feedback-contract.js";
 
 /**
@@ -38,7 +37,7 @@ export function registerFeedbackCommand(pi: ExtensionAPI): void {
 
       const includeDiagnostics = await ctx.ui.confirm(
         "Include diagnostics?",
-        "Attach system info + a one-line-per-event activity summary (no command output or arguments), sent to the Loom team's private feedback store. No API keys or credentials are sent.",
+        "Attach system info + a summary of recent activity (tool names, arguments, and truncated results), sent to the Loom team's private feedback store. Credentials and API keys are redacted.",
       );
 
       // Opaque tester code (config, env override) -- non-secret; lets the team
@@ -57,18 +56,19 @@ export function registerFeedbackCommand(pi: ExtensionAPI): void {
         ...(includeDiagnostics
           ? {
               sysinfo: buildBrainSysinfo(),
-              activityTail: summarizeActivityTail(getRecentActivityEvents(15)),
+              activityTail: formatActivityTail(getRecentActivityEvents(60)),
             }
           : { sysinfo: { appVersion: readLoomVersion() } }),
       };
 
-      const res = await submitFeedback(payload);
+      const capped = capFeedbackPayload(payload);
+      const res = await submitFeedback(capped);
       if (res.ok) {
         ctx.ui.notify("Thanks -- your feedback was sent.", "info");
         return;
       }
       // Durability: never lose the user's note if the store is unreachable.
-      const saved = appendToOutbox(payload);
+      const saved = appendToOutbox(capped);
       ctx.ui.notify(
         saved
           ? `Couldn't reach the feedback service (${res.error ?? "unknown error"}) -- saved locally, we'll pick it up later.`

--- a/extensions/loom/feedback.ts
+++ b/extensions/loom/feedback.ts
@@ -5,7 +5,6 @@ import {
   SCHEMA_VERSION,
 } from "../../shared/feedback-contract.js";
 import type { FeedbackPayload, FeedbackSysinfo } from "../../shared/feedback-contract.js";
-import type { ActivityEvent } from "./activity.js";
 import { loadConfig, getConfigDir } from "./config.js";
 import { loadProfiles } from "./profiles.js";
 import { appendFileSync, readFileSync } from "fs";
@@ -39,16 +38,6 @@ export function readLoomVersion(): string | undefined {
   } catch {
     return undefined;
   }
-}
-
-/**
- * Summarize an activity tail to `timestamp kind (source)` lines only. Never ship
- * raw event payloads -- they carry tool I/O (paths, prompts, dataset names).
- */
-export function summarizeActivityTail(events: ActivityEvent[]): string {
-  return events
-    .map((e) => `${e.timestamp} ${e.kind}${e.source ? " (" + e.source + ")" : ""}`)
-    .join("\n");
 }
 
 /** Brain-side sysinfo. No Electron here (the brain is a Node child), no secrets. */

--- a/shared/feedback-contract.d.ts
+++ b/shared/feedback-contract.d.ts
@@ -33,3 +33,15 @@ export interface FeedbackPayload {
 }
 
 export declare function validateFeedbackPayload(obj: unknown): obj is FeedbackPayload;
+
+export interface FeedbackActivityEvent {
+  timestamp: string;
+  kind: string;
+  source: string;
+  payload?: Record<string, unknown>;
+}
+
+export declare function formatActivityTail(
+  events: FeedbackActivityEvent[],
+  opts?: { maxBytes?: number },
+): string;

--- a/shared/feedback-contract.d.ts
+++ b/shared/feedback-contract.d.ts
@@ -45,3 +45,8 @@ export declare function formatActivityTail(
   events: FeedbackActivityEvent[],
   opts?: { maxBytes?: number },
 ): string;
+
+export declare function capFeedbackPayload(
+  payload: FeedbackPayload,
+  opts?: { maxTotalBytes?: number },
+): FeedbackPayload;

--- a/shared/feedback-contract.js
+++ b/shared/feedback-contract.js
@@ -26,3 +26,78 @@ export function validateFeedbackPayload(obj) {
   if (p.testerId !== undefined && typeof p.testerId !== "string") return false;
   return true;
 }
+
+const ACTIVITY_TAIL_MAX_BYTES = 64 * 1024;
+// Per-field character limits (not bytes) for readability; the wire byte budget
+// is enforced separately by trimLinesToBytes.
+const ARGS_MAX = 200;
+const RESULT_MAX = 500;
+const PROMPT_MAX = 200;
+
+const textEncoder = new TextEncoder();
+
+function byteLen(s) {
+  return textEncoder.encode(s).length;
+}
+
+function truncate(s, n) {
+  return s.length <= n ? s : s.slice(0, n) + "…";
+}
+
+function compactArgs(args) {
+  if (args == null) return "";
+  let s;
+  try {
+    s = JSON.stringify(args);
+  } catch {
+    s = String(args);
+  }
+  return s ? "args=" + truncate(s, ARGS_MAX) : "";
+}
+
+// One line per event. Renders the already-redacted/truncated payload fields the
+// upstream activity hooks produced -- this function adds no redaction of its own.
+function formatActivityEvent(e) {
+  const ts = e && e.timestamp ? e.timestamp : "?";
+  const p = (e && e.payload) || {};
+  switch (e && e.kind) {
+    case "user.prompt":
+      return `${ts} user.prompt ${truncate(String(p.text ?? ""), PROMPT_MAX)}`.trimEnd();
+    case "tool.start":
+      return `${ts} tool.start ${p.toolName ?? "?"} ${compactArgs(p.args)}`.trimEnd();
+    case "tool.end": {
+      const flag = p.isError ? "✗" : "✓";
+      return `${ts} tool.end ${p.toolName ?? "?"} ${flag} ${truncate(String(p.resultSummary ?? ""), RESULT_MAX)}`.trimEnd();
+    }
+    default:
+      return `${ts} ${(e && e.kind) ?? "?"}${e && e.source ? " (" + e.source + ")" : ""}`;
+  }
+}
+
+// Drop oldest (leading) lines until the text fits maxBytes; hard-slice a lone
+// over-budget line as a floor.
+function trimLinesToBytes(text, maxBytes) {
+  if (byteLen(text) <= maxBytes) return text;
+  const lines = text.split("\n");
+  while (lines.length > 1 && byteLen(lines.join("\n")) > maxBytes) {
+    lines.shift();
+  }
+  let out = lines.join("\n");
+  if (byteLen(out) > maxBytes) {
+    // Floor for a lone over-budget line: accumulate whole codepoints up to the
+    // budget so we never split a multibyte char or overshoot maxBytes.
+    let acc = "";
+    for (const ch of out) {
+      if (byteLen(acc + ch) > maxBytes) break;
+      acc += ch;
+    }
+    out = acc;
+  }
+  return out;
+}
+
+export function formatActivityTail(events, opts = {}) {
+  const maxBytes = opts.maxBytes ?? ACTIVITY_TAIL_MAX_BYTES;
+  const text = (events || []).map(formatActivityEvent).join("\n");
+  return trimLinesToBytes(text, maxBytes);
+}

--- a/shared/feedback-contract.js
+++ b/shared/feedback-contract.js
@@ -123,15 +123,17 @@ export function formatActivityTail(events, opts = {}) {
 const FEEDBACK_MAX_TOTAL_BYTES = 200 * 1024;
 
 // Final guard so an assembled payload never bounces off the worker's 256 KB cap.
-// Trims activityTail first, then shellTail, leaving the user's title/body intact.
+// Trim activityTail before shellTail -- the shell tail is closest to what the user
+// actually saw, so it's the last diagnostic we shed. Title/body always stay intact.
 export function capFeedbackPayload(payload, opts = {}) {
   const maxTotalBytes = opts.maxTotalBytes ?? FEEDBACK_MAX_TOTAL_BYTES;
   const totalBytes = (p) => byteLen(JSON.stringify(p));
   let p = { ...payload };
   for (const field of ["activityTail", "shellTail"]) {
-    if (totalBytes(p) <= maxTotalBytes) break;
+    const total = totalBytes(p);
+    if (total <= maxTotalBytes) break;
     if (typeof p[field] !== "string" || p[field].length === 0) continue;
-    const over = totalBytes(p) - maxTotalBytes;
+    const over = total - maxTotalBytes;
     const target = Math.max(0, byteLen(p[field]) - over);
     p = { ...p, [field]: trimLinesToBytes(p[field], target) };
   }

--- a/shared/feedback-contract.js
+++ b/shared/feedback-contract.js
@@ -101,3 +101,21 @@ export function formatActivityTail(events, opts = {}) {
   const text = (events || []).map(formatActivityEvent).join("\n");
   return trimLinesToBytes(text, maxBytes);
 }
+
+const FEEDBACK_MAX_TOTAL_BYTES = 200 * 1024;
+
+// Final guard so an assembled payload never bounces off the worker's 256 KB cap.
+// Trims activityTail first, then shellTail, leaving the user's title/body intact.
+export function capFeedbackPayload(payload, opts = {}) {
+  const maxTotalBytes = opts.maxTotalBytes ?? FEEDBACK_MAX_TOTAL_BYTES;
+  const totalBytes = (p) => byteLen(JSON.stringify(p));
+  let p = { ...payload };
+  for (const field of ["activityTail", "shellTail"]) {
+    if (totalBytes(p) <= maxTotalBytes) break;
+    if (typeof p[field] !== "string" || p[field].length === 0) continue;
+    const over = totalBytes(p) - maxTotalBytes;
+    const target = Math.max(0, byteLen(p[field]) - over);
+    p = { ...p, [field]: trimLinesToBytes(p[field], target) };
+  }
+  return p;
+}

--- a/shared/feedback-contract.js
+++ b/shared/feedback-contract.js
@@ -57,21 +57,30 @@ function compactArgs(args) {
 
 // One line per event. Renders the already-redacted/truncated payload fields the
 // upstream activity hooks produced -- this function adds no redaction of its own.
+// Embedded line breaks (LF, CRLF, or bare CR from progress-style output) are
+// flattened to spaces so each event stays exactly one line, which keeps the
+// byte-budget trimmer from orphaning a fragment of a multi-line event.
 function formatActivityEvent(e) {
   const ts = e && e.timestamp ? e.timestamp : "?";
   const p = (e && e.payload) || {};
+  let rawLine;
   switch (e && e.kind) {
     case "user.prompt":
-      return `${ts} user.prompt ${truncate(String(p.text ?? ""), PROMPT_MAX)}`.trimEnd();
+      rawLine = `${ts} user.prompt ${truncate(String(p.text ?? ""), PROMPT_MAX)}`;
+      break;
     case "tool.start":
-      return `${ts} tool.start ${p.toolName ?? "?"} ${compactArgs(p.args)}`.trimEnd();
+      rawLine = `${ts} tool.start ${p.toolName ?? "?"} ${compactArgs(p.args)}`;
+      break;
     case "tool.end": {
       const flag = p.isError ? "✗" : "✓";
-      return `${ts} tool.end ${p.toolName ?? "?"} ${flag} ${truncate(String(p.resultSummary ?? ""), RESULT_MAX)}`.trimEnd();
+      rawLine = `${ts} tool.end ${p.toolName ?? "?"} ${flag} ${truncate(String(p.resultSummary ?? ""), RESULT_MAX)}`;
+      break;
     }
     default:
-      return `${ts} ${(e && e.kind) ?? "?"}${e && e.source ? " (" + e.source + ")" : ""}`;
+      rawLine = `${ts} ${(e && e.kind) ?? "?"}${e && e.source ? " (" + e.source + ")" : ""}`;
+      break;
   }
+  return rawLine.trimEnd().replace(/[\r\n]+/g, " ");
 }
 
 // Drop oldest (leading) lines until the text fits maxBytes; hard-slice a lone
@@ -84,14 +93,23 @@ function trimLinesToBytes(text, maxBytes) {
   }
   let out = lines.join("\n");
   if (byteLen(out) > maxBytes) {
-    // Floor for a lone over-budget line: accumulate whole codepoints up to the
-    // budget so we never split a multibyte char or overshoot maxBytes.
-    let acc = "";
-    for (const ch of out) {
-      if (byteLen(acc + ch) > maxBytes) break;
-      acc += ch;
+    // Binary search for the maximum prefix of 'out' that fits in maxBytes
+    // using character offsets to avoid splitting Unicode surrogate pairs.
+    const arr = Array.from(out);
+    let low = 0;
+    let high = arr.length;
+    let best = "";
+    while (low <= high) {
+      const mid = Math.floor((low + high) / 2);
+      const candidate = arr.slice(0, mid).join("");
+      if (byteLen(candidate) <= maxBytes) {
+        best = candidate;
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
     }
-    out = acc;
+    out = best;
   }
   return out;
 }

--- a/tests/feedback-command.test.ts
+++ b/tests/feedback-command.test.ts
@@ -5,7 +5,6 @@ const appendToOutbox = vi.fn();
 vi.mock("../extensions/loom/feedback.js", () => ({
   submitFeedback: (...a: unknown[]) => submitFeedback(...a),
   buildBrainSysinfo: () => ({ platform: "darwin" }),
-  summarizeActivityTail: () => "t1 kind (src)",
   appendToOutbox: (...a: unknown[]) => appendToOutbox(...a),
   readLoomVersion: () => "0.0.0-test",
 }));

--- a/tests/feedback-contract.test.ts
+++ b/tests/feedback-contract.test.ts
@@ -5,6 +5,7 @@ import {
   FEEDBACK_ROUTE,
   FEEDBACK_KEY_HEADER,
   formatActivityTail,
+  capFeedbackPayload,
 } from "../shared/feedback-contract.js";
 
 const valid = {
@@ -111,5 +112,23 @@ describe("formatActivityTail", () => {
 
   it("returns an empty string for no events", () => {
     expect(formatActivityTail([])).toBe("");
+  });
+});
+
+describe("capFeedbackPayload", () => {
+  const base = { schemaVersion: 1, source: "orbit", title: "t", body: "b", clientTs: "now" };
+
+  it("returns the payload unchanged when under budget", () => {
+    const p = { ...base, activityTail: "a", shellTail: "s" };
+    expect(capFeedbackPayload(p)).toEqual(p);
+  });
+
+  it("trims activityTail before shellTail and keeps the result under budget", () => {
+    const big = Array.from({ length: 10000 }, (_, i) => `a${i}`).join("\n");
+    const p = { ...base, activityTail: big, shellTail: "keep-me" };
+    const capped = capFeedbackPayload(p, { maxTotalBytes: 8000 });
+    expect(new TextEncoder().encode(JSON.stringify(capped)).length).toBeLessThanOrEqual(8000);
+    expect(capped.shellTail).toBe("keep-me");                 // shell untouched
+    expect(capped.activityTail.length).toBeLessThan(big.length); // activity sacrificed first
   });
 });

--- a/tests/feedback-contract.test.ts
+++ b/tests/feedback-contract.test.ts
@@ -57,10 +57,18 @@ describe("feedback contract", () => {
 describe("formatActivityTail", () => {
   it("renders tool name, redacted args, and result summary with a status flag", () => {
     const out = formatActivityTail([
-      { timestamp: "t1", kind: "tool.start", source: "agent",
-        payload: { toolName: "bash", args: { command: "ls" } } },
-      { timestamp: "t2", kind: "tool.end", source: "agent",
-        payload: { toolName: "bash", isError: false, resultSummary: "ok" } },
+      {
+        timestamp: "t1",
+        kind: "tool.start",
+        source: "agent",
+        payload: { toolName: "bash", args: { command: "ls" } },
+      },
+      {
+        timestamp: "t2",
+        kind: "tool.end",
+        source: "agent",
+        payload: { toolName: "bash", isError: false, resultSummary: "ok" },
+      },
     ]);
     expect(out).toContain("t1 tool.start bash");
     expect(out).toContain('args={"command":"ls"}');
@@ -69,8 +77,16 @@ describe("formatActivityTail", () => {
 
   it("flags errored tools with ✗ and passes the summary through verbatim", () => {
     const out = formatActivityTail([
-      { timestamp: "t", kind: "tool.end", source: "agent",
-        payload: { toolName: "galaxy_invoke_workflow", isError: true, resultSummary: "ERROR: bad adapter" } },
+      {
+        timestamp: "t",
+        kind: "tool.end",
+        source: "agent",
+        payload: {
+          toolName: "galaxy_invoke_workflow",
+          isError: true,
+          resultSummary: "ERROR: bad adapter",
+        },
+      },
     ]);
     expect(out).toBe("t tool.end galaxy_invoke_workflow ✗ ERROR: bad adapter");
   });
@@ -86,12 +102,14 @@ describe("formatActivityTail", () => {
 
   it("trims oldest events to fit the byte budget, keeping the newest", () => {
     const events = Array.from({ length: 200 }, (_, i) => ({
-      timestamp: `t${i}`, kind: "tool.end", source: "agent",
+      timestamp: `t${i}`,
+      kind: "tool.end",
+      source: "agent",
       payload: { toolName: "bash", isError: false, resultSummary: "x".repeat(400) },
     }));
     const out = formatActivityTail(events, { maxBytes: 4096 });
     expect(new TextEncoder().encode(out).length).toBeLessThanOrEqual(4096);
-    expect(out).toContain("t199 ");   // newest kept
+    expect(out).toContain("t199 "); // newest kept
     expect(out.startsWith("t0 ")).toBe(false); // oldest dropped
   });
 
@@ -113,6 +131,60 @@ describe("formatActivityTail", () => {
   it("returns an empty string for no events", () => {
     expect(formatActivityTail([])).toBe("");
   });
+
+  it("flattens embedded newlines so each event stays exactly one line", () => {
+    const out = formatActivityTail([
+      {
+        timestamp: "t1",
+        kind: "user.prompt",
+        source: "user",
+        payload: { text: "first line\nsecond line" },
+      },
+      {
+        timestamp: "t2",
+        kind: "tool.end",
+        source: "agent",
+        payload: {
+          toolName: "bash",
+          isError: true,
+          resultSummary: "Error: boom\nstack frame",
+        },
+      },
+    ]);
+    expect(out).toContain("t1 user.prompt first line second line");
+    expect(out).toContain("t2 tool.end bash ✗ Error: boom stack frame");
+    expect(out.split("\n").length).toBe(2);
+  });
+
+  it("collapses bare carriage returns and CRLF runs, not just LF", () => {
+    const out = formatActivityTail([
+      {
+        timestamp: "t",
+        kind: "user.prompt",
+        source: "user",
+        payload: { text: "downloading\r99%\r\ndone" },
+      },
+    ]);
+    expect(out).toBe("t user.prompt downloading 99% done");
+    expect(out).not.toMatch(/[\r\n]/);
+  });
+
+  it("handles multibyte characters during hard-slicing without splitting unicode code points", () => {
+    const emoji = "🐻❄️🔥🌲";
+    const out = formatActivityTail(
+      [
+        {
+          timestamp: "t",
+          kind: "user.prompt",
+          source: "user",
+          payload: { text: emoji.repeat(50) },
+        },
+      ],
+      { maxBytes: 50 },
+    );
+    expect(new TextEncoder().encode(out).length).toBeLessThanOrEqual(50);
+    expect(out.endsWith("\uFFFD")).toBe(false);
+  });
 });
 
 describe("capFeedbackPayload", () => {
@@ -128,7 +200,7 @@ describe("capFeedbackPayload", () => {
     const p = { ...base, activityTail: big, shellTail: "keep-me" };
     const capped = capFeedbackPayload(p, { maxTotalBytes: 8000 });
     expect(new TextEncoder().encode(JSON.stringify(capped)).length).toBeLessThanOrEqual(8000);
-    expect(capped.shellTail).toBe("keep-me");                 // shell untouched
+    expect(capped.shellTail).toBe("keep-me"); // shell untouched
     expect(capped.activityTail.length).toBeLessThan(big.length); // activity sacrificed first
   });
 });

--- a/tests/feedback-contract.test.ts
+++ b/tests/feedback-contract.test.ts
@@ -4,6 +4,7 @@ import {
   SCHEMA_VERSION,
   FEEDBACK_ROUTE,
   FEEDBACK_KEY_HEADER,
+  formatActivityTail,
 } from "../shared/feedback-contract.js";
 
 const valid = {
@@ -49,5 +50,66 @@ describe("feedback contract", () => {
   it("accepts an optional string testerId and rejects a non-string one", () => {
     expect(validateFeedbackPayload({ ...valid, testerId: "orbit-007" })).toBe(true);
     expect(validateFeedbackPayload({ ...valid, testerId: 7 })).toBe(false);
+  });
+});
+
+describe("formatActivityTail", () => {
+  it("renders tool name, redacted args, and result summary with a status flag", () => {
+    const out = formatActivityTail([
+      { timestamp: "t1", kind: "tool.start", source: "agent",
+        payload: { toolName: "bash", args: { command: "ls" } } },
+      { timestamp: "t2", kind: "tool.end", source: "agent",
+        payload: { toolName: "bash", isError: false, resultSummary: "ok" } },
+    ]);
+    expect(out).toContain("t1 tool.start bash");
+    expect(out).toContain('args={"command":"ls"}');
+    expect(out).toContain("t2 tool.end bash ✓ ok");
+  });
+
+  it("flags errored tools with ✗ and passes the summary through verbatim", () => {
+    const out = formatActivityTail([
+      { timestamp: "t", kind: "tool.end", source: "agent",
+        payload: { toolName: "galaxy_invoke_workflow", isError: true, resultSummary: "ERROR: bad adapter" } },
+    ]);
+    expect(out).toBe("t tool.end galaxy_invoke_workflow ✗ ERROR: bad adapter");
+  });
+
+  it("renders user prompts and falls back to kind+source for unknown kinds", () => {
+    const out = formatActivityTail([
+      { timestamp: "t1", kind: "user.prompt", source: "user", payload: { text: "hello there" } },
+      { timestamp: "t2", kind: "guard.decision", source: "exec-guard", payload: {} },
+    ]);
+    expect(out).toContain("t1 user.prompt hello there");
+    expect(out).toContain("t2 guard.decision (exec-guard)");
+  });
+
+  it("trims oldest events to fit the byte budget, keeping the newest", () => {
+    const events = Array.from({ length: 200 }, (_, i) => ({
+      timestamp: `t${i}`, kind: "tool.end", source: "agent",
+      payload: { toolName: "bash", isError: false, resultSummary: "x".repeat(400) },
+    }));
+    const out = formatActivityTail(events, { maxBytes: 4096 });
+    expect(new TextEncoder().encode(out).length).toBeLessThanOrEqual(4096);
+    expect(out).toContain("t199 ");   // newest kept
+    expect(out.startsWith("t0 ")).toBe(false); // oldest dropped
+  });
+
+  it("hard-slices a single over-budget line to fit the byte budget", () => {
+    const out = formatActivityTail(
+      [
+        {
+          timestamp: "t",
+          kind: "tool.end",
+          source: "agent",
+          payload: { toolName: "x", isError: false, resultSummary: "y".repeat(600) },
+        },
+      ],
+      { maxBytes: 100 },
+    );
+    expect(new TextEncoder().encode(out).length).toBeLessThanOrEqual(100);
+  });
+
+  it("returns an empty string for no events", () => {
+    expect(formatActivityTail([])).toBe("");
   });
 });

--- a/tests/feedback-helper.test.ts
+++ b/tests/feedback-helper.test.ts
@@ -1,17 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { submitFeedback, summarizeActivityTail } from "../extensions/loom/feedback.js";
+import { submitFeedback } from "../extensions/loom/feedback.js";
 
 describe("brain submitFeedback", () => {
   beforeEach(() => vi.restoreAllMocks());
-
-  it("summarizes activity events to timestamp+kind+source", () => {
-    const out = summarizeActivityTail([
-      { timestamp: "t1", kind: "tool_call", source: "galaxy", payload: { secret: "x" } },
-      { timestamp: "t2", kind: "message", source: "user", payload: {} },
-    ]);
-    expect(out).toBe("t1 tool_call (galaxy)\nt2 message (user)");
-    expect(out).not.toContain("secret");
-  });
 
   it("POSTs the payload and returns ok+id", async () => {
     const fetchMock = vi.fn().mockResolvedValue({


### PR DESCRIPTION
Right now the feedback path throws away most of what it captures. Every `activity.jsonl` event gets collapsed to `<timestamp> <kind> (<source>)`, so a beta report's "recent activity" is ~15 lines of `tool.start (agent)` / `tool.end (agent)` with zero diagnostic value -- you can't tell which tool ran, what it was called with, or how it failed. The payloads already carry that detail (and it's already redacted/truncated at write time in `activity-hooks.ts`); we were just discarding it on the way out.

This forwards that already-redacted detail instead. One line per event:
- `tool.start` -> tool name + redacted args
- `tool.end` -> tool name + ✓/✗ + truncated result summary
- `user.prompt` -> the prompt text
- unknown kinds fall back to the old `kind (source)`

So the fastp adapter failure that kicked this off now reads:
```
… tool.end galaxy_run_tool ✗ ERROR: the adapter sequence contains invalid characters; fastp rejected the input
```
instead of a bare `tool.end (agent)`.

## How it's built
- A shared formatter `formatActivityTail` + a total-size guard `capFeedbackPayload` land in `shared/feedback-contract.js`, so both summarizers (the brain-side `/feedback` command and the Orbit modal) render identically with no drift.
- The formatter adds no redaction of its own -- it trusts the upstream hooks. Per-field display caps + a byte budget keep it bounded; `capFeedbackPayload` trims activity then shell so an assembled POST stays under the worker's 256KB cap.
- Bumped both consumers 15 -> 60 events, and the Orbit shell tail 80 -> 200 lines.

**Contract untouched:** `activityTail`/`shellTail` stay strings, `SCHEMA_VERSION` stays 1, the worker and D1 schema don't change -- the richer text rides inside the existing `payload` field. The public-GitHub fallback stays title + body only.

**Consent/disclosure copy** updated to match what each path actually sends: the brain path doesn't collect shell output so its consent string no longer claims it; the Orbit modal does, so its disclosure mentions it.

Tests: 426 green, typecheck clean, lint clean.

## Two minor follow-ups left for later
Noted so they're not a surprise in review:
- `capFeedbackPayload` trims the activity tail before the shell tail, so in the pathological case where the shell tail alone blows the budget (200 lines averaging >1KB each) the activity tail can get dropped entirely. Unlikely in practice; flagging the priority choice.
- Corrupt/unparseable `activity.jsonl` lines render as `? ?` in the Orbit path rather than salvaging the raw line text. Only affects malformed lines.