### PR TITLE
Show the working directory in the Orbit window title

### DIFF
--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -9,6 +9,7 @@ import { resolveLlmApiKey, resolveGalaxyApiKey } from "./secure-config.js";
 import { loadSessionHistory, newestSessionFile } from "./session-replay.js";
 import { collectDescendantsOf } from "./proc-monitor.js";
 import { TurnWatchdog } from "./turn-watchdog.js";
+import { formatWindowTitle } from "./window-title.js";
 
 /**
  * How long the brain may stay completely silent mid-turn before Orbit treats the
@@ -234,6 +235,17 @@ export class AgentManager {
       timeoutMs: TURN_SILENCE_TIMEOUT_MS,
       onTimeout: () => this.handleTurnStalled(),
     });
+    this.refreshWindowTitle();
+  }
+
+  /**
+   * Reflect the active analysis directory in the window title so the context
+   * is glanceable across multiple open project windows (#190). Main owns the
+   * title; see createWindow() where page-title-updated is suppressed.
+   */
+  private refreshWindowTitle(): void {
+    if (this.window.isDestroyed()) return;
+    this.window.setTitle(formatWindowTitle(this.cwd, os.homedir()));
   }
 
   /** Reset session continuity (e.g. when switching to a new analysis directory). */
@@ -249,12 +261,14 @@ export class AgentManager {
       this.hasStartedBefore = false;
     }
     this.cwd = cwd;
+    this.refreshWindowTitle();
     log("cwd set to", cwd);
   }
 
   switchCwd(cwd: string): boolean {
     if (cwd === this.cwd) return false;
     this.cwd = cwd;
+    this.refreshWindowTitle();
     this.hasStartedBefore = false;
     // Don't force-skip --continue: let start()'s hasExistingSession() check
     // decide. If the target cwd has a Pi session on disk, we want to resume

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -241,6 +241,13 @@ function createWindow(cwd: string): void {
     mainWindow?.focus();
   });
 
+  // The renderer's static <title> would otherwise be mirrored onto the native
+  // window title on every load/reload, clobbering the cwd-aware title that
+  // AgentManager sets (#190). Let main own the title instead.
+  mainWindow.webContents.on("page-title-updated", (event) => {
+    event.preventDefault();
+  });
+
   // Keep the main window on the renderer; external URLs (including file://
   // links from the notebook — IGV viewers, reports, etc.) open in new
   // Orbit-managed windows so the main app never navigates away.

--- a/app/src/main/window-title.ts
+++ b/app/src/main/window-title.ts
@@ -1,0 +1,27 @@
+const APP_NAME = "Orbit";
+
+/**
+ * Window title for #190: the working directory, home-abbreviated to "~/...".
+ * Showing the path (not just the folder name) keeps two same-named project
+ * dirs in different locations distinguishable -- the cross-project confusion
+ * the issue is about. Bare app name when no cwd is set yet.
+ */
+export function formatWindowTitle(cwd: string, home: string): string {
+  if (!cwd) return APP_NAME;
+  return `${abbreviateHome(cwd, home)} — ${APP_NAME}`;
+}
+
+function abbreviateHome(cwd: string, home: string): string {
+  if (!home) return cwd;
+  // Compare with trailing separators stripped so "/home/x/" matches "/home/x".
+  // Require a separator right after `home` so "/home/xtra" isn't read as inside
+  // "/home/x". Accept either separator (so posix paths abbreviate on Windows
+  // too) and slice rather than rebuild to keep the original one.
+  const c = cwd.replace(/[/\\]+$/, "");
+  const h = home.replace(/[/\\]+$/, "");
+  if (c === h) return "~";
+  if (c.startsWith(h) && (c[h.length] === "/" || c[h.length] === "\\")) {
+    return "~" + c.slice(h.length);
+  }
+  return cwd;
+}

--- a/tests/agent-manager.test.ts
+++ b/tests/agent-manager.test.ts
@@ -95,6 +95,7 @@ describe("AgentManager", () => {
     const { AgentManager } = await import("../app/src/main/agent.js");
     const window = {
       isDestroyed: () => false,
+      setTitle: vi.fn(),
       webContents: { send: vi.fn() },
     };
 
@@ -128,6 +129,7 @@ describe("AgentManager", () => {
     const { AgentManager } = await import("../app/src/main/agent.js");
     const window = {
       isDestroyed: () => false,
+      setTitle: vi.fn(),
       webContents: { send: vi.fn() },
     };
 
@@ -155,7 +157,7 @@ describe("AgentManager", () => {
         const proc = makeProcess(101);
         spawnMock.mockReturnValue(proc);
         const { AgentManager, TURN_SILENCE_TIMEOUT_MS } = await import("../app/src/main/agent.js");
-        const window = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+        const window = { isDestroyed: () => false, setTitle: vi.fn(), webContents: { send: vi.fn() } };
         const manager = new AgentManager(window as any, "/analysis");
         manager.start();
 
@@ -182,7 +184,7 @@ describe("AgentManager", () => {
         const proc = makeProcess(101);
         spawnMock.mockReturnValue(proc);
         const { AgentManager, TURN_SILENCE_TIMEOUT_MS } = await import("../app/src/main/agent.js");
-        const window = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+        const window = { isDestroyed: () => false, setTitle: vi.fn(), webContents: { send: vi.fn() } };
         const manager = new AgentManager(window as any, "/analysis");
         manager.start();
 
@@ -205,7 +207,7 @@ describe("AgentManager", () => {
         const proc = makeProcess(101);
         spawnMock.mockReturnValue(proc);
         const { AgentManager, TURN_SILENCE_TIMEOUT_MS } = await import("../app/src/main/agent.js");
-        const window = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+        const window = { isDestroyed: () => false, setTitle: vi.fn(), webContents: { send: vi.fn() } };
         const manager = new AgentManager(window as any, "/analysis");
         manager.start();
 
@@ -220,5 +222,27 @@ describe("AgentManager", () => {
         vi.useRealTimers();
       }
     });
+  });
+
+  it("sets the window title from the cwd on construction, switch, and setCwd", async () => {
+    spawnMock.mockReturnValue(makeProcess(101));
+
+    const { AgentManager } = await import("../app/src/main/agent.js");
+    const setTitle = vi.fn();
+    const window = {
+      isDestroyed: () => false,
+      setTitle,
+      webContents: { send: vi.fn() },
+    };
+
+    // os.homedir() is mocked to "/tmp/home" at the top of this file.
+    const manager = new AgentManager(window as any, "/tmp/home/projectA");
+    expect(setTitle).toHaveBeenLastCalledWith("~/projectA — Orbit");
+
+    expect(manager.switchCwd("/srv/data/projectB")).toBe(true);
+    expect(setTitle).toHaveBeenLastCalledWith("/srv/data/projectB — Orbit");
+
+    manager.setCwd("/tmp/home/projectC");
+    expect(setTitle).toHaveBeenLastCalledWith("~/projectC — Orbit");
   });
 });

--- a/tests/window-title.test.ts
+++ b/tests/window-title.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { formatWindowTitle } from "../app/src/main/window-title.js";
+
+describe("formatWindowTitle", () => {
+  it("home-abbreviates a cwd under the home directory", () => {
+    expect(formatWindowTitle("/Users/dannon/work/projectA", "/Users/dannon")).toBe(
+      "~/work/projectA — Orbit",
+    );
+  });
+
+  it("renders the home directory itself as ~", () => {
+    expect(formatWindowTitle("/Users/dannon", "/Users/dannon")).toBe("~ — Orbit");
+  });
+
+  it("leaves a cwd outside the home directory unabbreviated", () => {
+    expect(formatWindowTitle("/srv/data/projectB", "/Users/dannon")).toBe(
+      "/srv/data/projectB — Orbit",
+    );
+  });
+
+  it("does not abbreviate a sibling dir that merely shares the home prefix", () => {
+    // "/Users/dannonsextra" starts with "/Users/dannon" as a string but is not
+    // inside it -- abbreviating here would be wrong.
+    expect(formatWindowTitle("/Users/dannonsextra/x", "/Users/dannon")).toBe(
+      "/Users/dannonsextra/x — Orbit",
+    );
+  });
+
+  it("normalizes a trailing separator on the cwd", () => {
+    expect(formatWindowTitle("/Users/dannon/", "/Users/dannon")).toBe("~ — Orbit");
+  });
+
+  it("normalizes a trailing separator on the home dir", () => {
+    expect(formatWindowTitle("/Users/dannon/work", "/Users/dannon/")).toBe("~/work — Orbit");
+  });
+
+  it("abbreviates when home is the filesystem root", () => {
+    expect(formatWindowTitle("/srv/data", "/")).toBe("~/srv/data — Orbit");
+  });
+
+  it("abbreviates with the original separator (Windows-style paths)", () => {
+    // The helper must not key off the runner's path.sep -- a backslash path
+    // abbreviates on any OS, and the backslash separator is preserved.
+    expect(
+      formatWindowTitle("C:\\Users\\dannon\\work\\projectA", "C:\\Users\\dannon"),
+    ).toBe("~\\work\\projectA — Orbit");
+  });
+
+  it("falls back to bare Orbit when no cwd is set", () => {
+    expect(formatWindowTitle("", "/Users/dannon")).toBe("Orbit");
+  });
+});


### PR DESCRIPTION
Closes #190.

With several projects open at once it was easy to lose track of which window pointed at which analysis directory -- every title just read "Orbit". This carries the active working directory in the title, home-abbreviated, so the context is glanceable and a wrong-project mistake is easier to catch.

### What it does
- Title now shows the home-abbreviated cwd, e.g. `~/work/projectA — Orbit`, and falls back to bare `Orbit` when no directory is set.
- Updates live whenever you switch analysis directory. `AgentManager` sets the title in its constructor and in `switchCwd()` -- the single choke point all three cwd-change paths (File menu, second-instance `--cwd`, directory picker) already funnel through.
- The renderer's static `<title>` was being mirrored onto the native window title on every load/reload, which would clobber the cwd-aware title, so `page-title-updated` is now suppressed and main owns the title.

I went with the full home-abbreviated path rather than just the folder name on purpose: the issue is about telling near-identical projects apart, and two dirs both named `analysis` in different locations look identical if you only show the basename.

Only the working directory is wired in -- there's no project-name or active-history concept in the runtime today, so those are out of scope here.

### Notes for review
- With `titleBarStyle: "hiddenInset"` the title isn't prominent in the title bar itself; the payoff shows in the macOS **Window menu** and **Mission Control** when juggling multiple project windows. Worth an eyeball there.

### Tests
- New `formatWindowTitle` unit tests (incl. the path-boundary edge case so a sibling dir sharing the home prefix isn't wrongly abbreviated).
- New `AgentManager` test asserting the title is set from the cwd on construction and on switch.
- Full root suite green (435) + root and app typechecks clean.