### PR TITLE
Bump to 0.3.1 for release

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orbit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orbit",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orbit",
   "productName": "Orbit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Electron desktop shell for the Loom agent runtime (Galaxy bioinformatics)",
   "license": "MIT",
   "main": ".vite/build/main.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@galaxyproject/loom",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@galaxyproject/loom",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "^0.0.52",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galaxyproject/loom",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "AI co-scientist for Galaxy bioinformatics, built on Pi.dev",
   "keywords": [


### PR DESCRIPTION
Version bump only -- cuts a 0.3.1 release on top of 0.3.0.

What ships since 0.3.0:
- Orbit context-window fill indicator in the footer (#164)
- Decoupled Intel (x64) mac build + make-orbit composite action (#166)

This is the first tag to actually exercise the macos-26-intel build leg and the first 0.3.0->N auto-update. Once merged, the merge commit gets tagged `v0.3.1` to fire release.yml (arm64-mac + linux installers + best-effort Intel, draft GitHub Release, npm publish to latest).