### PR TITLE
Answer tester-ID questions from config instead of Galaxy (#189)

### DIFF
--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -125,6 +125,26 @@ You are **${modelStr}** running via the **${active}** provider. This is your cur
 `;
 }
 
+/**
+ * Surface the Orbit tester ID directly into the prompt so the agent answers
+ * "what's my tester ID?" from local config instead of guessing at Galaxy
+ * (issue #189). The id is an opaque, non-secret beta-tester code stored in
+ * ~/.loom/config.json (or LOOM_TESTER_ID). Reads ONLY testerId -- never the
+ * rest of the config, and never tells the agent to open the file (#183).
+ */
+export function buildTesterIdBlock(): string {
+  const testerId = loadConfig().testerId || process.env.LOOM_TESTER_ID;
+  if (!testerId) return "";
+  return `## Orbit tester ID
+
+This session's Orbit tester ID is **${testerId}**. It comes from the local
+Orbit/Loom config, not from Galaxy. When the user asks about their tester ID,
+report this value directly and do **not** call Galaxy tools such as
+\`galaxy_get_user\`. The tester ID is not a Galaxy account attribute; it's an
+opaque, non-secret code that rides along on feedback submissions.
+`;
+}
+
 function buildExecutionModeBlock(): string {
   const cfg = loadConfig();
   if (cfg.executionMode !== "local") return "";
@@ -971,6 +991,7 @@ export function setupContextInjection(pi: ExtensionAPI): void {
     const omitAnchors = isLlama4Family(ctx.model);
     const systemPrompt = [
       buildActiveModelBlock(),
+      buildTesterIdBlock(),
       buildOperatingDisciplineBlock(),
       buildVerificationDisciplineBlock(),
       buildPlanConventionBlock({ omitAnchors }),

--- a/tests/tester-id-context.test.ts
+++ b/tests/tester-id-context.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// context.ts reads identity facts from loadConfig(); control it so the block is
+// deterministic regardless of the dev machine's real ~/.loom/config.json.
+const { loadConfigMock } = vi.hoisted(() => ({ loadConfigMock: vi.fn() }));
+vi.mock("../extensions/loom/config", () => ({ loadConfig: loadConfigMock }));
+
+import { buildTesterIdBlock, setupContextInjection } from "../extensions/loom/context";
+
+describe("buildTesterIdBlock", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    loadConfigMock.mockReset();
+    loadConfigMock.mockReturnValue({});
+    savedEnv = process.env.LOOM_TESTER_ID;
+    delete process.env.LOOM_TESTER_ID;
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env.LOOM_TESTER_ID;
+    else process.env.LOOM_TESTER_ID = savedEnv;
+  });
+
+  it("surfaces the configured tester ID and de-routes it away from Galaxy", () => {
+    loadConfigMock.mockReturnValue({ testerId: "orbit-007" });
+
+    const block = buildTesterIdBlock();
+
+    expect(block).toContain("## Orbit tester ID");
+    expect(block).toContain("orbit-007");
+    // The bug was routing this to galaxy_get_user -- the prompt must say not to.
+    expect(block).toContain("galaxy_get_user");
+  });
+
+  it("falls back to LOOM_TESTER_ID when config has none", () => {
+    loadConfigMock.mockReturnValue({});
+    process.env.LOOM_TESTER_ID = "orbit-042";
+
+    expect(buildTesterIdBlock()).toContain("orbit-042");
+  });
+
+  it("injects nothing when no tester ID is configured", () => {
+    loadConfigMock.mockReturnValue({});
+
+    expect(buildTesterIdBlock()).toBe("");
+  });
+
+  it("reads only testerId -- never leaks other config values (#183)", () => {
+    loadConfigMock.mockReturnValue({
+      testerId: "orbit-007",
+      llm: {
+        active: "anthropic",
+        providers: { anthropic: { apiKey: "sk-SECRET-should-never-appear", model: "claude" } },
+      },
+    });
+
+    const block = buildTesterIdBlock();
+
+    expect(block).toContain("orbit-007");
+    expect(block).not.toContain("sk-SECRET-should-never-appear");
+    // Don't nudge the agent to cat the file (the #183 leak vector).
+    expect(block).not.toContain("config.json");
+  });
+
+  it("is wired into the assembled prompt, after the Active LLM block", async () => {
+    loadConfigMock.mockReturnValue({
+      testerId: "orbit-007",
+      llm: { active: "anthropic", providers: { anthropic: { model: "claude-opus-4-8" } } },
+    });
+
+    const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>();
+    const pi = {
+      on: (event: string, handler: (event: unknown, ctx: unknown) => Promise<unknown>) => {
+        handlers.set(event, handler);
+      },
+    };
+
+    setupContextInjection(pi as any);
+    const result = (await handlers.get("before_agent_start")!({}, {})) as { systemPrompt: string };
+
+    expect(result.systemPrompt).toContain("## Orbit tester ID");
+    expect(result.systemPrompt).toContain("orbit-007");
+    expect(result.systemPrompt.indexOf("## Active LLM")).toBeLessThan(
+      result.systemPrompt.indexOf("## Orbit tester ID"),
+    );
+  });
+});


### PR DESCRIPTION
Reported via Orbit beta feedback (#189): asking "what's my tester ID?" in a fresh session made the agent call `galaxy_get_user` instead of reading `testerId` from `~/.loom/config.json`, where it actually lives.

Root cause is a missing signal. `testerId` is loaded by `loadConfig()` and is a non-secret tester code that already rides along on feedback submissions, but the system prompt never surfaced it and no tool exposed it. With nothing config-side to go on, the model pattern-matched "ID/user" onto the only identity-shaped tool it had -- Galaxy's `get_user`.

The fix is a small `buildTesterIdBlock()` in `context.ts`, wired in right after the existing active-model identity block. When `testerId` (or `LOOM_TESTER_ID`) is set it injects just that one value plus a note to report it directly and not call `galaxy_get_user`; when it is unset it injects nothing, same as the active-model block. Putting the value in the prompt rather than adding a tool means even lower-capability models answer correctly without a tool call -- the issue called those out specifically -- and there is no longer a wrong tool to pick because there is no tool decision to make.

Kept the #183 overlap in mind: it reads only `testerId`, injects only that value (never the whole config), and deliberately does not tell the agent to open config.json, so it does not reinforce that secret-leak path. A test locks both of those in.

Scoped to the read/report path. The issue also mentions models struggling to *set* the tester ID; that is a guarded write path and a separate change.

Tests: new `tests/tester-id-context.test.ts` (value present, `LOOM_TESTER_ID` fallback, absent -> empty, read-only/no-leak guard, prompt wiring + ordering). Full root suite green (434), typecheck clean.

Closes #189.