### PR TITLE
Stop the macOS top banners from clobbering the titlebar

### DIFF
--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -204,6 +204,31 @@ a:visited {
   display: none;
 }
 
+/* macOS traffic-light handling for the top banners. With titleBarStyle
+   'hiddenInset' the lights float over whatever sits at the very top of the
+   window. When a banner is showing it IS that top strip, so on darwin it has to
+   double as the titlebar -- same drag + inset treatment .pane-title gets
+   otherwise -- or it both collides with the lights and kills the drag region.
+   Only #update-banner needs the left inset (its text is left-aligned); the
+   bypass/sandbox banners center their text, which never reaches under the
+   lights. The buttons/links stay no-drag (mirrors the .pane-title rule). */
+body.platform-darwin #update-banner,
+body.platform-darwin #bypass-banner,
+body.platform-darwin #sandbox-banner {
+  -webkit-app-region: drag;
+}
+body.platform-darwin #update-banner {
+  padding-left: 78px;
+}
+body.platform-darwin #update-banner button,
+body.platform-darwin #update-banner a,
+body.platform-darwin #bypass-banner button,
+body.platform-darwin #bypass-banner a,
+body.platform-darwin #sandbox-banner button,
+body.platform-darwin #sandbox-banner a {
+  -webkit-app-region: no-drag;
+}
+
 .pane {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What

On macOS the top banners (`#update-banner`, `#bypass-banner`, `#sandbox-banner`) sit at the very top of the window, where `titleBarStyle: hiddenInset` floats the traffic lights. The banners weren't titlebar-aware, which caused two bugs whenever one was showing:

1. The banner text rendered **underneath** the traffic lights -- e.g. the "Orbit X downloaded." restart notice came out as "…bi…0…1 downloaded." with the red/yellow/green dots painted over "Orbit 0".
2. The banner became the topmost strip but was **not a drag region**, so it both collided with the lights and killed window dragging at the top of the window (it had pushed the real drag surface -- the `.pane-title` row -- down below it).

## Why

Nothing wrong with the Electron config; `hiddenInset` is correct. The drag + traffic-light inset only lived on `.pane-title` (`-webkit-app-region: drag` + `padding-left: 78px` on `#files-title`), which is the topmost element *only when no banner is showing*. As soon as a banner appears it takes over the top strip without inheriting either treatment.

## Fix

Give the banners the same darwin-scoped treatment `.pane-title` already uses:

- `-webkit-app-region: drag` on all three banners so the top strip stays draggable whichever one is up (with no banner showing, the `.pane-title` row remains the drag surface as before).
- `padding-left: 78px` on `#update-banner` only -- it's the left-aligned one whose text would otherwise run under the lights. The bypass/sandbox banners center their text, which never reaches the light cluster, so they only need the drag region.
- Buttons/links kept `no-drag`, mirroring the existing `.pane-title` rule.

CSS-only, 25 lines, no layout restructuring and no permanent chrome.

## Verification

Packaged the app and drove it with Playwright, forcing the update banner into its "downloaded" state:

- `-webkit-app-region` resolves to `drag` on the banner and `no-drag` on the Restart button.
- `#update-banner` computed `padding-left` is `78px`; the "downloaded" text's left edge measures `x=78` -- the same inset `#files-title` uses to clear the lights in production.

Renderer screenshot of the forced state (native traffic lights aren't in the web bitmap, but the text now starts at the 78px inset where they sit, instead of at ~12px):

> "Orbit 0.3.1 downloaded." rendered with a clear left gap where the traffic-light cluster lives.
