### PR TITLE
Fix the macOS app showing up as lowercase "orbit"

### DIFF
--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -289,7 +289,15 @@ const macCodesign: Partial<Pick<PackagerOptions, "osxSign" | "osxNotarize">> =
 const config: ForgeConfig = {
   packagerConfig: {
     name: "Orbit",
-    executableName: "orbit",
+    // @electron/packager derives CFBundleDisplayName (the name Finder shows
+    // under the app icon) from executableName, not from `name` above -- so a
+    // lowercase value here makes the macOS app read "orbit" even though the
+    // bundle is Orbit.app. The lowercase binary is only wanted for the Linux
+    // deb/rpm CLI command; macOS has no need for it. Use the proper-cased name
+    // on darwin and keep lowercase elsewhere. Each platform builds on its own
+    // native runner (same assumption the codesign gate below relies on), so
+    // process.platform reflects the target OS family here.
+    executableName: process.platform === "darwin" ? "Orbit" : "orbit",
     icon: "resources/icon",
     appBundleId: "org.galaxyproject.orbit",
     appCategoryType: "public.app-category.developer-tools",

--- a/app/test/e2e/smoke.spec.ts
+++ b/app/test/e2e/smoke.spec.ts
@@ -29,8 +29,9 @@ function packagedExecutablePath(): string {
     return path.join(root, "out", `Orbit-linux-${arch}`, "orbit");
   }
   if (process.platform === "darwin") {
-    // Inner binary name follows forge.config.ts `executableName: "orbit"`
-    // (lowercase), not the .app bundle's display name.
+    // Inner binary name follows forge.config.ts `executableName`, which is the
+    // proper-cased "Orbit" on darwin (the lowercase variant is Linux/Windows
+    // only -- see the comment on executableName for why).
     return path.join(
       root,
       "out",
@@ -38,7 +39,7 @@ function packagedExecutablePath(): string {
       "Orbit.app",
       "Contents",
       "MacOS",
-      "orbit",
+      "Orbit",
     );
   }
   if (process.platform === "win32") {


### PR DESCRIPTION
## What

On macOS the app installed as lowercase **"orbit"** -- in the DMG window and after dragging to Applications -- instead of "Orbit" like every other app.

## Why

The `.app` bundle is genuinely `Orbit.app` on disk and `CFBundleName` is correctly "Orbit". The problem is `CFBundleDisplayName`, which is the name Finder actually shows under an app icon. `@electron/packager` derives `CFBundleDisplayName` (and `CFBundleExecutable`) from `executableName`, **not** from `packagerConfig.name`:

```js
// @electron/packager dist/mac.js
updatePlist(basePlist, displayName /* = executableName */, identifier, name) {
  return Object.assign(basePlist, {
    CFBundleDisplayName: displayName,
    CFBundleExecutable: sanitizeAppName(displayName),
    CFBundleName: sanitizeAppName(name),
  });
}
```

We'd set `executableName: "orbit"`, so the display name came out lowercase. (`extendInfo` can't fix this -- the packager applies `extendInfo` first and then overwrites `CFBundleDisplayName` from `executableName`.) The lowercase binary name is only wanted for the Linux deb/rpm CLI command; macOS has no need for it.

## Fix

Proper-cased `executableName` on darwin, lowercase elsewhere -- keyed on `process.platform`, the same idiom the codesign gate in this file already uses (each platform builds on its own native runner):

```ts
executableName: process.platform === "darwin" ? "Orbit" : "orbit",
```

Linux/Windows artifacts are unchanged (the `orbit` CLI command stays lowercase). The smoke test's darwin binary path is updated to match the rename.

## Verification

Built the actual installer (`Orbit-0.3.1-arm64.dmg`), mounted it, and inspected the app a user would drag out:

- bundle file: `Orbit.app`
- `CFBundleName` / `CFBundleDisplayName` / `CFBundleExecutable`: all `Orbit` (was `Orbit` / `orbit` / `orbit`)
- inner binary renamed `orbit` -> `Orbit`

`prettier --check` and `tsc --noEmit` both clean.

No auto-update impact: the installed bundle path (`/Applications/Orbit.app`) and bundle id (`org.galaxyproject.orbit`) are unchanged, so Squirrel.Mac still updates in place -- only the inner executable/display name changes.
