### PR TITLE
Build linux-arm64 Orbit installers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ name: release
 # GitHub Release (promote the draft manually), and publishes the @galaxyproject/loom
 # npm package via OIDC trusted publishing (no token, no 2FA prompt).
 #
-# All three installer platforms (arm64 mac, Intel mac, linux) build in one
+# All four installer legs (arm64 mac, Intel mac, linux x64/arm64) build in one
 # matrix that `publish` waits on. The Intel leg used to run decoupled off to the
 # side: GitHub's now-retired macos-13 Intel fleet was small and could sit queued
 # for hours (~19h on the alpha.1 cut), which would have held the draft Release
@@ -56,6 +56,14 @@ jobs:
           # Linux and inside WSL2 (with WSLg) on Windows 11.
           - os: ubuntu-latest
             arch: x64
+            platform: linux
+          # Linux arm64 — same .deb/.rpm/.zip outputs, built natively on
+          # GitHub's free arm64 Linux runner (public repos). Unblocks arm64
+          # hosts (Jetson, Raspberry Pi, arm64 servers) that can't run the x64
+          # installer or its bundled x64 uv. ubuntu-24.04-arm is the arm64
+          # counterpart to ubuntu-latest (currently 24.04).
+          - os: ubuntu-24.04-arm
+            arch: arm64
             platform: linux
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Adds a `linux-arm64` leg (`ubuntu-24.04-arm`) to the release build matrix so Orbit ships `.deb`/`.rpm`/`.zip` for arm64 Linux.

The `make-orbit` composite action is already arch-agnostic and the prePackage hook stages Node + uv per-arch (`UV_TARGETS` already maps `linux-arm64`), so no other changes are needed. `fail-fast: false` keeps an arm64 hiccup from blocking the other legs' publish.

Addresses #149 for the packaged-install path: arm64 hosts (e.g. Jetson) get a real installer with a bundled arm64 uv instead of falling back to a missing system `uvx`. The broader "host the MCP server at Galaxy / connect over a remote `url:` transport" proposal in that issue is separate and left open.

You can smoke-test the leg with a `workflow_dispatch` build-only run on the branch (uploads artifacts, no draft release / npm publish) before tagging.
