### PR TITLE
Stop the agent leaking ~/.loom/config.json API keys into provider logs

### DIFF
--- a/extensions/loom/activity-hooks.ts
+++ b/extensions/loom/activity-hooks.ts
@@ -11,6 +11,8 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import * as path from "path";
 import { getNotebookPath } from "./state";
 import { appendActivityEvent } from "./activity";
+import { collectSecretValues, redactSecrets } from "./secret-redaction";
+import { loadConfig } from "../../shared/loom-config.js";
 
 // Read-only / filesystem-traversal tools clutter the log without telling the
 // user anything they'd want to re-read later. Omit them.
@@ -65,9 +67,13 @@ function sessionDir(): string | null {
   return nb ? path.dirname(nb) : null;
 }
 
-function summarizeResult(result: unknown): string {
+// Redact BEFORE truncating so a secret can't survive by being split across the
+// truncation boundary. Tool RESULTS (unlike args) carry whatever a command
+// printed -- a `cat`-style leak lands here, and this log also feeds /feedback.
+export function summarizeResult(result: unknown, secrets: string[] = []): string {
   if (result == null) return "";
-  const str = typeof result === "string" ? result : JSON.stringify(result);
+  const raw = typeof result === "string" ? result : JSON.stringify(result);
+  const str = redactSecrets(raw, secrets);
   if (str.length <= RESULT_SUMMARY_MAX) return str;
   return (
     str.slice(0, RESULT_SUMMARY_MAX) + `… [truncated ${str.length - RESULT_SUMMARY_MAX} chars]`
@@ -107,6 +113,7 @@ export function registerActivityHooks(pi: ExtensionAPI): void {
     if (NOISY_TOOLS.has(event.toolName)) return;
     const dir = sessionDir();
     if (!dir) return;
+    const secrets = collectSecretValues(loadConfig(), process.env);
     appendActivityEvent(dir, {
       timestamp: new Date().toISOString(),
       kind: "tool.end",
@@ -115,7 +122,7 @@ export function registerActivityHooks(pi: ExtensionAPI): void {
         toolCallId: event.toolCallId,
         toolName: event.toolName,
         isError: event.isError,
-        resultSummary: summarizeResult(event.result),
+        resultSummary: summarizeResult(event.result, secrets),
       },
     });
   });

--- a/extensions/loom/exec-guard/bash-risk.ts
+++ b/extensions/loom/exec-guard/bash-risk.ts
@@ -4,6 +4,12 @@ export interface BashClass {
   /** Path-like args to read-style commands, for the policy layer to run through
    *  sensitive-read + jail. Best-effort; empty when not confidently parseable. */
   readPaths: string[];
+  /** Content-read targets surfaced from EVERY shell segment, so the sensitive-read
+   *  floor still fires when a pipe/compound forces kind="unknown" (closes the
+   *  `cat secret | tool` evasion in #183). Unlike readPaths, this is computed even
+   *  for compound commands; the policy layer applies only the sensitive floor to
+   *  it (never the workspace-jail floor, so compound jail semantics are unchanged). */
+  sensitiveReadPaths: string[];
 }
 
 // Never-legitimate, irreversible-system-damage patterns. Order matters; first match wins.
@@ -180,29 +186,72 @@ const SHELL_META = /[;&|`\n\r]|\$\(|\$\{|<\(|>>?|<|\\\n/;
 
 const READ_LIKE = new Set(["cat", "head", "tail", "less", "more", "grep", "rg"]);
 
+// Content-read targets across EVERY shell segment (split on the same separators
+// as the catastrophic-rm scan). For any segment whose verb is a content reader,
+// collect its non-flag args. This is what closes the pipe evasion: `cat secret |
+// tool` is "unknown" as a whole, but its first segment still reads `secret`. A
+// path that is only an auth arg to a non-reading command (`ssh -i key`) is NOT
+// collected -- only verbs that dump file contents to stdout.
+function extractReadTargets(command: string): string[] {
+  const out: string[] = [];
+  for (const segment of command.split(/[;&|\n\r]+/)) {
+    const tokens = unwrap(segment.trim().split(/\s+/).filter(Boolean).map(stripQuotes));
+    if (tokens.length === 0) continue;
+    const verb = tokens[0].split("/").pop(); // basename: /bin/cat -> cat
+    if (!verb || !READ_LIKE.has(verb)) continue;
+    for (const t of tokens.slice(1)) if (!t.startsWith("-")) out.push(t);
+  }
+  return out;
+}
+
 export function classifyBash(commandRaw: string, home = ""): BashClass {
   const command = commandRaw.trim();
+  // Computed for every kind (incl. compound/unknown) so the policy layer's
+  // sensitive-read floor fires through a pipe; see BashClass.sensitiveReadPaths.
+  const sensitiveReadPaths = extractReadTargets(command);
   for (const [re, why] of CATASTROPHIC) {
-    if (re.test(command)) return { kind: "catastrophic", reason: why, readPaths: [] };
+    if (re.test(command))
+      return { kind: "catastrophic", reason: why, readPaths: [], sensitiveReadPaths };
   }
   if (isCatastrophicRm(command, home)) {
-    return { kind: "catastrophic", reason: "recursive force-delete of / or home", readPaths: [] };
+    return {
+      kind: "catastrophic",
+      reason: "recursive force-delete of / or home",
+      readPaths: [],
+      sensitiveReadPaths,
+    };
   }
   if (SHELL_META.test(command)) {
-    return { kind: "unknown", reason: "compound or redirected command", readPaths: [] };
+    return {
+      kind: "unknown",
+      reason: "compound or redirected command",
+      readPaths: [],
+      sensitiveReadPaths,
+    };
   }
   const tokens = command.split(/\s+/).filter(Boolean);
-  if (tokens.length === 0) return { kind: "unknown", reason: "empty command", readPaths: [] };
+  if (tokens.length === 0)
+    return { kind: "unknown", reason: "empty command", readPaths: [], sensitiveReadPaths };
   const cmd = tokens[0];
 
   const prefixHit = SAFE_PREFIXES.some((p) => p.every((t, i) => tokens[i] === t));
   const isSafeCmd = SAFE_COMMANDS.has(cmd) || prefixHit;
   if (!isSafeCmd) {
-    return { kind: "unknown", reason: `'${cmd}' is not on the safe allowlist`, readPaths: [] };
+    return {
+      kind: "unknown",
+      reason: `'${cmd}' is not on the safe allowlist`,
+      readPaths: [],
+      sensitiveReadPaths,
+    };
   }
 
   // Collect path-like args for read-style commands so the policy layer can apply
   // the sensitive-read + jail floor (a "safe" cat must still not read ~/.ssh).
   const readPaths = READ_LIKE.has(cmd) ? tokens.slice(1).filter((t) => !t.startsWith("-")) : [];
-  return { kind: "safe", reason: `read-only/analysis command '${cmd}'`, readPaths };
+  return {
+    kind: "safe",
+    reason: `read-only/analysis command '${cmd}'`,
+    readPaths,
+    sensitiveReadPaths,
+  };
 }

--- a/extensions/loom/exec-guard/policy.ts
+++ b/extensions/loom/exec-guard/policy.ts
@@ -1,6 +1,18 @@
 import { classifyBash } from "./bash-risk";
-import { isSensitivePath, isProtectedWritePath } from "./sensitive-read";
+import { isSensitivePath, isCredentialStore, isProtectedWritePath } from "./sensitive-read";
 import type { PolicyDeps, PolicyRequest, PolicyResult } from "./types";
+
+// A dedicated credential store's CONTENTS are never readable by the agent --
+// denied for every tier, not downgraded to an ask. This is the floor that closes
+// #183: a capable model that gets to read ~/.loom/config.json echoes the keys
+// straight into the provider's request logs. Approval can't override it.
+function denyCredentialStore(p: string): PolicyResult {
+  return {
+    decision: "deny",
+    category: "read:credential-store",
+    reason: `access to credential store ${p} blocked for all models`,
+  };
+}
 
 const FILE_WRITE_TOOLS = new Set(["write", "edit"]);
 // Read-like pi tools that take an optional `path`. grep reads file CONTENTS, so
@@ -47,13 +59,23 @@ export function decide(req: PolicyRequest, deps: PolicyDeps): PolicyResult {
     if (c.kind === "catastrophic") {
       return { decision: "deny", category: "bash:catastrophic", reason: c.reason };
     }
-    // Floor: detectable read-args of a "safe" command still face sensitive-read +
-    // the workspace jail. A read pointed outside the work dir prompts, same as a write.
-    for (const p of c.readPaths) {
-      const { inside, resolved } = deps.resolver.contains(p);
+    // Sensitive-read floor: every content-read target, including inside a pipe or
+    // compound command (closes the `cat secret | tool` evasion). A dedicated
+    // credential store is denied for ALL tiers; any other sensitive path
+    // downgrades to an ask (deny for weak / non-interactive).
+    for (const p of c.sensitiveReadPaths) {
+      const { resolved } = deps.resolver.contains(p);
+      if (isCredentialStore(resolved, deps.home)) {
+        return denyCredentialStore(p);
+      }
       if (isSensitivePath(resolved, deps.home)) {
         return finalizeAsk(req, "read:sensitive", `read of sensitive path ${p}`);
       }
+    }
+    // Workspace-jail floor: only confidently-parsed simple read commands, so a
+    // compound command's jail semantics stay unchanged (it falls to "unknown").
+    for (const p of c.readPaths) {
+      const { inside } = deps.resolver.contains(p);
       if (!inside) {
         return finalizeAsk(req, "read:escape", `read outside workspace: ${p}`);
       }
@@ -89,6 +111,9 @@ export function decide(req: PolicyRequest, deps: PolicyDeps): PolicyResult {
     const p = pick(req.toolInput, "path");
     if (p) {
       const { inside, resolved } = deps.resolver.contains(p);
+      if (isCredentialStore(resolved, deps.home)) {
+        return denyCredentialStore(p);
+      }
       if (isSensitivePath(resolved, deps.home)) {
         return finalizeAsk(req, "read:sensitive", `${req.toolName} of sensitive path ${p}`);
       }

--- a/extensions/loom/exec-guard/sensitive-read.ts
+++ b/extensions/loom/exec-guard/sensitive-read.ts
@@ -21,11 +21,22 @@ function within(abs: string, dir: string): boolean {
   return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
 }
 
-export function isSensitivePath(absPath: string, home: string): boolean {
+// Dedicated credential stores: the home-relative dirs and exact files above
+// that exist solely to hold secrets. The agent has no legitimate reason to read
+// their CONTENTS, so reads are denied for every model tier (not just downgraded
+// to an ask). This is the floor that closes #183 -- ~/.loom/config.json is a
+// store. The basename patterns (.env, *.pem, *.key, ...) are deliberately NOT
+// stores: those can be project fixtures, so they keep the ask/deny-by-tier path.
+export function isCredentialStore(absPath: string, home: string): boolean {
   const norm = path.normalize(absPath);
   for (const d of SENSITIVE_HOME_DIRS) if (within(norm, path.join(home, d))) return true;
   for (const f of SENSITIVE_HOME_FILES) if (norm === path.join(home, f)) return true;
-  if (SENSITIVE_BASENAME.test(path.basename(norm))) return true;
+  return false;
+}
+
+export function isSensitivePath(absPath: string, home: string): boolean {
+  if (isCredentialStore(absPath, home)) return true;
+  if (SENSITIVE_BASENAME.test(path.basename(path.normalize(absPath)))) return true;
   return false;
 }
 

--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -24,6 +24,7 @@ import { isSessionIndexEnabled } from "./session-index/is-enabled";
 import { registerConfusablesHint } from "./confusables-hint";
 import { registerExecGuard } from "./exec-guard";
 import { registerSandbox } from "./sandbox";
+import { registerSecretRedaction } from "./secret-redaction";
 import * as fs from "fs";
 import { getState, getNotebookPath, getNotebookWidgetMode, setNotebookWidgetMode } from "./state";
 import {
@@ -46,6 +47,10 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
   // decides allow/ask/deny; the sandbox only contains an allowed command's blast
   // radius). Default-on file-write confinement lives in the gate itself.
   registerSandbox(pi);
+  // Data-shaped backstop to the path-shaped gate: scrub known secret VALUES out
+  // of tool OUTPUT before it returns to the model, so an approved/slipped read
+  // (or an `env` dump) can't push API keys into the provider's logs (#183).
+  registerSecretRedaction(pi);
 
   setupUIBridge(pi);
   registerSessionLifecycle(pi);

--- a/extensions/loom/secret-redaction.ts
+++ b/extensions/loom/secret-redaction.ts
@@ -1,0 +1,129 @@
+/**
+ * Secret redaction for tool OUTPUT (#183).
+ *
+ * The exec-guard decides whether a path may be read; this is the data-shaped
+ * companion that ensures a known secret VALUE never rides a tool result back
+ * into the model's context (and from there into the provider's request logs).
+ * It is value-based by design: we redact the concrete keys Loom holds -- the
+ * provider/Galaxy API keys in ~/.loom/config.json and the secret-valued env
+ * vars the agent process carries -- so there are no false positives on ordinary
+ * output. It is a defense-in-depth backstop for the guard, and it also catches
+ * vectors the guard can't (an `env` dump, a key pasted into some other file).
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { loadConfig } from "../../shared/loom-config.js";
+import type { LoomConfig } from "../../shared/loom-config.js";
+
+export const REDACTED = "[redacted]";
+
+// Below this length a "secret" is too short to redact safely -- scrubbing a
+// 3-char value would mangle ordinary output. Real API keys are far longer.
+const MIN_SECRET_LEN = 8;
+
+// Env vars whose VALUE is a live secret. The agent process carries these at
+// runtime (the CLI exports the active provider's key from config; Orbit injects
+// the decrypted key when it spawns the brain), so an `env`/`printenv` dump would
+// otherwise leak them even when the config file itself is locked down. Only
+// secret-VALUED vars belong here -- not names like AWS_PROFILE.
+const SECRET_ENV_VARS = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_OAUTH_TOKEN",
+  "OPENAI_API_KEY",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "GROQ_API_KEY",
+  "MISTRAL_API_KEY",
+  "XAI_API_KEY",
+  "DEEPSEEK_API_KEY",
+  "OPENROUTER_API_KEY",
+  "CEREBRAS_API_KEY",
+  "AI_GATEWAY_API_KEY",
+  "AZURE_OPENAI_API_KEY",
+  "HF_TOKEN",
+  "GALAXY_API_KEY",
+];
+
+/** Minimal structural shape for a pi tool-result content item. */
+interface ContentItem {
+  type: string;
+  text?: string;
+}
+
+/**
+ * Gather the concrete secret strings to scrub: every API key in the config
+ * (plaintext apiKey AND the apiKeyEncrypted blob, for LLM providers and Galaxy
+ * profiles) plus the known secret-valued env vars. Pure -- env is passed in so
+ * it's testable. `testerId` is deliberately not a secret, so it survives (the
+ * #189 path can read it without leaking keys).
+ */
+export function collectSecretValues(
+  config: LoomConfig,
+  env: Record<string, string | undefined>,
+): string[] {
+  const out = new Set<string>();
+  const add = (v: unknown): void => {
+    if (typeof v === "string" && v.length >= MIN_SECRET_LEN) out.add(v);
+  };
+  for (const p of Object.values(config.llm?.providers ?? {})) {
+    add(p?.apiKey);
+    add(p?.apiKeyEncrypted);
+  }
+  for (const p of Object.values(config.galaxy?.profiles ?? {})) {
+    add(p?.apiKey);
+    add(p?.apiKeyEncrypted);
+  }
+  for (const name of SECRET_ENV_VARS) add(env[name]);
+  return [...out];
+}
+
+/**
+ * Replace every occurrence of each known secret with the placeholder. Literal
+ * (no regex, so key characters can't be misread as patterns); longest-first so a
+ * key that contains a shorter one is scrubbed whole. Short/empty values ignored.
+ */
+export function redactSecrets(text: string, secrets: Iterable<string>): string {
+  let out = text;
+  const sorted = [...secrets]
+    .filter((s) => s.length >= MIN_SECRET_LEN)
+    .sort((a, b) => b.length - a.length);
+  for (const s of sorted) {
+    if (out.includes(s)) out = out.split(s).join(REDACTED);
+  }
+  return out;
+}
+
+/**
+ * Redact text items of a tool-result content array. Returns a changed copy, or
+ * `null` if nothing matched (so the caller can no-op). Non-text items (images)
+ * pass through untouched; the original array is never mutated.
+ */
+export function redactContent<T extends ContentItem>(content: T[], secrets: string[]): T[] | null {
+  if (secrets.length === 0) return null;
+  let changed = false;
+  const next = content.map((c) => {
+    if (c && c.type === "text" && typeof c.text === "string") {
+      const red = redactSecrets(c.text, secrets);
+      if (red !== c.text) {
+        changed = true;
+        return { ...c, text: red };
+      }
+    }
+    return c;
+  });
+  return changed ? next : null;
+}
+
+/**
+ * Register the output-redaction hook. Runs after every tool and rewrites the
+ * result content the model receives, so a leaked key never reaches the provider.
+ * Reloads config each time so a key added mid-session is covered immediately;
+ * a clean result returns nothing (pi keeps the original).
+ */
+export function registerSecretRedaction(pi: ExtensionAPI): void {
+  pi.on("tool_result", async (event) => {
+    const secrets = collectSecretValues(loadConfig(), process.env);
+    const content = redactContent(event.content, secrets);
+    if (content) return { content };
+  });
+}

--- a/tests/activity-redaction.test.ts
+++ b/tests/activity-redaction.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { redactArgs } from "../extensions/loom/activity-hooks";
+import { redactArgs, summarizeResult } from "../extensions/loom/activity-hooks";
 
 describe("redactArgs", () => {
   it("whole-object redacts credential tools", () => {
@@ -59,5 +59,20 @@ describe("redactArgs", () => {
     const out = redactArgs("bash", { ApiKey: "x", AUTHORIZATION: "y" }) as Record<string, unknown>;
     expect(out.ApiKey).toBe("[redacted]");
     expect(out.AUTHORIZATION).toBe("[redacted]");
+  });
+});
+
+describe("summarizeResult", () => {
+  const KEY = "sk-ant-RESULT-SECRET-7777777";
+  it("scrubs known secret VALUES out of a tool result before it is logged", () => {
+    // bash results are not args -- a `cat`-style leak lands in the result text,
+    // which also feeds the on-disk activity log and the /feedback payload.
+    const out = summarizeResult(`{"apiKey":"${KEY}"}`, [KEY]);
+    expect(out).not.toContain(KEY);
+    expect(out).toContain("[redacted]");
+  });
+  it("passes ordinary results through unchanged", () => {
+    expect(summarizeResult("plain output", [KEY])).toBe("plain output");
+    expect(summarizeResult("plain output")).toBe("plain output");
   });
 });

--- a/tests/exec-guard-bash-risk.test.ts
+++ b/tests/exec-guard-bash-risk.test.ts
@@ -128,3 +128,31 @@ describe("classifyBash -- adversarial-review hardening", () => {
     );
   });
 });
+
+// sensitiveReadPaths surfaces content-read targets to the policy layer even when
+// the command is compound -- closing the `cat secret | tool` pipe evasion that
+// the report (#183) used to dodge the sensitive-read floor (SHELL_META forces
+// kind="unknown", so readPaths alone stays empty).
+describe("classifyBash -- sensitiveReadPaths (pipe-evasion floor)", () => {
+  const CFG = "/home/alice/.loom/config.json";
+  it("surfaces a content-read target from a simple command", () => {
+    expect(classifyBash(`cat ${CFG}`).sensitiveReadPaths).toContain(CFG);
+    expect(classifyBash(`grep apiKey ${CFG}`).sensitiveReadPaths).toContain(CFG);
+    expect(classifyBash(`head -n 5 ${CFG}`).sensitiveReadPaths).toContain(CFG);
+  });
+  it("surfaces the read target even when piped/compound (the reported evasion)", () => {
+    expect(classifyBash(`cat ${CFG} | python3 -m json.tool`).sensitiveReadPaths).toContain(CFG);
+    expect(classifyBash(`cat ${CFG} | base64`).sensitiveReadPaths).toContain(CFG);
+    expect(classifyBash(`echo start; cat ${CFG}`).sensitiveReadPaths).toContain(CFG);
+  });
+  it("does not surface a path that is only an auth arg to a non-reading command", () => {
+    // ssh reads the key to authenticate; it is not dumping contents to stdout.
+    expect(
+      classifyBash("ssh -i /home/alice/.ssh/id_rsa user@host").sensitiveReadPaths,
+    ).not.toContain("/home/alice/.ssh/id_rsa");
+  });
+  it("is empty for commands with no content-read verb", () => {
+    expect(classifyBash("ls -la /home/alice/.ssh").sensitiveReadPaths).toEqual([]);
+    expect(classifyBash("python train.py").sensitiveReadPaths).toEqual([]);
+  });
+});

--- a/tests/exec-guard-policy.test.ts
+++ b/tests/exec-guard-policy.test.ts
@@ -47,16 +47,63 @@ describe("decide", () => {
   it("safe bash allows", () => {
     expect(decide(req({ toolInput: { command: "ls -la" } }), deps).decision).toBe("allow");
   });
-  it("safe read-command on a sensitive path -> ask (trusted) / deny (weak)", () => {
+  it("read of a credential store is denied for ALL tiers (bash)", () => {
+    // hardened (#183): a dedicated credential store is never readable, even by a
+    // capable model with an interactive session to approve.
+    for (const tier of ["trusted", "weak"] as const)
+      expect(
+        decide(
+          req({ modelTier: tier, toolInput: { command: "cat /home/alice/.ssh/id_rsa" } }),
+          deps,
+        ).decision,
+        tier,
+      ).toBe("deny");
+  });
+  it("reading ~/.loom/config.json is denied for all tiers and via any path (#183)", () => {
+    const cfg = "/home/alice/.loom/config.json";
+    for (const tier of ["trusted", "weak"] as const)
+      expect(
+        decide(req({ modelTier: tier, toolInput: { command: `cat ${cfg}` } }), deps).decision,
+        `cat/${tier}`,
+      ).toBe("deny");
     expect(
-      decide(req({ toolInput: { command: "cat /home/alice/.ssh/id_rsa" } }), deps).decision,
-    ).toBe("ask");
+      decide(req({ toolName: "read", toolInput: { path: cfg } }), deps).decision,
+      "read tool",
+    ).toBe("deny");
+    // the reported evasion: a pipe forced kind="unknown" so the floor was skipped.
+    expect(
+      decide(req({ toolInput: { command: `cat ${cfg} | python3 -m json.tool` } }), deps).decision,
+      "piped",
+    ).toBe("deny");
+  });
+  it("the credential-store floor is NOT lifted by a trusted workspace", () => {
+    const cfg = { ...baseCfg, trustedWorkspaces: [CWD] };
     expect(
       decide(
-        req({ modelTier: "weak", toolInput: { command: "cat /home/alice/.ssh/id_rsa" } }),
+        req({ config: cfg, toolInput: { command: "cat /home/alice/.loom/config.json | base64" } }),
         deps,
       ).decision,
     ).toBe("deny");
+  });
+  it("a credential-SHAPED file that is not a dedicated store still asks/denies by tier", () => {
+    // basename .key/.pem can be a project fixture -> keep the prompt, don't hard-deny
+    expect(
+      decide(req({ toolName: "read", toolInput: { path: "/home/alice/project/server.key" } }), deps)
+        .decision,
+    ).toBe("ask");
+    expect(
+      decide(
+        req({
+          toolName: "read",
+          modelTier: "weak",
+          toolInput: { path: "/home/alice/project/server.key" },
+        }),
+        deps,
+      ).decision,
+    ).toBe("deny");
+    expect(
+      decide(req({ toolInput: { command: "cat /home/alice/project/secret.pem" } }), deps).decision,
+    ).toBe("ask");
   });
   it("write inside jail allows, outside asks (trusted) / denies (weak)", () => {
     expect(
@@ -73,37 +120,34 @@ describe("decide", () => {
       ).decision,
     ).toBe("deny");
   });
-  it("read sensitive -> ask/deny by tier", () => {
-    expect(
-      decide(req({ toolName: "read", toolInput: { path: "/home/alice/.aws/credentials" } }), deps)
-        .decision,
-    ).toBe("ask");
-    expect(
-      decide(
-        req({
-          toolName: "read",
-          modelTier: "weak",
-          toolInput: { path: "/home/alice/.aws/credentials" },
-        }),
-        deps,
-      ).decision,
-    ).toBe("deny");
-  });
-  it("grep/ls/find of a sensitive path -> ask (trusted) / deny (weak)", () => {
-    for (const tool of ["grep", "ls", "find"]) {
-      expect(
-        decide(req({ toolName: tool, toolInput: { path: "/home/alice/.ssh/id_rsa" } }), deps)
-          .decision,
-        tool,
-      ).toBe("ask");
+  it("read tool on a credential store is denied for ALL tiers", () => {
+    for (const tier of ["trusted", "weak"] as const)
       expect(
         decide(
-          req({ toolName: tool, modelTier: "weak", toolInput: { path: "/home/alice/.ssh" } }),
+          req({
+            toolName: "read",
+            modelTier: tier,
+            toolInput: { path: "/home/alice/.aws/credentials" },
+          }),
           deps,
         ).decision,
-        tool,
+        tier,
       ).toBe("deny");
-    }
+  });
+  it("grep/ls/find of a credential store is denied for ALL tiers", () => {
+    for (const tool of ["grep", "ls", "find"])
+      for (const tier of ["trusted", "weak"] as const)
+        expect(
+          decide(
+            req({
+              toolName: tool,
+              modelTier: tier,
+              toolInput: { path: "/home/alice/.ssh/id_rsa" },
+            }),
+            deps,
+          ).decision,
+          `${tool}/${tier}`,
+        ).toBe("deny");
   });
   it("grep with no path (searches cwd) is allowed", () => {
     expect(decide(req({ toolName: "grep", toolInput: { pattern: "TODO" } }), deps).decision).toBe(

--- a/tests/exec-guard-sensitive-read.test.ts
+++ b/tests/exec-guard-sensitive-read.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   isSensitivePath,
+  isCredentialStore,
   isProtectedWritePath,
 } from "../extensions/loom/exec-guard/sensitive-read";
 
@@ -28,6 +29,42 @@ describe("isSensitivePath", () => {
   it("allows ordinary project files", () => {
     expect(isSensitivePath("/home/alice/project/notebook.md", HOME)).toBe(false);
     expect(isSensitivePath("/home/alice/project/data/reads.fastq", HOME)).toBe(false);
+  });
+});
+
+// Dedicated credential stores: a subset of sensitive paths whose CONTENTS the
+// agent has no business reading, so reads are denied for ALL model tiers (not
+// downgraded to an ask). This is the floor that closes #183 -- ~/.loom/config.json
+// is a store; a credential-SHAPED file that might be a project fixture is not.
+describe("isCredentialStore", () => {
+  it("flags the dedicated home credential stores (dirs + exact files)", () => {
+    for (const p of [
+      "/home/alice/.ssh/id_rsa",
+      "/home/alice/.aws/credentials",
+      "/home/alice/.gnupg/secring.gpg",
+      "/home/alice/.config/gcloud/access_tokens.db",
+      "/home/alice/.kube/config",
+      "/home/alice/.docker/config.json",
+      "/home/alice/Library/Keychains/login.keychain-db",
+      "/home/alice/.netrc",
+      "/home/alice/.pgpass",
+      "/home/alice/.npmrc",
+      "/home/alice/.loom/config.json",
+    ])
+      expect(isCredentialStore(p, HOME), p).toBe(true);
+  });
+  it("does NOT flag credential-shaped files that may be project fixtures", () => {
+    // sensitive by basename, but not a dedicated store -> stays an ask, not a deny
+    expect(isCredentialStore("/home/alice/project/.env", HOME)).toBe(false);
+    expect(isCredentialStore("/home/alice/project/server.key", HOME)).toBe(false);
+    expect(isCredentialStore("/tmp/foo.pem", HOME)).toBe(false);
+    // every store is still sensitive; the inverse just isn't true
+    expect(isSensitivePath("/home/alice/project/.env", HOME)).toBe(true);
+  });
+  it("does NOT flag ordinary files, and is not fooled by lookalikes", () => {
+    expect(isCredentialStore("/home/alice/project/notebook.md", HOME)).toBe(false);
+    expect(isCredentialStore("/home/alice/.loom/analyses/proj/config.json", HOME)).toBe(false);
+    expect(isCredentialStore("/home/alice/.sshconfig", HOME)).toBe(false);
   });
 });
 

--- a/tests/secret-redaction.test.ts
+++ b/tests/secret-redaction.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  collectSecretValues,
+  redactSecrets,
+  redactContent,
+  REDACTED,
+} from "../extensions/loom/secret-redaction";
+
+describe("collectSecretValues", () => {
+  it("gathers plaintext + encrypted keys from llm providers and galaxy profiles", () => {
+    const config = {
+      llm: {
+        active: "anthropic",
+        providers: {
+          anthropic: { apiKey: "sk-ant-PLAINTEXT-000000000" },
+          google: { apiKeyEncrypted: "ENCRYPTEDBLOBaaaaaaaa==" },
+        },
+      },
+      galaxy: {
+        active: "main",
+        profiles: { main: { apiKey: "galaxy-key-1111111111" } },
+      },
+    } as never;
+    const secrets = collectSecretValues(config, {});
+    expect(secrets).toContain("sk-ant-PLAINTEXT-000000000");
+    expect(secrets).toContain("ENCRYPTEDBLOBaaaaaaaa==");
+    expect(secrets).toContain("galaxy-key-1111111111");
+  });
+
+  it("includes the secret-valued env vars the agent process carries at runtime", () => {
+    const secrets = collectSecretValues({} as never, {
+      GALAXY_API_KEY: "galaxy-env-2222222222",
+      ANTHROPIC_API_KEY: "sk-ant-env-3333333333",
+      PATH: "/usr/bin", // not a secret var -> ignored
+    });
+    expect(secrets).toContain("galaxy-env-2222222222");
+    expect(secrets).toContain("sk-ant-env-3333333333");
+    expect(secrets).not.toContain("/usr/bin");
+  });
+
+  it("ignores short/empty values so ordinary output isn't mangled", () => {
+    const config = { llm: { active: "x", providers: { x: { apiKey: "abc" } } } } as never;
+    expect(collectSecretValues(config, { GALAXY_API_KEY: "" })).toEqual([]);
+  });
+
+  it("tolerates a config with no llm/galaxy sections", () => {
+    expect(collectSecretValues({} as never, {})).toEqual([]);
+  });
+});
+
+describe("redactSecrets", () => {
+  const KEY = "sk-ant-api03-SECRETVALUE-9999";
+  it("replaces every occurrence of a known secret", () => {
+    const out = redactSecrets(`key=${KEY} and again ${KEY}`, [KEY]);
+    expect(out).not.toContain(KEY);
+    expect(out).toBe(`key=${REDACTED} and again ${REDACTED}`);
+  });
+  it("leaves text untouched when no secret is present", () => {
+    expect(redactSecrets("nothing secret here", [KEY])).toBe("nothing secret here");
+  });
+  it("redacts the longer secret first when one contains another", () => {
+    const short = "longenoughsecret";
+    const long = "longenoughsecret-with-suffix";
+    expect(redactSecrets(`val=${long}`, [short, long])).toBe(`val=${REDACTED}`);
+  });
+  it("ignores empty/short secrets", () => {
+    expect(redactSecrets("abc value", ["", "ab"])).toBe("abc value");
+  });
+});
+
+describe("redactContent", () => {
+  const KEY = "sk-ant-SECRET-444444444444";
+  it("redacts text content and returns a changed copy without mutating the original", () => {
+    const content = [{ type: "text", text: `here is ${KEY}` }];
+    const out = redactContent(content, [KEY]);
+    expect(out).not.toBeNull();
+    expect(out?.[0].text).toBe(`here is ${REDACTED}`);
+    expect(content[0].text).toBe(`here is ${KEY}`); // original untouched
+  });
+  it("returns null when nothing changed, so the hook can no-op", () => {
+    expect(redactContent([{ type: "text", text: "clean" }], [KEY])).toBeNull();
+    expect(redactContent([{ type: "text", text: "x" }], [])).toBeNull();
+  });
+  it("leaves non-text content (images) alone", () => {
+    const content = [{ type: "image", data: "binarydata", mimeType: "image/png" }];
+    expect(redactContent(content, [KEY])).toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #183.

Reported from Orbit beta (Linux 0.3.1): asked to confirm the tester ID, a capable model just `cat`'d `~/.loom/config.json` and echoed the Anthropic/Google/DeepSeek/Galaxy keys back into chat -- which pushes them straight into the provider's request logs.

The root problem is that every control we had was path/identity-shaped, not data-shaped. The sensitive-path guard only *denied weak models*; a capable model got an `ask`, and once you approve (or have trusted the workspace) the full plaintext file flows right back to the model. And nothing ever redacted tool *output* -- the existing redaction only scrubs tool *arguments* on their way into `activity.jsonl`. There was also a pipe evasion: `cat config.json | python3` trips the shell-meta check, so `classifyBash` returns "unknown" with no read paths and the sensitive floor never runs (that's the `exit 0` in the report).

So this takes two layers:

**Hard-deny the credential stores, for every model tier.** A new `isCredentialStore()` splits the sensitive set: the dedicated stores (the home credential dirs + exact files like `~/.loom/config.json`) are now denied outright -- approval can't override them -- while credential-*shaped* files (`.env`, `*.pem`, `*.key`) keep the ask/deny-by-tier behavior since those can be legit project fixtures. `classifyBash` also surfaces per-segment content-read targets, so `cat config.json | python3` is caught while `ssh -i ~/.ssh/key` (an auth arg, not a content dump) isn't falsely denied.

**Redact known secret values out of tool output.** A `tool_result` hook scrubs the concrete secrets Loom holds -- the provider/Galaxy keys from config (plaintext and the encrypted blob) plus the secret-valued env vars the process carries -- before the result reaches the model. Value-based on purpose: only actual keys get touched, so no false positives on normal output, and `testerId` passes through untouched. The same scrub runs over the activity-log summary that feeds `/feedback`. This is the data-shaped backstop -- it also catches things the guard can't, like an `env` dump.

Deliberately out of scope (follow-ups): moving secrets off plaintext disk into the OS keychain (partly exists via `apiKeyEncrypted`, but CLI/Linux have no usable `safeStorage`), and this can't beat a model that *deliberately* encodes a secret (`base64 config.json`).

Heads-up on the #189 overlap: `testerId` isn't a secret so it survives redaction, but config.json reads are now hard-denied -- so #189 ("what's my tester ID") needs a narrow accessor that returns only `testerId`, not a `cat` of the whole file.

Test-first; 452 tests green, typecheck/lint clean.