### PR TITLE
Stop the agent over-claiming it compacted the conversation (#171)

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -1,4 +1,5 @@
 import { ChatPanel } from "./chat/chat-panel.js";
+import { detectCompactIntent } from "./chat/compact-intent.js";
 import { humanizeAgentError } from "./chat/error-humanizer.js";
 import { ShellPanel } from "./chat/shell-panel.js";
 import { ArtifactPanel } from "./artifacts/artifact-panel.js";
@@ -1361,6 +1362,41 @@ messagesEl.addEventListener("click", (e) => {
   target.replaceWith(document.createTextNode("(dismissed)"));
 });
 
+// Compact-intent nudge state (#171). Same one-time-per-session +
+// "Don't show again" persistence as the cheaper-model nudge.
+const COMPACT_NUDGE_SKIP_KEY = "loom.skipCompactNudge";
+let compactNudgeShownThisSession = false;
+
+/**
+ * The agent cannot compact its own context -- that's the `/compact` command,
+ * a harness action. Users type "compact"/"reduce the context" into chat
+ * anyway, the agent writes a notebook summary, and (before its guardrail)
+ * over-claimed it had compacted while the context-fill bar didn't move (#171).
+ * Catch that plain-text intent shell-side and point them at the real command.
+ */
+function maybeShowCompactIntentHint(text: string): void {
+  if (compactNudgeShownThisSession) return;
+  if (localStorage.getItem(COMPACT_NUDGE_SKIP_KEY) === "1") return;
+  if (!detectCompactIntent(text)) return;
+  compactNudgeShownThisSession = true;
+  chat.addInfoMessage(
+    `<i><strong>Heads up:</strong> the agent can't compact the conversation ` +
+      `itself. Writing a notebook summary won't shrink the context window. ` +
+      `Run <code>/compact</code> to actually reclaim context (the notebook is ` +
+      `kept). For a full reset, start a new session and choose ` +
+      `<strong>Keep notebook</strong>. ` +
+      `<a href="#" class="compact-nudge-dismiss">Don't show again</a></i>`,
+  );
+}
+
+messagesEl.addEventListener("click", (e) => {
+  const target = e.target as HTMLElement | null;
+  if (!target?.classList.contains("compact-nudge-dismiss")) return;
+  e.preventDefault();
+  localStorage.setItem(COMPACT_NUDGE_SKIP_KEY, "1");
+  target.replaceWith(document.createTextNode("(dismissed)"));
+});
+
 function submit(): void {
   const text = inputEl.value.trim();
   if (!text) return;
@@ -1370,6 +1406,9 @@ function submit(): void {
   // Cheaper-model nudge fires before slash dispatch so /execute on Opus
   // gets the hint inline above the agent's thinking response.
   maybeShowCheaperModelNudge(text);
+
+  // Nudge plain-text "compact"/"reduce context" requests toward /compact (#171).
+  maybeShowCompactIntentHint(text);
 
   // If the agent is mid-turn, queue the message and flush when agent_end fires.
   // Purely local slash commands still run immediately; slash commands that

--- a/app/src/renderer/chat/compact-intent.ts
+++ b/app/src/renderer/chat/compact-intent.ts
@@ -1,0 +1,38 @@
+/**
+ * Plain-text "compact the conversation" intent detection (issue #171).
+ *
+ * Users type things like "compact" or "reduce the context" into chat
+ * expecting the live context window to shrink. It won't -- compaction is the
+ * `/compact` command (a harness action), not a chat message the agent can
+ * act on. We detect that intent shell-side and nudge them to `/compact`.
+ *
+ * The hard part is precision: this runs in a bioinformatics tool where
+ * "compact" (a compact genome), "reduce", and "history" (a Galaxy history)
+ * carry unrelated meanings. So we only fire when a compaction verb is paired
+ * with a conversation-referring noun, or when the message is a bare "compact"
+ * imperative. False negatives are cheap (the agent's own guardrail still
+ * routes them to `/compact`); false positives are annoying, so we err quiet.
+ */
+
+const COMPACT_VERB = /\bcompact(s|ed|ing)?\b/;
+const REDUCE_VERB = /\b(reduce|shrink|trim)\b/;
+// Nouns that clearly refer to the chat/LLM context, not Galaxy/genomic data.
+const CONVERSATION_NOUN = /\b(context|conversation|chat)\b/;
+// A bare imperative: "compact", "compact it", "please compact now", etc.
+// Deliberately does NOT accept "compact the <anything>" -- that path goes
+// through the verb+noun rule so "compact the genome" can't slip in.
+const BARE_COMPACT =
+  /^(please\s+|can\s+you\s+|could\s+you\s+|hey,?\s+)*compact(\s+(it|this|that|everything|now|please))*[\s.!?]*$/;
+
+export function detectCompactIntent(text: string): boolean {
+  const t = text.trim().toLowerCase();
+  if (!t) return false;
+  // Already a slash command, or already referencing the real command.
+  if (t.startsWith("/")) return false;
+  if (t.includes("/compact")) return false;
+
+  if (BARE_COMPACT.test(t)) return true;
+  if (COMPACT_VERB.test(t) && CONVERSATION_NOUN.test(t)) return true;
+  if (REDUCE_VERB.test(t) && CONVERSATION_NOUN.test(t)) return true;
+  return false;
+}

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -429,6 +429,32 @@ do not write it to the notebook or activity log, and tell them once
 that the value is now in their LLM provider's request logs and they
 should rotate it.
 
+### Context and compaction
+
+You **cannot compact your own context.** Compaction (shrinking the
+conversation the harness sends to the model) is a user or harness
+action, not something you can trigger with a tool call. Writing a
+summary into the notebook is useful, but it
+**does not shrink the live context window**; the model still receives
+the full prior conversation.
+
+When the user asks you to "compact", "reduce context", "shrink the
+conversation", or anything similar, you may summarize the work so far
+into \`notebook.md\`, but you
+**must not claim the context window was compacted**. Say plainly that
+you wrote a summary and that the live context is unchanged, then point
+the user at the real mechanism:
+
+- Run **\`/compact\`** to actually compact the conversation. It keeps the
+  notebook, which holds the durable record, so verbose tool chatter can
+  be dropped safely.
+- For a full reset that still preserves the notebook, start a new
+  session and choose **Keep notebook** (\`/new\` in Orbit).
+
+The context-fill indicator reflects the true window size. If you tell
+the user you compacted and the indicator does not move, you have
+misreported your own state.
+
 `;
 }
 

--- a/tests/compact-intent.test.ts
+++ b/tests/compact-intent.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { detectCompactIntent } from "../app/src/renderer/chat/compact-intent.js";
+
+/**
+ * Issue #171: users type "compact" into chat as plain text expecting the
+ * conversation to shrink. The shell should detect that intent and nudge them
+ * to the real `/compact` command. The detector must catch the real intent
+ * (the two prompts from the bug report) without firing on bioinformatics
+ * phrasing where "compact"/"reduce" mean something else.
+ */
+describe("detectCompactIntent", () => {
+  describe("fires on real compaction intent", () => {
+    const positives = [
+      "compact",
+      "Compact",
+      "compact it",
+      "compact now",
+      "please compact",
+      "compact conversation", // verbatim from the bug report
+      "compact the conversation",
+      "compact the context",
+      "compact the chat",
+      "Summarize everything up to this point in the notebook and compact the context so we can continue.", // verbatim from the bug report
+      "reduce context",
+      "can you reduce the context?",
+      "shrink the conversation",
+      "trim the chat context",
+    ];
+    for (const text of positives) {
+      it(`fires on: ${JSON.stringify(text)}`, () => {
+        expect(detectCompactIntent(text)).toBe(true);
+      });
+    }
+  });
+
+  describe("does not fire on unrelated or already-correct input", () => {
+    const negatives = [
+      "", // empty
+      "/compact", // already the slash command
+      "/compact keep the plan", // slash command with args
+      "please run /compact for me", // references the command already
+      "the assembly produced a compact genome", // compact = small genome
+      "use a compact data structure", // compact = dense
+      "compact the genome assembly", // compact + non-conversation object
+      "reduce the number of reads to 1000", // reduce, but not the context
+      "clear the Galaxy history", // history = Galaxy, not chat
+      "summarize the results into the notebook", // summarize only, no compaction
+      "what does compaction mean?", // a question, not a request
+    ];
+    for (const text of negatives) {
+      it(`stays quiet on: ${JSON.stringify(text)}`, () => {
+        expect(detectCompactIntent(text)).toBe(false);
+      });
+    }
+  });
+});

--- a/tests/compaction-guardrail-context.test.ts
+++ b/tests/compaction-guardrail-context.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { setupContextInjection } from "../extensions/loom/context";
+
+/**
+ * Issue #171: the agent over-claims it compacted the conversation when asked
+ * in chat, but compaction is a harness operation it cannot perform itself.
+ * The system prompt must tell the agent it cannot compact its own context,
+ * must not claim it did, and must route the user to the real mechanism.
+ */
+function assembleSystemPrompt(): Promise<{ systemPrompt: string }> {
+  const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>();
+  const pi = {
+    on: (event: string, handler: (event: unknown, ctx: unknown) => Promise<unknown>) => {
+      handlers.set(event, handler);
+    },
+  };
+  setupContextInjection(pi as any);
+  return handlers.get("before_agent_start")!({}, {}) as Promise<{ systemPrompt: string }>;
+}
+
+describe("compaction guardrail", () => {
+  it("tells the agent it cannot compact its own context", async () => {
+    const { systemPrompt } = await assembleSystemPrompt();
+    expect(systemPrompt).toContain("compact your own context");
+  });
+
+  it("forbids claiming the context window was compacted", async () => {
+    const { systemPrompt } = await assembleSystemPrompt();
+    expect(systemPrompt).toContain("must not claim the context window was compacted");
+  });
+
+  it("allows summarizing into the notebook as the thing it can actually do", async () => {
+    const { systemPrompt } = await assembleSystemPrompt();
+    expect(systemPrompt).toContain("does not shrink the live context window");
+  });
+
+  it("routes the user to the real mechanism (/compact, /new -> Keep notebook)", async () => {
+    const { systemPrompt } = await assembleSystemPrompt();
+    expect(systemPrompt).toContain("/compact");
+    expect(systemPrompt).toContain("Keep notebook");
+  });
+
+  it("lands inside the Operating discipline section", async () => {
+    const { systemPrompt } = await assembleSystemPrompt();
+    const disciplineIdx = systemPrompt.indexOf("## Operating discipline");
+    const guardrailIdx = systemPrompt.indexOf("compact your own context");
+    const planIdx = systemPrompt.indexOf("## Project model and plan sections");
+    expect(disciplineIdx).toBeGreaterThanOrEqual(0);
+    expect(guardrailIdx).toBeGreaterThan(disciplineIdx);
+    expect(guardrailIdx).toBeLessThan(planIdx);
+  });
+});


### PR DESCRIPTION
When a user asks in chat to "compact the conversation," the agent would write a summary into `notebook.md` and then report that it had compacted -- but an LLM can't shrink the context the harness sends to the model. Compaction is the `/compact` action. The context-fill indicator (#164) made the gap visible: the agent confirms success, the bar doesn't move.

This takes the primary route from the issue -- a guardrail in the system prompt -- plus the secondary discoverability nudge, and leaves the heavier "let the agent trigger a real compaction" tool route for a later discussion.

**Guardrail (`extensions/loom/context.ts`).** A new *Context and compaction* subsection in the operating-discipline block tells the agent plainly that it cannot compact its own context, that summarizing into the notebook does not shrink the live window, and that it must not claim the context was compacted. When asked, it should summarize if useful, say the live context is unchanged, and point the user at the real mechanism -- `/compact`, or `/new -> Keep notebook` for a full reset.

**Orbit hint (`app/src/renderer/chat/compact-intent.ts` + `app.ts`).** Users naturally type "compact" into chat instead of running the command, so a small pure `detectCompactIntent()` catches that intent and surfaces a one-time, dismissible chat hint pointing at `/compact`, mirroring the existing cheaper-model nudge. It only fires on a compaction verb paired with a conversation noun (context/conversation/chat) or a bare "compact" imperative, so it stays quiet on bioinformatics phrasing like "compact genome" or "clear the Galaxy history."

**Testing.** New unit tests cover the guardrail wiring (5) and the intent detector (25, including the two verbatim prompts from the report). Full root suite green (459), root + app typecheck clean, prettier/eslint clean. The Orbit toast itself wasn't exercised in a live Electron run -- the wiring is a 1:1 mirror of the cheaper-model nudge.

Closes #171.
