### PR TITLE
Note the .deb app-launcher refresh gotcha in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,6 +71,12 @@ sudo apt-get install -f   # resolves any missing dependencies
 orbit                     # launch from terminal, or find it in your app launcher
 ```
 
+Not showing up in your application menu? Some desktop environments don't
+refresh their app database right after a `dpkg` install, so the Orbit icon can
+be missing even though the install worked. Run `sudo update-desktop-database
+/usr/share/applications` (or just log out and back in) and it'll appear. Either
+way, `orbit` from the terminal always launches it.
+
 ### Install (.rpm — Fedora/RHEL)
 
 ```bash


### PR DESCRIPTION
Closes #135.

After installing the `.deb`, Orbit's `.desktop` entry lands fine but some desktop environments don't refresh their application database right away, so the icon's missing from the menu even though the install worked. This adds a short note in the Linux `.deb` section of `INSTALL.md` pointing at `sudo update-desktop-database /usr/share/applications` (or a logout), and reminds folks that `orbit` from the terminal always launches it in the meantime.

Docs-only change.
