### PR TITLE
Make CLI startup Galaxy state coherent and stop leaking the welcome prompt

### DIFF
--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -32,13 +32,10 @@ import {
   switchProfile,
   profileNameFromUrl,
   normalizeGalaxyUrl,
-  warnOnUnusableActiveProfile,
 } from "./profiles";
 import { LoomWidgetKey, encodeMarkdownWidget } from "../../shared/loom-shell-contract.js";
 
 export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
-  warnOnUnusableActiveProfile();
-
   // Register the local-execution safety gate first so its tool_call decision is
   // the authoritative boundary before anything else runs.
   registerExecGuard(pi);

--- a/extensions/loom/profiles.ts
+++ b/extensions/loom/profiles.ts
@@ -185,25 +185,37 @@ export function resolveProfileApiKey(name: string, profile: GalaxyProfile): stri
   throw new Error(`Profile "${name}" has no API key configured.`);
 }
 
+export type ActiveGalaxyStatus = "usable" | "configured-unusable" | "none";
+
 /**
- * Called once at brain startup. If the active profile is encrypted-only
- * and the shell hasn't injected `GALAXY_API_KEY`, log a clear stderr
- * line so the user knows why Galaxy calls won't work -- otherwise the
- * brain would silently 401 against every request.
+ * Usability of the active Galaxy profile for THIS process. The startup greeting
+ * reads this so its message can't contradict the actual credential state.
+ *
+ * - `usable`: GALAXY_URL + GALAXY_API_KEY are both in env (however they got
+ *   there -- plaintext profile, explicit export, or Orbit's decrypt-inject).
+ * - `configured-unusable`: no usable env key, but the active profile carries an
+ *   encrypted key this process can't decrypt (Orbit-only safeStorage). Galaxy
+ *   calls would 401; the fix is to run from Orbit or export GALAXY_API_KEY.
+ * - `none`: no usable active profile to speak of.
+ *
+ * Pure given (profiles, env); `activeGalaxyStatus()` is the thin live wrapper.
  */
-export function warnOnUnusableActiveProfile(): void {
-  const { active, profiles } = loadProfiles();
-  if (!active) return;
-  const profile = profiles[active];
-  if (!profile) return;
-  if (profile.apiKey) return;
-  if (process.env.GALAXY_API_KEY) return;
-  if (!profile.apiKeyEncrypted) return;
-  console.error(
-    `[galaxy] Active profile "${active}" has only an encrypted API key and ` +
-      `GALAXY_API_KEY is not set in the environment. Galaxy calls will fail. ` +
-      `Run from Orbit (auto-injects the decrypted key) or export GALAXY_API_KEY explicitly.`,
-  );
+export function getActiveGalaxyStatus(
+  profiles: GalaxyProfiles,
+  env: NodeJS.ProcessEnv,
+): ActiveGalaxyStatus {
+  if (env.GALAXY_URL && env.GALAXY_API_KEY) return "usable";
+  const active = profiles.active;
+  if (!active) return "none";
+  const profile = profiles.profiles[active];
+  if (profile && !profile.apiKey && !env.GALAXY_API_KEY && profile.apiKeyEncrypted) {
+    return "configured-unusable";
+  }
+  return "none";
+}
+
+export function activeGalaxyStatus(): ActiveGalaxyStatus {
+  return getActiveGalaxyStatus(loadProfiles(), process.env);
 }
 
 /**

--- a/extensions/loom/session-lifecycle.ts
+++ b/extensions/loom/session-lifecycle.ts
@@ -8,6 +8,7 @@ import {
   writeNotebook,
   type SessionSummaryYaml,
 } from "./notebook-writer.js";
+import { activeGalaxyStatus, type ActiveGalaxyStatus } from "./profiles.js";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -41,7 +42,7 @@ export function registerSessionLifecycle(pi: ExtensionAPI): void {
       return;
     }
 
-    sendStartupGreeting(pi);
+    sendStartupGreeting(pi, ctx);
   });
 
   // Compaction recovery: snapshot the notebook so the post-compact agent can
@@ -137,36 +138,59 @@ function syncSessionJsonlSymlink(ctx: ExtensionContext): void {
   }
 }
 
-function sendStartupGreeting(pi: ExtensionAPI): void {
-  const hasCredentials = Boolean(process.env.GALAXY_URL && process.env.GALAXY_API_KEY);
-  const isOrbit = process.env.LOOM_SHELL_KIND === "orbit";
+type GreetingAction =
+  | { kind: "model"; message: string }
+  | { kind: "notify"; text: string; level: "info" | "warning" };
 
-  // Note: Galaxy MCP gets credentials via env vars; agent calls
-  // galaxy_connect() if needed. Just nudge it.
-  const connectInstr = hasCredentials
-    ? ` Galaxy credentials are configured -- call galaxy_connect() to establish the connection.` +
-      ` Do NOT call other Galaxy tools until connected.`
-    : "";
-
-  if (hasCredentials) {
-    pi.sendUserMessage(
+/**
+ * Decide the startup greeting from the active Galaxy credential status. Pure so
+ * it can be unit-tested without a live session.
+ *
+ * `usable` keeps a real model turn -- it has to nudge galaxy_connect(). The
+ * other two states are pure pleasantries, so they render as a static notify:
+ * no model round-trip, no leaked instruction, and the same call surfaces in
+ * both the terminal TUI and Orbit (which renders the notify RPC event).
+ */
+export function planStartupGreeting(status: ActiveGalaxyStatus, isOrbit: boolean): GreetingAction {
+  if (status === "usable") {
+    const message =
       `Session started in this project directory. Read \`notebook.md\` to see prior work. ` +
-        (isOrbit
-          ? `Reply with one short sentence: "What do you want to work on next?" ` +
-            `No greeting, no emojis, no product branding.`
-          : `Give a brief welcome, then ask what to work on next, referencing the notebook contents if there is prior work. ` +
-            `Keep it to 2-3 sentences.`) +
-        connectInstr,
-    );
-    return;
+      (isOrbit
+        ? `Reply with one short sentence: "What do you want to work on next?" ` +
+          `No greeting, no emojis, no product branding.`
+        : `Give a brief welcome, then ask what to work on next, referencing the notebook contents if there is prior work. ` +
+          `Keep it to 2-3 sentences.`) +
+      ` Galaxy credentials are configured -- call galaxy_connect() to establish the connection.` +
+      ` Do NOT call other Galaxy tools until connected.`;
+    return { kind: "model", message };
   }
 
-  pi.sendUserMessage(
-    `Session started in this project directory. No Galaxy server configured. ` +
-      (isOrbit
-        ? `Reply with two short sentences: mention /connect for Galaxy, then ask "What do you want to work on?". ` +
-          `No greeting, no emojis, no product branding.`
-        : `Give a brief welcome, mention /connect to set up a Galaxy server, and ask what to work on. ` +
-          `Keep it to 2-3 sentences.`),
-  );
+  if (status === "configured-unusable") {
+    return {
+      kind: "notify",
+      level: "warning",
+      text:
+        `Welcome to Loom. A Galaxy profile is configured, but its API key only decrypts inside Orbit -- ` +
+        `Galaxy tools won't work in this terminal. Run from Orbit, export GALAXY_API_KEY, or /connect a server. ` +
+        `What would you like to work on?`,
+    };
+  }
+
+  return {
+    kind: "notify",
+    level: "info",
+    text:
+      `Welcome to Loom. No Galaxy server is configured, so work runs locally for now -- use /connect to set one up. ` +
+      `What would you like to work on?`,
+  };
+}
+
+export function sendStartupGreeting(pi: ExtensionAPI, ctx: ExtensionContext): void {
+  const isOrbit = process.env.LOOM_SHELL_KIND === "orbit";
+  const action = planStartupGreeting(activeGalaxyStatus(), isOrbit);
+  if (action.kind === "model") {
+    pi.sendUserMessage(action.message);
+  } else {
+    ctx.ui.notify(action.text, action.level);
+  }
 }

--- a/tests/profiles.test.ts
+++ b/tests/profiles.test.ts
@@ -8,7 +8,7 @@ import {
   saveProfile,
   switchProfile,
   loadProfiles,
-  warnOnUnusableActiveProfile,
+  getActiveGalaxyStatus,
 } from "../extensions/loom/profiles";
 
 // All loom-config / profiles paths derive from os.homedir() at call time.
@@ -137,52 +137,46 @@ describe("syncMcpConfig", () => {
   });
 });
 
-describe("warnOnUnusableActiveProfile", () => {
-  function captureErrors(fn: () => void): string[] {
-    const errors: string[] = [];
-    const orig = console.error;
-    console.error = (msg: string) => errors.push(msg);
-    try {
-      fn();
-    } finally {
-      console.error = orig;
-    }
-    return errors;
-  }
-
-  it("warns when active profile is encrypted-only and env is unset", () => {
-    saveProfile("a", "https://a.galaxyproject.org", "plain-A");
-    const cfgPath = path.join(sandboxHome, ".loom/config.json");
-    const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
-    cfg.galaxy.profiles.a = { url: "https://a.galaxyproject.org", apiKeyEncrypted: "ZW5j" };
-    fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
-    delete process.env.GALAXY_API_KEY;
-    const errors = captureErrors(() => warnOnUnusableActiveProfile());
-    expect(errors.length).toBe(1);
-    expect(errors[0]).toContain('Active profile "a"');
-    expect(errors[0]).toMatch(/GALAXY_API_KEY/);
+describe("getActiveGalaxyStatus", () => {
+  const withDefault = (p: Record<string, unknown>) => ({
+    active: "default",
+    profiles: { default: p as never },
   });
 
-  it("does not warn when active profile has plaintext key", () => {
-    saveProfile("a", "https://a.galaxyproject.org", "plain-A");
-    delete process.env.GALAXY_API_KEY;
-    const errors = captureErrors(() => warnOnUnusableActiveProfile());
-    expect(errors.length).toBe(0);
+  it("is usable when GALAXY_URL and GALAXY_API_KEY are both in env", () => {
+    const status = getActiveGalaxyStatus(withDefault({ url: "u", apiKeyEncrypted: "ZW5j" }), {
+      GALAXY_URL: "u",
+      GALAXY_API_KEY: "k",
+    });
+    expect(status).toBe("usable");
   });
 
-  it("does not warn when env injection is present (Orbit path)", () => {
-    saveProfile("a", "https://a.galaxyproject.org", "plain-A");
-    const cfgPath = path.join(sandboxHome, ".loom/config.json");
-    const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf-8"));
-    cfg.galaxy.profiles.a = { url: "https://a.galaxyproject.org", apiKeyEncrypted: "ZW5j" };
-    fs.writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
-    process.env.GALAXY_API_KEY = "injected-by-orbit";
-    const errors = captureErrors(() => warnOnUnusableActiveProfile());
-    expect(errors.length).toBe(0);
+  it("is configured-unusable for an encrypted-only active profile with no env key", () => {
+    const status = getActiveGalaxyStatus(withDefault({ url: "u", apiKeyEncrypted: "ZW5j" }), {});
+    expect(status).toBe("configured-unusable");
   });
 
-  it("does not warn when there is no active profile", () => {
-    const errors = captureErrors(() => warnOnUnusableActiveProfile());
-    expect(errors.length).toBe(0);
+  it("is usable (not configured-unusable) once Orbit injects the env key", () => {
+    const status = getActiveGalaxyStatus(withDefault({ url: "u", apiKeyEncrypted: "ZW5j" }), {
+      GALAXY_URL: "u",
+      GALAXY_API_KEY: "injected-by-orbit",
+    });
+    expect(status).toBe("usable");
+  });
+
+  it("is none when there is no active profile", () => {
+    expect(getActiveGalaxyStatus({ active: null, profiles: {} }, {})).toBe("none");
+  });
+
+  it("is none when the active name points at a missing profile", () => {
+    expect(getActiveGalaxyStatus({ active: "ghost", profiles: {} }, {})).toBe("none");
+  });
+
+  it("is none for a plaintext-key profile not yet wired into env", () => {
+    // Has a usable key on disk, so it's not the encrypted-unusable case; env
+    // just isn't set, which bin/loom.js wouldn't allow in practice. Documents
+    // the boundary.
+    const status = getActiveGalaxyStatus(withDefault({ url: "u", apiKey: "plain" }), {});
+    expect(status).toBe("none");
   });
 });

--- a/tests/startup-greeting.test.ts
+++ b/tests/startup-greeting.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { planStartupGreeting, sendStartupGreeting } from "../extensions/loom/session-lifecycle.js";
+
+describe("planStartupGreeting", () => {
+  it("usable -> a model turn that nudges galaxy_connect", () => {
+    const action = planStartupGreeting("usable", false);
+    expect(action.kind).toBe("model");
+    if (action.kind === "model") expect(action.message).toContain("galaxy_connect");
+  });
+
+  it("configured-unusable -> a warning notify naming Orbit and GALAXY_API_KEY", () => {
+    const action = planStartupGreeting("configured-unusable", false);
+    expect(action.kind).toBe("notify");
+    if (action.kind === "notify") {
+      expect(action.level).toBe("warning");
+      expect(action.text).toContain("GALAXY_API_KEY");
+      expect(action.text).toContain("Orbit");
+    }
+  });
+
+  it("none -> an info notify pointing at /connect", () => {
+    const action = planStartupGreeting("none", false);
+    expect(action.kind).toBe("notify");
+    if (action.kind === "notify") {
+      expect(action.level).toBe("info");
+      expect(action.text).toContain("/connect");
+    }
+  });
+});
+
+// Dispatch: the greeting reads the live config + env (activeGalaxyStatus) and
+// routes to a model turn or a static notify. Sandbox HOME so the on-disk config
+// is ours; fake pi/ctx so we can see which channel fired.
+describe("sendStartupGreeting (dispatch)", () => {
+  let prevHome: string | undefined;
+  let prevUserProfile: string | undefined;
+  let sandboxHome: string;
+
+  beforeEach(() => {
+    prevHome = process.env.HOME;
+    prevUserProfile = process.env.USERPROFILE;
+    sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), "loom-greeting-test-"));
+    process.env.HOME = sandboxHome;
+    process.env.USERPROFILE = sandboxHome;
+    delete process.env.GALAXY_URL;
+    delete process.env.GALAXY_API_KEY;
+    delete process.env.PI_CODING_AGENT_DIR;
+    delete process.env.LOOM_SHELL_KIND;
+    fs.mkdirSync(path.join(sandboxHome, ".loom"), { recursive: true });
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevUserProfile;
+    delete process.env.GALAXY_URL;
+    delete process.env.GALAXY_API_KEY;
+    try {
+      fs.rmSync(sandboxHome, { recursive: true, force: true });
+    } catch {}
+  });
+
+  function writeConfig(galaxy: unknown): void {
+    const cfg = { llm: { active: "anthropic", providers: { anthropic: { apiKey: "k" } } }, galaxy };
+    fs.writeFileSync(path.join(sandboxHome, ".loom", "config.json"), JSON.stringify(cfg));
+  }
+
+  function fakes() {
+    const pi = { sendUserMessage: vi.fn() };
+    const ctx = { ui: { notify: vi.fn() } };
+    return { pi, ctx };
+  }
+
+  it("usable (encrypted profile + Orbit-injected env) -> model turn, no notify", () => {
+    writeConfig({
+      active: "default",
+      profiles: { default: { url: "https://x.galaxyproject.org", apiKeyEncrypted: "ZW5j" } },
+    });
+    process.env.GALAXY_URL = "https://x.galaxyproject.org";
+    process.env.GALAXY_API_KEY = "injected-by-orbit";
+    const { pi, ctx } = fakes();
+    sendStartupGreeting(pi as never, ctx as never);
+    expect(pi.sendUserMessage).toHaveBeenCalledTimes(1);
+    expect(ctx.ui.notify).not.toHaveBeenCalled();
+  });
+
+  it("encrypted-only profile, no env -> warning notify, no model turn", () => {
+    writeConfig({
+      active: "default",
+      profiles: { default: { url: "https://x.galaxyproject.org", apiKeyEncrypted: "ZW5j" } },
+    });
+    const { pi, ctx } = fakes();
+    sendStartupGreeting(pi as never, ctx as never);
+    expect(ctx.ui.notify).toHaveBeenCalledTimes(1);
+    expect(ctx.ui.notify.mock.calls[0][1]).toBe("warning");
+    expect(pi.sendUserMessage).not.toHaveBeenCalled();
+  });
+
+  it("no active profile -> info notify, no model turn", () => {
+    writeConfig({ active: null, profiles: {} });
+    const { pi, ctx } = fakes();
+    sendStartupGreeting(pi as never, ctx as never);
+    expect(ctx.ui.notify).toHaveBeenCalledTimes(1);
+    expect(ctx.ui.notify.mock.calls[0][1]).toBe("info");
+    expect(pi.sendUserMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
On a standalone `npx @galaxyproject/loom` run where the Galaxy profile was saved through Orbit (key encrypted in safeStorage), startup printed three messages that disagreed:

- `profiles.ts` warned on stderr that the active profile's key was unusable;
- the greeting separately announced "No Galaxy server configured";
- and the greeting's *instruction* ("Give a brief welcome, mention /connect ... Keep it to 2-3 sentences") rendered verbatim as a visible turn before the model's actual welcome.

Two sources of truth (the config profile vs. the runtime env) plus a leaked prompt.

This collapses the check into one `getActiveGalaxyStatus` predicate -- `usable` / `configured-unusable` / `none` -- that the greeting reads, so the two can't contradict each other, and drops the now-redundant stderr warning. For the two non-usable states the greeting is pure pleasantry, so it renders as a static `ctx.ui.notify` instead of a model instruction: no round-trip, nothing leaked, and it surfaces in both the terminal TUI and Orbit (whose renderer already handles the `notify` event). The `usable` path keeps its model turn since it still has to call `galaxy_connect()`.

Scope: the `usable` path's instruction is left as-is (it does real work). Resumed sessions (`--continue`) skip the greeting, so the "key unusable here" signal for them now comes at tool-call time via the existing `EncryptedProfileUnavailableError` ("run from Orbit or export GALAXY_API_KEY") rather than at startup. The EBADENGINE / `[Skill conflicts]` / tmux noise is upstream/environmental and not touched here.

437 tests + typecheck + lint green; new unit tests for `getActiveGalaxyStatus` and `planStartupGreeting`, plus a sandboxed dispatch test confirming encrypted-only -> warning notify (no model turn), no-profile -> info notify, usable -> model turn.