### PR TITLE
Fix SVG file previews vanishing after first paint

### DIFF
--- a/app/src/renderer/files/file-viewer.ts
+++ b/app/src/renderer/files/file-viewer.ts
@@ -7,6 +7,7 @@
  */
 
 import { renderMarkdown } from "../chat/markdown.js";
+import { extOf, imagePreviewBlob } from "./image-preview.js";
 
 type FileKind = "text" | "image" | "pdf" | "binary";
 
@@ -73,17 +74,6 @@ const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"]);
 
 const PDF_EXTS = new Set([".pdf"]);
 
-function extOf(path: string): string {
-  const base = path.split("/").pop() ?? "";
-  // Handle .gz / .bz2 / .xz / .zst suffixes — strip and look at the inner ext.
-  // (Useful for things like sample.vcf.gz that should still be recognized as
-  // text in spirit; we treat the compressed version as binary because we
-  // can't decompress in the renderer, but exposing the inner ext is harmless.)
-  const dot = base.lastIndexOf(".");
-  if (dot <= 0) return "";
-  return base.slice(dot).toLowerCase();
-}
-
 function kindOf(path: string): FileKind {
   const ext = extOf(path);
   if (!ext) return "text"; // no extension → treat as text
@@ -91,24 +81,6 @@ function kindOf(path: string): FileKind {
   if (IMAGE_EXTS.has(ext)) return "image";
   if (PDF_EXTS.has(ext)) return "pdf";
   return "binary";
-}
-
-function mimeForImage(ext: string): string {
-  switch (ext) {
-    case ".png":
-      return "image/png";
-    case ".jpg":
-    case ".jpeg":
-      return "image/jpeg";
-    case ".gif":
-      return "image/gif";
-    case ".svg":
-      return "image/svg+xml";
-    case ".webp":
-      return "image/webp";
-    default:
-      return "application/octet-stream";
-  }
 }
 
 function formatBytes(n: number): string {
@@ -288,11 +260,9 @@ export class FileViewer {
   private reloadImage(bytes: Uint8Array): void {
     const img = this.container.querySelector<HTMLImageElement>("img.file-viewer-image");
     if (!img) return;
-    const buf = bytes.buffer.slice(
-      bytes.byteOffset,
-      bytes.byteOffset + bytes.byteLength,
-    ) as ArrayBuffer;
-    const blob = new Blob([buf]);
+    // Must keep the MIME type — a typeless blob: URL loads raster formats fine
+    // but breaks SVG, which is what made previews vanish on the next reload (#188).
+    const blob = imagePreviewBlob(this.currentPath ?? "", bytes);
     const nextUrl = URL.createObjectURL(blob);
     const prev = this.currentImageUrl;
     this.currentImageUrl = nextUrl;
@@ -523,13 +493,7 @@ export class FileViewer {
     const wrap = document.createElement("div");
     wrap.className = "file-viewer-image-wrap";
 
-    const ext = extOf(relPath);
-    const mime = mimeForImage(ext);
-    // Copy into a fresh ArrayBuffer to satisfy Blob's BlobPart typing, which
-    // requires a plain ArrayBuffer (not ArrayBufferLike).
-    const buffer = new ArrayBuffer(bytes.byteLength);
-    new Uint8Array(buffer).set(bytes);
-    const blob = new Blob([buffer], { type: mime });
+    const blob = imagePreviewBlob(relPath, bytes);
     const url = URL.createObjectURL(blob);
     this.currentImageUrl = url;
 

--- a/app/src/renderer/files/image-preview.ts
+++ b/app/src/renderer/files/image-preview.ts
@@ -1,0 +1,52 @@
+/**
+ * Image-preview helpers, kept free of any DOM/Electron imports so they can be
+ * unit-tested in a plain Node environment.
+ *
+ * The one rule that matters here: a preview Blob must always carry the correct
+ * MIME type. Chromium will content-sniff raster formats (PNG/JPEG/GIF/WebP) out
+ * of a typeless blob: URL, but it refuses to sniff SVG — an <img> pointed at a
+ * typeless blob of SVG bytes silently fails to load and shows the broken-image
+ * icon. The first render and every on-disk reload must go through the same
+ * builder so neither path can drift back to a typeless blob. (#188)
+ */
+
+export function extOf(path: string): string {
+  const base = path.split("/").pop() ?? "";
+  // Handle .gz / .bz2 / .xz / .zst suffixes — strip and look at the inner ext.
+  // (Useful for things like sample.vcf.gz that should still be recognized as
+  // text in spirit; we treat the compressed version as binary because we
+  // can't decompress in the renderer, but exposing the inner ext is harmless.)
+  const dot = base.lastIndexOf(".");
+  if (dot <= 0) return "";
+  return base.slice(dot).toLowerCase();
+}
+
+export function mimeForImage(ext: string): string {
+  switch (ext) {
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".gif":
+      return "image/gif";
+    case ".svg":
+      return "image/svg+xml";
+    case ".webp":
+      return "image/webp";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+/**
+ * Build an object-URL-ready Blob for an image preview, tagged with the MIME
+ * type implied by `path`'s extension. Copies into a fresh ArrayBuffer so the
+ * Blob owns its bytes (the caller may hand us a Uint8Array that is a view into
+ * a larger buffer) and to satisfy Blob's BlobPart typing.
+ */
+export function imagePreviewBlob(path: string, bytes: Uint8Array): Blob {
+  const buffer = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(buffer).set(bytes);
+  return new Blob([buffer], { type: mimeForImage(extOf(path)) });
+}

--- a/tests/image-preview.test.ts
+++ b/tests/image-preview.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { extOf, mimeForImage, imagePreviewBlob } from "../app/src/renderer/files/image-preview.js";
+
+// Regression coverage for #188: SVG previews paint once, then turn into a
+// broken-image icon. The first render tagged the blob image/svg+xml, but the
+// on-disk reload path rebuilt a *typeless* blob. Chromium content-sniffs raster
+// formats out of a typeless blob: URL, but it will NOT sniff SVG — an <img>
+// pointed at a typeless blob of SVG bytes fails to load. The fix routes both the
+// initial render and the reload through imagePreviewBlob, so the MIME type is
+// always present. These tests pin that invariant on the shared builder.
+
+const SVG_BYTES = new TextEncoder().encode(
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><rect width="10" height="10"/></svg>',
+);
+
+describe("extOf", () => {
+  it("lower-cases the extension and is case-insensitive", () => {
+    expect(extOf("chart.SVG")).toBe(".svg");
+    expect(extOf("a/b/photo.JPG")).toBe(".jpg");
+  });
+});
+
+describe("mimeForImage", () => {
+  it("maps SVG to image/svg+xml", () => {
+    expect(mimeForImage(".svg")).toBe("image/svg+xml");
+  });
+
+  it("maps the raster formats", () => {
+    expect(mimeForImage(".png")).toBe("image/png");
+    expect(mimeForImage(".jpg")).toBe("image/jpeg");
+    expect(mimeForImage(".jpeg")).toBe("image/jpeg");
+    expect(mimeForImage(".gif")).toBe("image/gif");
+    expect(mimeForImage(".webp")).toBe("image/webp");
+  });
+});
+
+describe("imagePreviewBlob", () => {
+  it("tags an SVG blob with image/svg+xml so <img> can load it (#188)", () => {
+    const blob = imagePreviewBlob("figure.svg", SVG_BYTES);
+    expect(blob.type).toBe("image/svg+xml");
+  });
+
+  it("is case-insensitive about the extension", () => {
+    expect(imagePreviewBlob("Figure.SVG", SVG_BYTES).type).toBe("image/svg+xml");
+  });
+
+  it("tags raster previews with their own type", () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    expect(imagePreviewBlob("a.png", bytes).type).toBe("image/png");
+    expect(imagePreviewBlob("a.jpg", bytes).type).toBe("image/jpeg");
+  });
+
+  it("preserves the exact bytes", async () => {
+    const blob = imagePreviewBlob("figure.svg", SVG_BYTES);
+    expect(blob.size).toBe(SVG_BYTES.byteLength);
+    const roundTrip = new Uint8Array(await blob.arrayBuffer());
+    expect(roundTrip).toEqual(SVG_BYTES);
+  });
+
+  it("copies the bytes into a standalone buffer (no shared view aliasing)", () => {
+    // reloadImage hands us a Uint8Array that may be a view into a larger
+    // buffer; the blob must own an independent copy.
+    const backing = new Uint8Array([0, 0, 1, 2, 3, 0, 0]);
+    const view = backing.subarray(2, 5); // [1,2,3]
+    const blob = imagePreviewBlob("a.png", view);
+    expect(blob.size).toBe(3);
+  });
+});


### PR DESCRIPTION
Closes #188.

Clicking an SVG in the Files list rendered it for a moment, then it flipped
to the broken-image icon. Turned out the file viewer had two different
blob-building paths that had drifted apart: the initial render tagged the
blob `image/svg+xml`, but the on-disk reload path (`reloadImage`, which runs
on every `files:changed`) rebuilt a *typeless* blob. Chromium content-sniffs
raster formats out of a typeless `blob:` URL but won't sniff SVG, so the
`<img>` errored. Since the fs watcher fires on basically any change under the
cwd during an agent session, an open SVG got reloaded into a typeless blob
almost immediately after it first painted -- hence "shows for a second, then
breaks." Raster previews were fine because they sniff, which is why only SVG
broke.

The fix pulls the blob construction and its mime mapping into a small
DOM-free `image-preview.ts` helper and routes both the first render and the
reload through it, so the type can't drift again. Confirmed the mechanism in
real Chromium (typeless SVG blob -> onerror; typed -> loads; typeless PNG ->
loads), and added unit tests for the helper.

Not addressed here (pre-existing, separate): the image reload has no
unchanged-bytes guard like the text path does, so any open preview churns its
blob on every cwd change. Minor flicker, happy to do as a follow-up.