### PR TITLE
Recover the UI when a provider call dies silently instead of hanging on "thinking"

### DIFF
--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -8,6 +8,15 @@ import { loadConfig } from "./config.js";
 import { resolveLlmApiKey, resolveGalaxyApiKey } from "./secure-config.js";
 import { loadSessionHistory, newestSessionFile } from "./session-replay.js";
 import { collectDescendantsOf } from "./proc-monitor.js";
+import { TurnWatchdog } from "./turn-watchdog.js";
+
+/**
+ * How long the brain may stay completely silent mid-turn before Orbit treats the
+ * turn as stalled and recovers the UI (#185). Generous on purpose: tool runs and
+ * UI modals are excluded by the watchdog, so the only window this guards is
+ * "waiting on the model", where multi-minute silence is unambiguously a failure.
+ */
+export const TURN_SILENCE_TIMEOUT_MS = 120_000;
 
 const PROVIDER_ENV_MAP: Record<string, string> = {
   anthropic: "ANTHROPIC_API_KEY",
@@ -214,9 +223,17 @@ export class AgentManager {
   private static readonly MAX_RESTARTS_PER_WINDOW = 3;
   private static readonly RESTART_WINDOW_MS = 60_000;
 
+  // Breaks the "stuck on thinking" hang (#185): fires when a turn goes silent
+  // long enough that the provider call must have failed or stalled.
+  private readonly watchdog: TurnWatchdog;
+
   constructor(window: BrowserWindow, cwd: string) {
     this.window = window;
     this.cwd = cwd;
+    this.watchdog = new TurnWatchdog({
+      timeoutMs: TURN_SILENCE_TIMEOUT_MS,
+      onTimeout: () => this.handleTurnStalled(),
+    });
   }
 
   /** Reset session continuity (e.g. when switching to a new analysis directory). */
@@ -505,6 +522,11 @@ export class AgentManager {
     const json = JSON.stringify(obj);
     log("→ stdin:", json.slice(0, 200));
     this.process.stdin.write(json + "\n");
+    // A prompt (including streamed steer/followUp) starts a turn we must watch
+    // for a silent stall. Other commands (abort, set_model, ...) don't.
+    if (obj.type === "prompt") {
+      this.watchdog.promptSent();
+    }
   }
 
   /**
@@ -576,6 +598,8 @@ export class AgentManager {
     // Process death (clean or otherwise) ends any in-flight turn.
     if (status === "stopped" || status === "error") {
       this.turnActive = false;
+      // The process is gone; never let a pending watchdog fire against it.
+      this.watchdog.stop();
     }
     log("status:", status, message || "");
     // During a silent restart we suppress the transient stopped→running flicker;
@@ -584,6 +608,30 @@ export class AgentManager {
     if (!this.window.isDestroyed()) {
       this.window.webContents.send("agent:status", status, message);
     }
+  }
+
+  /**
+   * The brain went silent mid-turn (#185): a provider call failed or stalled
+   * without emitting a terminal event, so the renderer is pinned on "thinking".
+   * Surface a recoverable error through the existing `error` event path, mark the
+   * turn done, and best-effort tell the brain to abort so its streaming state
+   * clears and the next prompt isn't queued behind a dead turn.
+   */
+  private handleTurnStalled(): void {
+    log("turn stalled: no brain activity for", TURN_SILENCE_TIMEOUT_MS, "ms");
+    this.turnActive = false;
+    if (!this.window.isDestroyed()) {
+      this.window.webContents.send("agent:event", {
+        type: "error",
+        message:
+          "The assistant stopped responding. The request may have failed or " +
+          "been blocked -- please try again.",
+      });
+    }
+    // Best-effort: unstick pi's streaming state so the next prompt runs. If the
+    // brain is wedged on a dead socket this may not land, but the UI is already
+    // recovered either way.
+    this.send({ type: "abort" });
   }
 
   private handleLine(line: string): void {
@@ -600,6 +648,10 @@ export class AgentManager {
     const type = data.type as string;
     const noisy = type === "message_update" || type === "tool_execution_update";
     log("← event:", type, noisy ? "" : JSON.stringify(data).slice(0, 150));
+
+    // Any line from the brain is a sign of life: reset/pause/disarm the stall
+    // watchdog before we act on (or early-return from) this event.
+    this.watchdog.observe(type);
 
     if (type === "response" && data.id) {
       const pending = this.pendingResponses.get(data.id as string);

--- a/app/src/main/turn-watchdog.ts
+++ b/app/src/main/turn-watchdog.ts
@@ -1,0 +1,102 @@
+/**
+ * Watchdog that breaks the "stuck on thinking" hang (#185).
+ *
+ * Orbit clears its "...thinking" indicator only when the brain emits a terminal
+ * event (`agent_end` / `error` / `message_end` with an error stop reason). When a
+ * cloud provider call fails or stalls *after* prompt preflight, pi can emit no
+ * terminal event at all -- the RPC layer swallows a post-preflight throw, and a
+ * truly stalled socket never resolves -- so the UI spins forever with no error,
+ * no timeout, no recovery.
+ *
+ * This watchdog is the shell-side backstop: while a prompt is in flight it arms a
+ * silence timer, resets it on every byte of brain activity, and fires if the
+ * brain goes completely silent for `timeoutMs`. It deliberately pauses for the
+ * whole tool-execution window and while a UI modal is open, since those are
+ * legitimate long/indefinite waits rather than a stalled provider call.
+ */
+export interface TurnWatchdogConfig {
+  /** How long the brain may stay silent mid-turn before we treat it as stalled. */
+  timeoutMs: number;
+  /** Invoked when a turn stalls. The watchdog is already disarmed when this runs. */
+  onTimeout: () => void;
+}
+
+export class TurnWatchdog {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  // A user prompt is in flight (turn started, not yet terminal).
+  private active = false;
+  // The brain is legitimately blocked (running a tool, or awaiting a modal),
+  // so silence is expected and must not be mistaken for a stall.
+  private paused = false;
+
+  constructor(private readonly config: TurnWatchdogConfig) {}
+
+  /** A user prompt was dispatched to the brain; begin watching for a stall. */
+  promptSent(): void {
+    this.active = true;
+    this.paused = false;
+    this.arm();
+  }
+
+  /**
+   * Observe a brain -> shell event by its `type`. Resets the silence window on
+   * normal activity, pauses across tool/modal waits, and disarms on terminal
+   * events. No-ops when no turn is in flight.
+   */
+  observe(eventType: string): void {
+    if (!this.active) return;
+    switch (eventType) {
+      case "agent_end":
+      case "error":
+        // Turn resolved (success or surfaced error) -- nothing to guard.
+        this.stop();
+        return;
+      case "tool_execution_start":
+      case "extension_ui_request":
+        // Tool may run long; a modal may wait on the user indefinitely. Pause
+        // until the brain produces output again.
+        this.paused = true;
+        this.clearTimer();
+        return;
+      case "tool_execution_update":
+        // Liveness mid-tool, but the tool can still go silent afterward. Stay
+        // paused for the whole tool window rather than re-arming here.
+        return;
+      case "tool_execution_end":
+        // Back to waiting on the model.
+        this.paused = false;
+        this.arm();
+        return;
+      default:
+        // Normal turn lifecycle / streaming (agent_start, message_*, turn_*,
+        // text_*). Any such event also implicitly resumes after a modal.
+        this.paused = false;
+        this.arm();
+        return;
+    }
+  }
+
+  /** Disarm entirely (process stop/restart, or after firing). */
+  stop(): void {
+    this.clearTimer();
+    this.active = false;
+    this.paused = false;
+  }
+
+  private arm(): void {
+    this.clearTimer();
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.active = false;
+      this.paused = false;
+      this.config.onTimeout();
+    }, this.config.timeoutMs);
+  }
+
+  private clearTimer(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/tests/agent-manager.test.ts
+++ b/tests/agent-manager.test.ts
@@ -2,7 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EventEmitter } from "node:events";
 
 const spawnMock = vi.fn();
-const createInterfaceMock = vi.fn(() => ({ on: vi.fn() }));
+// Capture the readline "line" handler so tests can feed brain stdout events
+// through handleLine() (the real one is wired in start()).
+let lineHandler: ((line: string) => void) | null = null;
+const createInterfaceMock = vi.fn(() => ({
+  on: (event: string, cb: (line: string) => void) => {
+    if (event === "line") lineHandler = cb;
+  },
+}));
 const existsSyncMock = vi.fn(() => false);
 const readdirSyncMock = vi.fn(() => []);
 
@@ -73,6 +80,7 @@ describe("AgentManager", () => {
     vi.resetModules();
     spawnMock.mockReset();
     createInterfaceMock.mockClear();
+    lineHandler = null;
     existsSyncMock.mockReset();
     existsSyncMock.mockReturnValue(false);
     readdirSyncMock.mockReset();
@@ -129,5 +137,88 @@ describe("AgentManager", () => {
     expect(manager.switchCwd("/analysis/same")).toBe(false);
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(firstProc.kill).not.toHaveBeenCalled();
+  });
+
+  describe("stall watchdog (#185)", () => {
+    function agentEvents(window: { webContents: { send: ReturnType<typeof vi.fn> } }) {
+      return window.webContents.send.mock.calls.filter((c: unknown[]) => c[0] === "agent:event");
+    }
+    function errorEvents(window: { webContents: { send: ReturnType<typeof vi.fn> } }) {
+      return agentEvents(window).filter(
+        (c: unknown[]) => (c[1] as { type?: string })?.type === "error",
+      );
+    }
+
+    it("surfaces a synthetic error when the brain goes silent after a prompt", async () => {
+      vi.useFakeTimers();
+      try {
+        const proc = makeProcess(101);
+        spawnMock.mockReturnValue(proc);
+        const { AgentManager, TURN_SILENCE_TIMEOUT_MS } = await import("../app/src/main/agent.js");
+        const window = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+        const manager = new AgentManager(window as any, "/analysis");
+        manager.start();
+
+        manager.send({ type: "prompt", message: "How many histories do I have?" });
+        expect(errorEvents(window)).toHaveLength(0);
+
+        vi.advanceTimersByTime(TURN_SILENCE_TIMEOUT_MS + 1);
+
+        const errors = errorEvents(window);
+        expect(errors).toHaveLength(1);
+        expect((errors[0][1] as { message?: string }).message).toMatch(/responding|stalled/i);
+        // Best-effort: tell the wedged brain to abort so the next prompt works.
+        expect(proc.stdin.write).toHaveBeenCalledWith(expect.stringMatching(/"type":"abort"/));
+        // Turn is no longer considered active after recovery.
+        expect(manager.getStatusSnapshot().turnActive).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not fire when the brain keeps streaming activity", async () => {
+      vi.useFakeTimers();
+      try {
+        const proc = makeProcess(101);
+        spawnMock.mockReturnValue(proc);
+        const { AgentManager, TURN_SILENCE_TIMEOUT_MS } = await import("../app/src/main/agent.js");
+        const window = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+        const manager = new AgentManager(window as any, "/analysis");
+        manager.start();
+
+        manager.send({ type: "prompt", message: "hi" });
+        // Brain stays alive: an event arrives just before each deadline.
+        for (let i = 0; i < 4; i++) {
+          vi.advanceTimersByTime(TURN_SILENCE_TIMEOUT_MS - 1);
+          lineHandler?.(JSON.stringify({ type: "message_update" }));
+        }
+
+        expect(errorEvents(window)).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("disarms on agent_end so a completed turn never false-fires", async () => {
+      vi.useFakeTimers();
+      try {
+        const proc = makeProcess(101);
+        spawnMock.mockReturnValue(proc);
+        const { AgentManager, TURN_SILENCE_TIMEOUT_MS } = await import("../app/src/main/agent.js");
+        const window = { isDestroyed: () => false, webContents: { send: vi.fn() } };
+        const manager = new AgentManager(window as any, "/analysis");
+        manager.start();
+
+        manager.send({ type: "prompt", message: "hi" });
+        lineHandler?.(JSON.stringify({ type: "agent_start" }));
+        lineHandler?.(JSON.stringify({ type: "agent_end" }));
+
+        vi.advanceTimersByTime(TURN_SILENCE_TIMEOUT_MS * 3);
+
+        expect(errorEvents(window)).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/tests/turn-watchdog.test.ts
+++ b/tests/turn-watchdog.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TurnWatchdog } from "../app/src/main/turn-watchdog.js";
+
+const TIMEOUT = 1000;
+
+describe("TurnWatchdog", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function make() {
+    const onTimeout = vi.fn();
+    const watchdog = new TurnWatchdog({ timeoutMs: TIMEOUT, onTimeout });
+    return { watchdog, onTimeout };
+  }
+
+  it("fires onTimeout when the brain goes silent after a prompt", () => {
+    const { watchdog, onTimeout } = make();
+    watchdog.promptSent();
+
+    vi.advanceTimersByTime(TIMEOUT);
+
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire while a turn is idle (no prompt in flight)", () => {
+    const { watchdog, onTimeout } = make();
+
+    vi.advanceTimersByTime(TIMEOUT * 5);
+
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("ignores events observed before a prompt is sent", () => {
+    const { watchdog, onTimeout } = make();
+
+    // A stray lifecycle event with no active turn must not arm the watchdog.
+    watchdog.observe("agent_start");
+    vi.advanceTimersByTime(TIMEOUT * 5);
+
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("resets the silence window each time the brain emits an event", () => {
+    const { watchdog, onTimeout } = make();
+    watchdog.promptSent();
+
+    // Events keep arriving just before each deadline -> never fires.
+    for (let i = 0; i < 5; i++) {
+      vi.advanceTimersByTime(TIMEOUT - 1);
+      watchdog.observe("message_update");
+    }
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    // ...then the brain goes silent for a full window.
+    vi.advanceTimersByTime(TIMEOUT);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("disarms on agent_end (normal completion)", () => {
+    const { watchdog, onTimeout } = make();
+    watchdog.promptSent();
+    watchdog.observe("agent_end");
+
+    vi.advanceTimersByTime(TIMEOUT * 5);
+
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("disarms on a surfaced error event", () => {
+    const { watchdog, onTimeout } = make();
+    watchdog.promptSent();
+    watchdog.observe("error");
+
+    vi.advanceTimersByTime(TIMEOUT * 5);
+
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("pauses for the whole tool-execution window so long tools don't false-fire", () => {
+    const { watchdog, onTimeout } = make();
+    watchdog.promptSent();
+    watchdog.observe("tool_execution_start");
+
+    // Tool runs far longer than the silence window, emitting nothing or only
+    // sporadic progress -- must not be mistaken for a stalled provider call.
+    vi.advanceTimersByTime(TIMEOUT * 10);
+    watchdog.observe("tool_execution_update");
+    vi.advanceTimersByTime(TIMEOUT * 10);
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    // Once the tool finishes we're waiting on the model again -> re-armed.
+    watchdog.observe("tool_execution_end");
+    vi.advanceTimersByTime(TIMEOUT);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("pauses while a UI modal is open and resumes when the brain continues", () => {
+    const { watchdog, onTimeout } = make();
+    watchdog.promptSent();
+    watchdog.observe("extension_ui_request");
+
+    // User takes their time answering the modal; brain is blocked on stdin.
+    vi.advanceTimersByTime(TIMEOUT * 10);
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    // Brain resumes (emits lifecycle activity) -> watchdog re-arms.
+    watchdog.observe("message_update");
+    vi.advanceTimersByTime(TIMEOUT);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("stop() disarms an in-flight turn", () => {
+    const { watchdog, onTimeout } = make();
+    watchdog.promptSent();
+    watchdog.stop();
+
+    vi.advanceTimersByTime(TIMEOUT * 5);
+
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("only fires once per stalled turn", () => {
+    const { watchdog, onTimeout } = make();
+    watchdog.promptSent();
+
+    vi.advanceTimersByTime(TIMEOUT * 5);
+
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #185.

When a cloud LLM call fails or stalls *after* prompt preflight, the brain can emit no terminal event at all, so Orbit stays pinned on "...thinking" forever -- no error, no timeout, no recovery. Two ways it happens:

- pi's RPC layer swallows a throw that lands after preflight succeeds (`rpc-mode.js` neutralizes the prompt `.catch` once `preflightSucceeded`), so e.g. a Gemini geo-block 400 that propagates as an exception just vanishes.
- A genuinely stalled socket never resolves -- no throw, no response, same silence.

The renderer only clears "thinking" on a terminal event (`agent_end` / `error` / `message_end` with an error stop reason), and there was no timeout anywhere. A crash is handled (exit → restart); a silent-but-alive brain wasn't.

This adds a main-process silence watchdog (`TurnWatchdog`). While a prompt is in flight it watches for any sign of life from the brain; if the brain goes completely silent past 120s it surfaces a recoverable error through the existing error path and tells the brain to abort so the next prompt still works. It pauses for the whole tool-execution window and while a UI modal is open, since those are legitimate long or indefinite waits -- healthy long-running turns don't trip it.

Scope is just the shell robustness gap: a failed or blocked call must surface an error or time out, never hang. The provider-specific handling for the Gemini geo-block lives in #184 / #192; this is the universal backstop that also covers the stalled-socket case.

Tests are TDD: new `TurnWatchdog` unit tests plus integration tests in the AgentManager suite (stall fires + aborts + clears the turn; streaming activity doesn't false-fire; agent_end disarms). Full root suite green.