### PR TITLE
Pre-empt the macOS Keychain prompt with a heads-up modal

### DIFF
--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -308,6 +308,10 @@ export function registerIpcHandlers(agent: AgentManager): void {
     },
   );
 
+  // Lets the renderer know whether saving a key will actually hit the OS keychain
+  // (macOS safeStorage), so it can pre-warn the user before the system dialog.
+  ipcMain.handle("secure:is-encryption-available", () => safeStorageAvailable());
+
   // Top-level config keys the renderer is allowed to set. Anything else
   // submitted via config:save is dropped before saveConfig() runs — the
   // renderer is the smaller trust boundary, so a markdown XSS that

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -82,6 +82,7 @@ export interface OrbitAPI {
     key: string,
     baseUrl?: string,
   ): Promise<{ valid: boolean; error?: string; models?: string[] }>;
+  isEncryptionAvailable(): Promise<boolean>;
   oauthStatus(
     provider: string,
   ): Promise<{ signedIn: boolean; expiresInSeconds?: number; accountId?: string }>;
@@ -178,6 +179,7 @@ const api: OrbitAPI = {
   setBypassPermissions: (enabled) => ipcRenderer.invoke("guardian:set-bypass", enabled),
   validateApiKey: (provider, key, baseUrl) =>
     ipcRenderer.invoke("apiKey:validate", provider, key, baseUrl),
+  isEncryptionAvailable: () => ipcRenderer.invoke("secure:is-encryption-available"),
   oauthStatus: (provider) => ipcRenderer.invoke("oauth:status", provider),
   oauthSignIn: (provider) => ipcRenderer.invoke("oauth:sign-in", provider),
   oauthSignOut: (provider) => ipcRenderer.invoke("oauth:sign-out", provider),

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -9,6 +9,11 @@ import { PromptQueue, queuedPreview } from "./prompt-queue.js";
 import { LoomWidgetKey, decodeMarkdownWidget } from "../../../shared/loom-shell-contract.js";
 import { ALLOWED_SKILLS_PREFIX, isAllowedSkillUrl } from "../../../shared/loom-config.js";
 import {
+  KEYCHAIN_EXPLAINER_SHOWN_KEY,
+  payloadHasNewSecret,
+  shouldShowKeychainExplainer,
+} from "./keychain-explainer.js";
+import {
   SCHEMA_VERSION,
   formatActivityTail,
   capFeedbackPayload,
@@ -900,6 +905,7 @@ welcomeSave.addEventListener("click", async () => {
   const cwd = welcomeCwd.value.trim();
   if (cwd) cfg.defaultCwd = cwd;
 
+  await maybeShowKeychainExplainer(cfg);
   await window.orbit.saveConfig(cfg);
   welcomeOverlay.classList.add("hidden");
   await refreshGalaxyStatus();
@@ -1813,6 +1819,60 @@ function showNewSessionModal(): Promise<NewSessionChoice> {
     cancelBtn.addEventListener("click", onCancel);
     document.addEventListener("keydown", onKey);
   });
+}
+
+/**
+ * Show the one-time macOS keychain explainer and resolve when dismissed. While
+ * it's up it owns the keyboard: Enter or Escape dismiss it (this is a heads-up,
+ * not a gate -- the user already clicked Save, so dismissing just proceeds). We
+ * listen in the capture phase and stopImmediatePropagation so the welcome/prefs
+ * global Escape handlers don't fire on the overlay underneath us; capture wins
+ * regardless of the order those document-level listeners were registered.
+ */
+function showKeychainExplainer(): Promise<void> {
+  return new Promise((resolve) => {
+    const overlay = document.getElementById("keychain-overlay");
+    const continueBtn = document.getElementById("keychain-continue") as HTMLButtonElement | null;
+    if (!overlay || !continueBtn) {
+      resolve();
+      return;
+    }
+    overlay.classList.remove("hidden");
+    const cleanup = () => {
+      overlay.classList.add("hidden");
+      continueBtn.removeEventListener("click", cleanup);
+      document.removeEventListener("keydown", onKey, true);
+      resolve();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Enter" || e.key === "Escape") {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+        cleanup();
+      }
+    };
+    continueBtn.addEventListener("click", cleanup);
+    document.addEventListener("keydown", onKey, true);
+  });
+}
+
+/**
+ * Show the keychain explainer once, immediately before a save that will encrypt
+ * a newly typed key. No-op after the first time, off macOS, when nothing new was
+ * typed, or when safeStorage is unavailable. Cheap checks short-circuit before the
+ * availability IPC; shouldShowKeychainExplainer stays the single source of truth.
+ */
+async function maybeShowKeychainExplainer(config: Record<string, unknown>): Promise<void> {
+  const alreadyShown = localStorage.getItem(KEYCHAIN_EXPLAINER_SHOWN_KEY) === "1";
+  const hasNewSecret = payloadHasNewSecret(config, UNCHANGED_SECRET);
+  if (alreadyShown || !hasNewSecret) return;
+  const platform = window.orbit.platform;
+  const encryptionAvailable = await window.orbit.isEncryptionAvailable();
+  if (!shouldShowKeychainExplainer({ platform, encryptionAvailable, alreadyShown, hasNewSecret })) {
+    return;
+  }
+  await showKeychainExplainer();
+  localStorage.setItem(KEYCHAIN_EXPLAINER_SHOWN_KEY, "1");
 }
 
 async function showCwdWelcome(prefix?: string): Promise<void> {
@@ -3331,6 +3391,7 @@ async function savePreferences(): Promise<void> {
   // and not touching the model — that case shouldn't claim a model swap).
   const prevModel = currentModel;
 
+  await maybeShowKeychainExplainer(config as Record<string, unknown>);
   const result = await window.orbit.saveConfig(config as Record<string, unknown>);
   if (result.success) {
     closePreferences();

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -817,6 +817,28 @@
       </div>
     </div>
 
+    <!-- macOS keychain pre-prompt explainer: primes the user right before
+         safeStorage triggers the system Keychain dialog on the first key save. -->
+    <div id="keychain-overlay" class="modal-overlay hidden">
+      <div class="modal">
+        <div class="modal-header">
+          <h2>Storing your API key securely</h2>
+        </div>
+        <div class="modal-body">
+          <p>
+            Orbit keeps your API keys in your Mac's Keychain so they're encrypted on disk. macOS
+            will now ask permission to do that. Please click
+            <strong>Always Allow</strong> so Orbit won't have to ask again.
+          </p>
+        </div>
+        <div class="modal-footer">
+          <div class="modal-actions">
+            <button id="keychain-continue" class="plan-btn primary">Continue</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <script type="module" src="./app.ts"></script>
   </body>
 </html>

--- a/app/src/renderer/keychain-explainer.ts
+++ b/app/src/renderer/keychain-explainer.ts
@@ -1,0 +1,46 @@
+/**
+ * localStorage flag marking that the macOS Keychain explainer has been shown
+ * once on this install. Renderer-local; survives launches.
+ */
+export const KEYCHAIN_EXPLAINER_SHOWN_KEY = "orbit.keychainExplainerShown";
+
+type SecretBearingConfig = {
+  llm?: { providers?: Record<string, { apiKey?: unknown }> };
+  galaxy?: { profiles?: Record<string, { apiKey?: unknown }> };
+};
+
+/**
+ * True when the outgoing config payload carries at least one freshly typed
+ * secret -- i.e. a real string that is neither empty nor the unchanged-secret
+ * sentinel. OAuth providers omit apiKey entirely, so they never count.
+ */
+export function payloadHasNewSecret(
+  config: SecretBearingConfig,
+  unchangedSentinel: string,
+): boolean {
+  const isReal = (k: unknown): k is string =>
+    typeof k === "string" && k.length > 0 && k !== unchangedSentinel;
+  for (const p of Object.values(config.llm?.providers ?? {})) {
+    if (isReal(p?.apiKey)) return true;
+  }
+  for (const p of Object.values(config.galaxy?.profiles ?? {})) {
+    if (isReal(p?.apiKey)) return true;
+  }
+  return false;
+}
+
+export interface KeychainExplainerGate {
+  platform: string;
+  encryptionAvailable: boolean;
+  alreadyShown: boolean;
+  hasNewSecret: boolean;
+}
+
+/**
+ * Sole authority for whether to show the pre-prompt explainer. macOS only pops
+ * the Keychain dialog when safeStorage actually encrypts, and only the first
+ * time, so we gate on darwin + availability + a new secret + not-shown-before.
+ */
+export function shouldShowKeychainExplainer(g: KeychainExplainerGate): boolean {
+  return g.platform === "darwin" && g.encryptionAvailable && !g.alreadyShown && g.hasNewSecret;
+}

--- a/tests/keychain-explainer.test.ts
+++ b/tests/keychain-explainer.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  payloadHasNewSecret,
+  shouldShowKeychainExplainer,
+} from "../app/src/renderer/keychain-explainer.js";
+
+const SENTINEL = "__loom_unchanged_secret__";
+
+describe("payloadHasNewSecret", () => {
+  it("is true when an LLM provider carries a freshly typed key", () => {
+    const cfg = { llm: { active: "anthropic", providers: { anthropic: { apiKey: "sk-real" } } } };
+    expect(payloadHasNewSecret(cfg, SENTINEL)).toBe(true);
+  });
+
+  it("is false for the unchanged-secret sentinel", () => {
+    const cfg = { llm: { active: "anthropic", providers: { anthropic: { apiKey: SENTINEL } } } };
+    expect(payloadHasNewSecret(cfg, SENTINEL)).toBe(false);
+  });
+
+  it("is false for an empty key string", () => {
+    const cfg = { llm: { active: "anthropic", providers: { anthropic: { apiKey: "" } } } };
+    expect(payloadHasNewSecret(cfg, SENTINEL)).toBe(false);
+  });
+
+  it("is false for an OAuth provider with no apiKey field", () => {
+    const cfg = { llm: { active: "openai-codex", providers: { "openai-codex": { model: "x" } } } };
+    expect(payloadHasNewSecret(cfg, SENTINEL)).toBe(false);
+  });
+
+  it("is true when a Galaxy profile carries a freshly typed key", () => {
+    const cfg = { galaxy: { active: "default", profiles: { default: { url: "u", apiKey: "g" } } } };
+    expect(payloadHasNewSecret(cfg, SENTINEL)).toBe(true);
+  });
+
+  it("is false when the Galaxy profile key is the sentinel", () => {
+    const cfg = {
+      galaxy: { active: "default", profiles: { default: { url: "u", apiKey: SENTINEL } } },
+    };
+    expect(payloadHasNewSecret(cfg, SENTINEL)).toBe(false);
+  });
+
+  it("is false for an empty payload", () => {
+    expect(payloadHasNewSecret({}, SENTINEL)).toBe(false);
+  });
+});
+
+describe("shouldShowKeychainExplainer", () => {
+  const base = {
+    platform: "darwin",
+    encryptionAvailable: true,
+    alreadyShown: false,
+    hasNewSecret: true,
+  };
+
+  it("is true when all conditions hold", () => {
+    expect(shouldShowKeychainExplainer(base)).toBe(true);
+  });
+
+  it("is false off macOS", () => {
+    expect(shouldShowKeychainExplainer({ ...base, platform: "linux" })).toBe(false);
+    expect(shouldShowKeychainExplainer({ ...base, platform: "win32" })).toBe(false);
+  });
+
+  it("is false when safeStorage is unavailable", () => {
+    expect(shouldShowKeychainExplainer({ ...base, encryptionAvailable: false })).toBe(false);
+  });
+
+  it("is false when already shown", () => {
+    expect(shouldShowKeychainExplainer({ ...base, alreadyShown: true })).toBe(false);
+  });
+
+  it("is false when there is no new secret", () => {
+    expect(shouldShowKeychainExplainer({ ...base, hasNewSecret: false })).toBe(false);
+  });
+});


### PR DESCRIPTION
Orbit stores API keys encrypted at rest via Electron safeStorage, which on macOS means the Keychain. The first time we encrypt a key, macOS throws its own permission dialog ("Orbit wants to use confidential information stored in your keychain..."), and to a new user that looks alarming and unexplained -- nothing tells them it's just us protecting their key, or that they should click Always Allow.

We can't suppress that system dialog (it's macOS gating Keychain access by code signature, and we're signed + notarized, so a clean user gets exactly one prompt and then silence). What we can do is warn them right before it. This adds a small one-time explainer that pops just before the first key save -- "Orbit keeps your API keys in your Mac's Keychain... macOS will now ask permission... please click Always Allow." Once they've seen it, it never shows again.

Details:
- Gated to the cases that matter: macOS only, only when safeStorage is actually available, only when the save carries a newly-typed key (not an unchanged one, not an OAuth provider), and only the first time (a localStorage flag). That decision lives in one pure, unit-tested function.
- Wired into both key-entry paths -- the first-run welcome screen and Preferences -- through a shared helper so they can't drift.
- A tiny new IPC (`secure:is-encryption-available`) so the renderer knows whether saving will hit the keychain before it shows anything.

Deliberately out of scope: the startup re-encryption prompt for users upgrading from an old plaintext-key build (it fires before any UI, so there's nowhere to hang the explainer), and Linux/Windows (Windows DPAPI is silent; Linux libsecret is a different UX). Both are easy to add later.

Testing: 12 unit tests on the gating logic, full suite green, typechecks clean. Worth a manual GUI pass on a fresh macOS profile to eyeball the modal-then-dialog ordering before merge.
