### PR TITLE
Surface a clear message when Gemini is geo-blocked

### DIFF
--- a/app/src/renderer/chat/error-humanizer.ts
+++ b/app/src/renderer/chat/error-humanizer.ts
@@ -35,6 +35,17 @@ export function humanizeAgentError(raw: string | undefined | null): HumanizedErr
   const errType = inner?.type;
   const errMsg = inner?.message ?? parsed.message ?? "";
 
+  // Google's consumer Generative Language API geo-blocks unsupported regions
+  // with a 400 FAILED_PRECONDITION. It keys the error on `status`/`code`, not
+  // the Anthropic-style `type`, so it slips past the switch below -- match its
+  // stable message and explain it instead of echoing the raw payload.
+  if (/user location is not supported/i.test(errMsg)) {
+    return {
+      text: "Gemini isn't available in your region -- Google blocked the request. Switch to a non-Google provider (e.g. Anthropic, OpenAI, or DeepSeek) in Preferences.",
+      retriable: false,
+    };
+  }
+
   switch (errType) {
     case "overloaded_error":
       return {

--- a/tests/error-humanizer.test.ts
+++ b/tests/error-humanizer.test.ts
@@ -61,4 +61,22 @@ describe("humanizeAgentError", () => {
     const raw = "Just a plain error string {not really json";
     expect(humanizeAgentError(raw).text).toBe(raw);
   });
+
+  it("explains the Google geo-block 400 instead of showing the raw payload", () => {
+    // Shape @google/genai throws (and pi forwards verbatim) for a region block:
+    // ApiError.message === JSON.stringify(errorBody). Note Google keys the error
+    // on `status`/`code`, not the Anthropic-style `type`.
+    const raw = JSON.stringify({
+      error: {
+        code: 400,
+        message: "User location is not supported for the API use.",
+        status: "FAILED_PRECONDITION",
+      },
+    });
+    const result = humanizeAgentError(raw);
+    expect(result.text).toMatch(/region/i);
+    expect(result.text).not.toContain("{");
+    expect(result.text).not.toContain("FAILED_PRECONDITION");
+    expect(result.retriable).toBe(false);
+  });
 });


### PR DESCRIPTION
Reported via Orbit beta feedback (#184): Gemini cloud models fail with a raw `400 FAILED_PRECONDITION` -- `"User location is not supported for the API use."` -- for users in regions Google's consumer Generative Language API doesn't serve. DeepSeek/Anthropic/OpenAI work fine for the same user.

We were dumping that raw 400 payload straight into chat. The error humanizer only recognized Anthropic-style errors keyed on `error.type`, but Google keys the error on `status`/`code` (no `type`), so the geo-block slipped past the switch into the generic fallback and showed the bare upstream message with no context.

This detects the geo-block by its stable message and shows something actionable instead:

> Gemini isn't available in your region -- Google blocked the request. Switch to a non-Google provider (e.g. Anthropic, OpenAI, or DeepSeek) in Preferences.

Scoped to the message-surfacing path. Actually routing Gemini through Vertex AI (with a region) or a proxy so it works in blocked regions is a separate architecture call -- worth its own issue if we want it.

Not the same as #185: that one hangs with no event ever arriving. This geo-block returns a prompt 400 that already surfaces and clears the spinner -- it just surfaced badly -- so this doesn't fix the #185 hang.

Added a geo-block case to the humanizer suite; full root suite (430) green, app typecheck clean.

Closes #184