### PR TITLE
Warn when Galaxy is configured but uvx isn't installed

### DIFF
--- a/bin/loom.js
+++ b/bin/loom.js
@@ -11,6 +11,7 @@ import {
 } from "../shared/loom-config.js";
 import { spawn } from "child_process";
 import { getLoomVersion, detectInstall } from "./update-check.js";
+import { isUvxAvailable, uvxMissingNotice } from "./uvx-check.js";
 import { pickChannel } from "../shared/version-compare.js";
 import {
   isCustomProvider,
@@ -587,6 +588,14 @@ if (userArgs[0] === "update") {
   child.on("exit", (code) => process.exit(code ?? 0));
 } else {
   checkLLMProvider();
+
+  // Galaxy is configured but the uvx runner that launches galaxy-mcp is missing.
+  // Warn (don't block): Loom is still useful without Galaxy, and pi-mcp-adapter
+  // would otherwise fail to spawn that server with a buried error. Orbit bundles
+  // uv onto PATH before spawn, so this only fires for standalone CLI installs.
+  if (galaxyUrl && galaxyApiKey && !isUvxAvailable()) {
+    console.error(`\n${uvxMissingNotice()}\n`);
+  }
 
   // Resolve pi-coding-agent's own version by walking up from its entry point to
   // the package root. Used to pin the changelog watermark below.

--- a/bin/uvx-check.d.ts
+++ b/bin/uvx-check.d.ts
@@ -1,0 +1,11 @@
+export function resolveExecutable(
+  cmd: string,
+  opts?: {
+    pathEnv?: string;
+    platform?: NodeJS.Platform;
+    pathExt?: string;
+    isExecutable?: (p: string) => boolean;
+  },
+): string | null;
+export function isUvxAvailable(): boolean;
+export function uvxMissingNotice(): string;

--- a/bin/uvx-check.js
+++ b/bin/uvx-check.js
@@ -1,0 +1,73 @@
+// Pre-flight helper: is `uvx` resolvable on PATH? Galaxy MCP launches via
+// `uvx galaxy-mcp>=1.6.0` (see bin/loom.js), so when Galaxy credentials are
+// configured but uv isn't installed, pi-mcp-adapter fails to start that one
+// server with a spawn error buried in the logs and Galaxy tools silently
+// vanish. We detect the gap up front and print an actionable notice. Orbit
+// bundles uv and prepends it to the brain's PATH before spawn, so the check
+// naturally passes there. Pure helpers (resolveExecutable, uvxMissingNotice)
+// are unit-tested; isUvxAvailable is a thin fs wrapper.
+
+import fs from "node:fs";
+import path from "node:path";
+
+/** Real executable check: a regular file we're allowed to execute. On Windows
+ * the X_OK bit is meaningless, so presence + PATHEXT match is enough.
+ * @param {string} p @returns {boolean} */
+function defaultIsExecutable(p) {
+  try {
+    if (!fs.statSync(p).isFile()) return false;
+    if (process.platform === "win32") return true;
+    fs.accessSync(p, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Mirror how `child_process.spawn` resolves a bare command: walk PATH entries
+ * and return the first executable named `cmd` (trying PATHEXT suffixes on
+ * Windows). Pure given injected `pathEnv` / `platform` / `isExecutable`.
+ * @param {string} cmd
+ * @param {{ pathEnv?: string, platform?: NodeJS.Platform, pathExt?: string, isExecutable?: (p: string) => boolean }} [opts]
+ * @returns {string | null}
+ */
+export function resolveExecutable(cmd, opts = {}) {
+  const {
+    pathEnv = process.env.PATH || "",
+    platform = process.platform,
+    pathExt = process.env.PATHEXT,
+    isExecutable = defaultIsExecutable,
+  } = opts;
+  if (!pathEnv) return null;
+  const isWin = platform === "win32";
+  const sep = isWin ? ";" : ":";
+  const exts = isWin ? (pathExt ?? ".EXE;.CMD;.BAT;.COM").split(";").filter(Boolean) : [""];
+  for (const dir of pathEnv.split(sep)) {
+    if (!dir) continue; // empty segment must not resolve to the cwd
+    for (const ext of exts) {
+      const candidate = path.join(dir, cmd + ext);
+      if (isExecutable(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+/** @returns {boolean} whether `uvx` is resolvable on the current PATH. */
+export function isUvxAvailable() {
+  return resolveExecutable("uvx") !== null;
+}
+
+/** Actionable notice shown when Galaxy creds are set but `uvx` is missing. Pure.
+ * @returns {string} */
+export function uvxMissingNotice() {
+  return `loom: Galaxy is configured, but \`uvx\` was not found on your PATH.
+Galaxy tools run through \`uvx galaxy-mcp\` (a Python MCP server), so they
+won't be available until you install uv:
+
+  * Install script:  curl -LsSf https://astral.sh/uv/install.sh | sh
+  * Homebrew:        brew install uv
+
+See https://docs.astral.sh/uv/ for details. Loom will keep running without
+Galaxy tools -- web search, BRC Analytics, and local execution still work.`;
+}

--- a/bin/uvx-check.js
+++ b/bin/uvx-check.js
@@ -41,12 +41,16 @@ export function resolveExecutable(cmd, opts = {}) {
   } = opts;
   if (!pathEnv) return null;
   const isWin = platform === "win32";
+  // Join with the injected platform's separator, not the host OS's. Bare
+  // path.join uses native separators, so a win32 PATH probed on a posix host
+  // (or vice versa) yielded mismatched slashes -- which broke this on Windows CI.
+  const pathMod = isWin ? path.win32 : path.posix;
   const sep = isWin ? ";" : ":";
   const exts = isWin ? (pathExt ?? ".EXE;.CMD;.BAT;.COM").split(";").filter(Boolean) : [""];
   for (const dir of pathEnv.split(sep)) {
     if (!dir) continue; // empty segment must not resolve to the cwd
     for (const ext of exts) {
-      const candidate = path.join(dir, cmd + ext);
+      const candidate = pathMod.join(dir, cmd + ext);
       if (isExecutable(candidate)) return candidate;
     }
   }

--- a/tests/cli-uvx-check.test.ts
+++ b/tests/cli-uvx-check.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { resolveExecutable, uvxMissingNotice } from "../bin/uvx-check.js";
+
+describe("resolveExecutable", () => {
+  it("finds an executable in a later PATH dir", () => {
+    const found = resolveExecutable("uvx", {
+      pathEnv: "/usr/bin:/opt/uv/bin",
+      platform: "linux",
+      isExecutable: (p) => p === "/opt/uv/bin/uvx",
+    });
+    expect(found).toBe("/opt/uv/bin/uvx");
+  });
+
+  it("returns null when the command is on no PATH dir", () => {
+    const found = resolveExecutable("uvx", {
+      pathEnv: "/usr/bin:/bin",
+      platform: "linux",
+      isExecutable: () => false,
+    });
+    expect(found).toBeNull();
+  });
+
+  it("returns null for an empty PATH instead of resolving the cwd", () => {
+    const found = resolveExecutable("uvx", {
+      pathEnv: "",
+      platform: "linux",
+      isExecutable: () => true,
+    });
+    expect(found).toBeNull();
+  });
+
+  it("skips empty PATH segments so a leading ':' can't match the cwd", () => {
+    const probed: string[] = [];
+    resolveExecutable("uvx", {
+      pathEnv: ":/opt/bin",
+      platform: "linux",
+      isExecutable: (p) => {
+        probed.push(p);
+        return false;
+      },
+    });
+    expect(probed).toEqual(["/opt/bin/uvx"]);
+  });
+
+  it("appends PATHEXT suffixes on Windows", () => {
+    const found = resolveExecutable("uvx", {
+      pathEnv: "C:\\tools",
+      platform: "win32",
+      pathExt: ".EXE;.CMD",
+      isExecutable: (p) => p.endsWith("uvx.EXE"),
+    });
+    expect(found?.endsWith("uvx.EXE")).toBe(true);
+  });
+});
+
+describe("uvxMissingNotice", () => {
+  it("names uvx, points at the uv installer, and says Galaxy is the casualty", () => {
+    const msg = uvxMissingNotice();
+    expect(msg).toContain("uvx");
+    expect(msg).toContain("astral.sh");
+    expect(msg.toLowerCase()).toContain("galaxy");
+  });
+});

--- a/tests/cli-uvx-check.test.ts
+++ b/tests/cli-uvx-check.test.ts
@@ -49,7 +49,10 @@ describe("resolveExecutable", () => {
       pathExt: ".EXE;.CMD",
       isExecutable: (p) => p.endsWith("uvx.EXE"),
     });
-    expect(found?.endsWith("uvx.EXE")).toBe(true);
+    // Assert the full path, not just the suffix: the separator must come from
+    // the injected platform, not the host OS. This is exactly what broke on the
+    // Windows runner -- path.join used native separators regardless of platform.
+    expect(found).toBe("C:\\tools\\uvx.EXE");
   });
 });
 


### PR DESCRIPTION
The CLI registers Galaxy MCP as `uvx galaxy-mcp>=1.6.0`, but nothing checked that `uvx` actually exists on the standalone CLI path. If you've saved Galaxy creds but don't have `uv` installed, `pi-mcp-adapter` just fails to spawn the server with an error buried in the logs and Galaxy tools silently vanish -- confusing, because everything else (web search, BRC Analytics, local exec) keeps working.

This adds a preflight that runs right before the agent launches: if Galaxy creds are present but `uvx` isn't resolvable on PATH, it prints an actionable install hint. It **warns rather than blocks** -- Loom is still useful without Galaxy -- and stays silent under Orbit, which bundles `uv` onto PATH before launching the brain, so the check only ever fires for standalone CLI installs.

`bin/uvx-check.js` mirrors how `child_process.spawn` resolves a bare command (walk PATH, honor PATHEXT on Windows, require an executable regular file). The pure helpers are unit-tested; `isUvxAvailable` is a thin fs wrapper, matching the `update-check.js` convention.

Verified end-to-end on the real CLI -- warns when `uvx` is missing, silent when present. 435 root tests + typecheck + lint green.