### PR TITLE
Show "What's new" on the first launch after an update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+Notable, user-facing changes to Loom and Orbit. Each release lists a short set of
+highlights; the full commit-level notes live on the GitHub release pages. Add a
+new `## [<version>] - <date>` block with a `### Highlights` list at release time.
+
+## [0.3.1] - 2026-06-05
+
+### Highlights
+
+- Reliability and release-pipeline fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,31 @@ Notable, user-facing changes to Loom and Orbit. Each release lists a short set o
 highlights; the full commit-level notes live on the GitHub release pages. Add a
 new `## [<version>] - <date>` block with a `### Highlights` list at release time.
 
-## [0.3.1] - 2026-06-05
+## [0.3.1] - 2026-06-04
 
 ### Highlights
 
-- Reliability and release-pipeline fixes
+- Connect any OpenAI-compatible model endpoint, with a one-click Jetstream preset
+- Orbit shows how full the context window is, right in the footer
+- Lower per-turn token use, plus `/compact` to trim conversation history on demand
+
+## [0.3.0] - 2026-06-03
+
+### Highlights
+
+- Orbit updates itself in place on macOS; the CLI now tells you when a new version is out (and `loom update` to get it)
+- Claude Opus 4.8 is available, with corrected pricing
+- `/orbit` hands a running CLI session off to the Orbit desktop app
+
+## [0.2.0] - 2026-06-02
+
+### Highlights
+
+- The agent's file writes are confined to your analysis directory by default, with an opt-in bash sandbox and a local-execution approval gate
+- Send feedback straight from Orbit or with `/feedback`
+
+## [0.1.1] - 2026-05-29
+
+### Highlights
+
+- Signed and notarized macOS builds

--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -30,6 +30,7 @@ const LOOM_BUNDLE_FILES = [
   "bin",
   "extensions",
   "shared",
+  "CHANGELOG.md",
   "package.json",
   "package-lock.json",
   "README.md",

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -558,6 +558,14 @@ export function registerIpcHandlers(agent: AgentManager): void {
     return await checkLatestVersion();
   });
 
+  // Running app version + packaged flag for the what's-new banner. Unlike
+  // version:check this never hits the network and ignores updateCheck -- the
+  // what's-new surface is local and must work even with update checks off.
+  ipcMain.handle("version:current", () => ({
+    version: app.getVersion(),
+    isPackaged: app.isPackaged,
+  }));
+
   // Opens the GitHub releases page in the user's default browser when they
   // click the "update available" banner. Hard-coded URL — renderer never
   // gets a generic openExternal capability.

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -151,6 +151,7 @@ export interface OrbitAPI {
     hasUpdate: boolean;
     releaseUrl: string;
   } | null>;
+  getVersion(): Promise<{ version: string; isPackaged: boolean }>;
   openReleasePage(url?: string): Promise<{ opened: boolean }>;
   restartToUpdate(): Promise<{ restarting: boolean }>;
   onUpdateDownloaded(cb: (info: { version: string }) => void): void;
@@ -257,6 +258,7 @@ const api: OrbitAPI = {
 
   listAllModels: () => ipcRenderer.invoke("models:list-all"),
   checkVersion: () => ipcRenderer.invoke("version:check"),
+  getVersion: () => ipcRenderer.invoke("version:current"),
   openReleasePage: (url) => ipcRenderer.invoke("version:open-release", url),
   restartToUpdate: () => ipcRenderer.invoke("update:restart"),
   onUpdateDownloaded: (cb) => {

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -15,6 +15,8 @@ import {
   capFeedbackPayload,
 } from "../../../shared/feedback-contract.js";
 import type { FeedbackPayload, FeedbackSysinfo } from "../../../shared/feedback-contract.js";
+import changelogRaw from "../../../CHANGELOG.md?raw";
+import { parseChangelog, decideWhatsNew, releaseUrlFor } from "../../../shared/whats-new.js";
 
 declare global {
   interface Window {
@@ -3918,6 +3920,82 @@ window.orbit.onProcUpdate((procs) => {
       // Linux (and any non-darwin): the GitHub-releases notify-link banner.
       void showNotifyLinkBanner();
     }
+  }
+}
+
+// ── What's-new (first launch after an update) ────────────────────────────────
+//
+// Backward-looking: compare the running version to a persisted stamp. Newer ->
+// show a banner that opens the highlights modal (accumulating any skipped
+// versions), then advance the stamp. Fresh install stamps silently. Packaged
+// builds only, so `npm start` dev versions never trigger it. Offline -- reads
+// the bundled CHANGELOG, no network.
+{
+  const wnBanner = document.getElementById("whatsnew-banner");
+  const wnVersionEl = document.getElementById("whatsnew-banner-version");
+  const wnOpenBtn = document.getElementById("whatsnew-banner-open");
+  const wnDismissBtn = document.getElementById("whatsnew-banner-dismiss");
+  const wnOverlay = document.getElementById("whatsnew-overlay");
+  const wnBody = document.getElementById("whatsnew-body");
+  const wnTitle = document.getElementById("whatsnew-title");
+  const wnClose = document.getElementById("whatsnew-close");
+  const wnGotIt = document.getElementById("whatsnew-got-it");
+  const wnNotes = document.getElementById("whatsnew-notes");
+
+  const WN_SEEN_KEY = "orbit:whatsnew-last-seen";
+  let wnReleaseUrl: string | null = null;
+
+  if (wnBanner && wnVersionEl && wnOpenBtn && wnDismissBtn && wnOverlay && wnBody) {
+    wnOpenBtn.addEventListener("click", () => wnOverlay.classList.remove("hidden"));
+    wnClose?.addEventListener("click", () => wnOverlay.classList.add("hidden"));
+    wnGotIt?.addEventListener("click", () => wnOverlay.classList.add("hidden"));
+    wnDismissBtn.addEventListener("click", () => wnBanner.classList.add("hidden"));
+    wnNotes?.addEventListener("click", () => {
+      if (wnReleaseUrl) void window.orbit.openReleasePage(wnReleaseUrl);
+    });
+
+    void (async () => {
+      try {
+        const { version, isPackaged } = await window.orbit.getVersion();
+        if (!isPackaged) return; // dev builds never show what's-new
+        let lastSeen: string | undefined;
+        try {
+          lastSeen = localStorage.getItem(WN_SEEN_KEY) ?? undefined;
+        } catch {}
+        const decision = decideWhatsNew(
+          parseChangelog(changelogRaw),
+          lastSeen,
+          version,
+          "accumulate",
+        );
+        if (decision.entries.length) {
+          wnVersionEl.textContent = version;
+          if (wnTitle) wnTitle.textContent = `What's new in ${version}`;
+          wnReleaseUrl = releaseUrlFor(version);
+          wnBody.replaceChildren();
+          for (const entry of decision.entries) {
+            const wrap = document.createElement("div");
+            wrap.className = "whatsnew-entry";
+            const h = document.createElement("h3");
+            h.textContent = entry.date ? `${entry.version} (${entry.date})` : entry.version;
+            const ul = document.createElement("ul");
+            for (const hi of entry.highlights) {
+              const li = document.createElement("li");
+              li.textContent = hi;
+              ul.appendChild(li);
+            }
+            wrap.append(h, ul);
+            wnBody.appendChild(wrap);
+          }
+          wnBanner.classList.remove("hidden");
+        }
+        if (decision.stamp) {
+          try {
+            localStorage.setItem(WN_SEEN_KEY, decision.stamp);
+          } catch {}
+        }
+      } catch {}
+    })();
   }
 }
 

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -48,6 +48,26 @@
           ×
         </button>
       </div>
+      <!-- What's-new banner. Shown on the first launch of a version newer than
+           the one last seen; clicking opens the highlights modal. Packaged
+           builds only; reads the bundled CHANGELOG (offline). -->
+      <div id="whatsnew-banner" class="hidden" role="status" aria-live="polite">
+        <span class="wn-banner-text">
+          ✨ Updated to Orbit <span id="whatsnew-banner-version"></span>
+        </span>
+        <button id="whatsnew-banner-open" class="wn-banner-link" type="button">
+          See what's new
+        </button>
+        <button
+          id="whatsnew-banner-dismiss"
+          class="wn-banner-dismiss"
+          type="button"
+          title="Dismiss"
+          aria-label="Dismiss what's-new notice"
+        >
+          ×
+        </button>
+      </div>
       <!-- Permissions-bypass banner. Shown only while the safety gate is off
            (guardian.dangerouslyBypassPermissions). Persistent and unmissable. -->
       <div id="bypass-banner" class="hidden" role="alert" aria-live="assertive">
@@ -696,6 +716,25 @@
           <div class="modal-actions">
             <button id="welcome-skip" class="plan-btn">Skip — set up later</button>
             <button id="welcome-save" class="plan-btn execute">Save and continue</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- What's-new highlights modal (opened from #whatsnew-banner). -->
+    <div id="whatsnew-overlay" class="modal-overlay hidden">
+      <div class="modal">
+        <div class="modal-header">
+          <h2 id="whatsnew-title">What's new</h2>
+          <button id="whatsnew-close" class="modal-close" type="button" aria-label="Close">
+            ×
+          </button>
+        </div>
+        <div class="modal-body" id="whatsnew-body"></div>
+        <div class="modal-footer">
+          <div class="modal-actions">
+            <button id="whatsnew-notes" class="plan-btn" type="button">Full release notes ↗</button>
+            <button id="whatsnew-got-it" class="plan-btn execute" type="button">Got it</button>
           </div>
         </div>
       </div>

--- a/app/src/renderer/raw-assets.d.ts
+++ b/app/src/renderer/raw-assets.d.ts
@@ -1,0 +1,6 @@
+// Vite text imports (`import s from "./x.md?raw"`). The app tsconfig sets no
+// `types`, so declare the module shape here for tsc.
+declare module "*?raw" {
+  const content: string;
+  export default content;
+}

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -209,15 +209,18 @@ a:visited {
    window. When a banner is showing it IS that top strip, so on darwin it has to
    double as the titlebar -- same drag + inset treatment .pane-title gets
    otherwise -- or it both collides with the lights and kills the drag region.
-   Only #update-banner needs the left inset (its text is left-aligned); the
-   bypass/sandbox banners center their text, which never reaches under the
-   lights. The buttons/links stay no-drag (mirrors the .pane-title rule). */
+   Only #update-banner and #whatsnew-banner need the left inset (their text is
+   left-aligned); the bypass/sandbox banners center their text, which never
+   reaches under the lights. The buttons/links stay no-drag (mirrors the
+   .pane-title rule). */
 body.platform-darwin #update-banner,
 body.platform-darwin #bypass-banner,
-body.platform-darwin #sandbox-banner {
+body.platform-darwin #sandbox-banner,
+body.platform-darwin #whatsnew-banner {
   -webkit-app-region: drag;
 }
-body.platform-darwin #update-banner {
+body.platform-darwin #update-banner,
+body.platform-darwin #whatsnew-banner {
   padding-left: 78px;
 }
 body.platform-darwin #update-banner button,
@@ -225,7 +228,9 @@ body.platform-darwin #update-banner a,
 body.platform-darwin #bypass-banner button,
 body.platform-darwin #bypass-banner a,
 body.platform-darwin #sandbox-banner button,
-body.platform-darwin #sandbox-banner a {
+body.platform-darwin #sandbox-banner a,
+body.platform-darwin #whatsnew-banner button,
+body.platform-darwin #whatsnew-banner a {
   -webkit-app-region: no-drag;
 }
 
@@ -2990,4 +2995,73 @@ body.platform-darwin #files-title {
 .file-viewer-stale-banner .file-viewer-btn {
   font-size: 10px;
   padding: 2px 8px;
+}
+
+/* What's-new banner -- mirrors #update-banner; shown once per upgrade. */
+#whatsnew-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 12px;
+  background: var(--accent-bg);
+  color: var(--text-bright);
+  border-bottom: 1px solid var(--border-strong);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  flex: 0 0 auto;
+}
+#whatsnew-banner.hidden {
+  display: none;
+}
+#whatsnew-banner .wn-banner-text {
+  flex: 1;
+}
+#whatsnew-banner-version {
+  font-weight: 600;
+  color: var(--accent);
+}
+#whatsnew-banner .wn-banner-link {
+  background: none;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  padding: 2px 8px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  font: inherit;
+}
+#whatsnew-banner .wn-banner-link:hover {
+  background: var(--accent);
+  color: var(--bg-deep);
+}
+#whatsnew-banner .wn-banner-dismiss {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 4px;
+}
+#whatsnew-banner .wn-banner-dismiss:hover {
+  color: var(--text-bright);
+}
+/* What's-new modal body */
+.whatsnew-entry {
+  margin-bottom: 16px;
+}
+.whatsnew-entry:last-child {
+  margin-bottom: 0;
+}
+.whatsnew-entry h3 {
+  font-size: 13px;
+  font-weight: 700;
+  margin: 0 0 6px;
+  color: var(--accent);
+}
+.whatsnew-entry ul {
+  margin: 0;
+  padding-left: 18px;
+}
+.whatsnew-entry li {
+  margin: 2px 0;
 }

--- a/app/vite.renderer.config.ts
+++ b/app/vite.renderer.config.ts
@@ -26,5 +26,8 @@ export default defineConfig({
     // subprocess keeps running. location.reload is [LegacyUnforgeable], so
     // patching it fails. Disabling HMR removes the WebSocket entirely.
     hmr: false,
+    fs: {
+      allow: [path.resolve(__dirname, "..")],
+    },
   },
 });

--- a/bin/loom.js
+++ b/bin/loom.js
@@ -31,6 +31,7 @@ const extensionPath = resolve(__dirname, "../extensions/loom");
 // the brain stays shell-neutral; the command no-ops when embedded in Orbit.
 const orbitHandoffPath = resolve(__dirname, "../extensions/orbit-handoff");
 const cliUpdatePath = resolve(__dirname, "../extensions/cli-update");
+const whatsNewPath = resolve(__dirname, "../extensions/whats-new");
 const updateCheckScript = resolve(__dirname, "update-check.js");
 
 // pi-mcp-adapter is what teaches Pi how to use MCP servers from mcp.json
@@ -557,6 +558,8 @@ const args = [
   orbitHandoffPath,
   "-e",
   cliUpdatePath,
+  "-e",
+  whatsNewPath,
   ...providerArgs,
   ...userArgs,
 ];

--- a/extensions/whats-new/index.ts
+++ b/extensions/whats-new/index.ts
@@ -1,0 +1,96 @@
+/**
+ * What's-new notice -- CLI-shell glue, NOT part of the loom brain.
+ *
+ * On the first session after an upgrade, surfaces the running version's curated
+ * highlights (from the shipped CHANGELOG.md) once via ctx.ui.notify, then stamps
+ * a sidecar so it shows once per upgrade. Also registers /whatsnew to re-view on
+ * demand. No-ops inside Orbit, which owns its own what's-new banner. Lives here,
+ * alongside cli-update, so extensions/loom/ stays shell-neutral.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { fileURLToPath } from "node:url";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+// bin/ and shared/ are siblings of extensions/.
+import { getLoomVersion } from "../../bin/update-check.js";
+import {
+  parseChangelog,
+  decideWhatsNew,
+  selectEntries,
+  formatHighlightsText,
+  releaseUrlFor,
+} from "../../shared/whats-new.js";
+
+// This file lives at <pkg>/extensions/whats-new/index.ts, so the package root is two up.
+const PKG_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const CHANGELOG_PATH = path.join(PKG_ROOT, "CHANGELOG.md");
+const SEEN_FILE = path.join(os.homedir(), ".loom", "whats-new-seen.json");
+
+function loadEntries() {
+  try {
+    return parseChangelog(fs.readFileSync(CHANGELOG_PATH, "utf-8"));
+  } catch {
+    return [];
+  }
+}
+
+function readSeen(): string | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(SEEN_FILE, "utf-8"));
+    return typeof parsed?.version === "string" ? parsed.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeSeen(version: string): void {
+  try {
+    fs.mkdirSync(path.dirname(SEEN_FILE), { recursive: true });
+    fs.writeFileSync(SEEN_FILE, JSON.stringify({ version }));
+  } catch {}
+}
+
+export default function whatsNewExtension(pi: ExtensionAPI): void {
+  let shown = false;
+  pi.on("before_agent_start", async (_event, ctx: ExtensionContext) => {
+    if (shown) return;
+    shown = true;
+    // Orbit owns its own what's-new banner for the embedded brain.
+    if (process.env.LOOM_SHELL_KIND === "orbit") return;
+    try {
+      const running = getLoomVersion();
+      const decision = decideWhatsNew(loadEntries(), readSeen(), running, "latest");
+      if (decision.entries.length) {
+        const body = formatHighlightsText(decision.entries);
+        ctx.ui.notify(`${body}\n  Full notes: /whatsnew  or  ${releaseUrlFor(running)}`, "info");
+      }
+      // Stamp even with no entries: silently advances the sidecar for versions
+      // without Highlights so we don't re-check on every later launch.
+      if (decision.stamp) writeSeen(decision.stamp);
+    } catch {
+      // A notice must never break a session.
+    }
+  });
+
+  pi.registerCommand("whatsnew", {
+    description: "Show what's new in this version of loom",
+    handler: async (_args: string | undefined, ctx: ExtensionContext) => {
+      try {
+        const running = getLoomVersion();
+        const entries = selectEntries(loadEntries(), undefined, running, "latest");
+        if (entries.length) {
+          ctx.ui.notify(
+            `${formatHighlightsText(entries)}\n  Full notes: ${releaseUrlFor(running)}`,
+            "info",
+          );
+        } else {
+          ctx.ui.notify(`No what's-new notes for loom ${running}.`, "info");
+        }
+      } catch {
+        ctx.ui.notify("Could not load what's-new notes.", "warning");
+      }
+    },
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
       "version": "0.91.1",
       "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
       "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -104,6 +105,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
       "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -118,6 +120,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -133,6 +136,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -147,6 +151,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -156,6 +161,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
@@ -167,6 +173,7 @@
       "version": "3.1048.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
       "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -192,6 +199,7 @@
       "version": "3.974.12",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
       "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -211,6 +219,7 @@
       "version": "3.972.38",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.38.tgz",
       "integrity": "sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.12",
@@ -227,6 +236,7 @@
       "version": "3.972.40",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.40.tgz",
       "integrity": "sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.12",
@@ -245,6 +255,7 @@
       "version": "3.972.42",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.42.tgz",
       "integrity": "sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.12",
@@ -269,6 +280,7 @@
       "version": "3.972.42",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.42.tgz",
       "integrity": "sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.12",
@@ -286,6 +298,7 @@
       "version": "3.972.43",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.43.tgz",
       "integrity": "sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "^3.972.38",
@@ -308,6 +321,7 @@
       "version": "3.972.38",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.38.tgz",
       "integrity": "sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.12",
@@ -324,6 +338,7 @@
       "version": "3.972.42",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.42.tgz",
       "integrity": "sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.12",
@@ -342,6 +357,7 @@
       "version": "3.1049.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1049.0.tgz",
       "integrity": "sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.12",
@@ -359,6 +375,7 @@
       "version": "3.972.42",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.42.tgz",
       "integrity": "sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.12",
@@ -376,6 +393,7 @@
       "version": "3.972.16",
       "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
       "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -391,6 +409,7 @@
       "version": "3.972.12",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
       "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -406,6 +425,7 @@
       "version": "3.972.20",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.20.tgz",
       "integrity": "sha512-LM6P0i+Lu6pi25oNw2nqxjRxiEOtLgPB7xIvHfa+FxHTRLg8wcgqu3qg2COl4QaT7Es2yCxYdeRLVYazKAwL8g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.12",
@@ -424,6 +444,7 @@
       "version": "3.997.10",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.10.tgz",
       "integrity": "sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -445,6 +466,7 @@
       "version": "3.996.27",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
       "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -461,6 +483,7 @@
       "version": "3.1048.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
       "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.11",
@@ -478,6 +501,7 @@
       "version": "3.973.8",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
       "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -491,6 +515,7 @@
       "version": "3.965.5",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
       "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -503,6 +528,7 @@
       "version": "3.972.24",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
       "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@nodable/entities": "2.1.0",
@@ -518,6 +544,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
       "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -749,6 +776,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -806,6 +834,7 @@
       "version": "0.78.0",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.78.0.tgz",
       "integrity": "sha512-q0hUrvT6ngT6cgBX0oIbzfQfmzztgdkZobP8OTL+sCOOBlnG6+1YRt8g7zO9CC/4NdeYEqa7uGqWdQhH0fjCLA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -3231,6 +3260,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
       "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3333,6 +3363,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -3350,6 +3381,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3362,6 +3394,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3374,12 +3407,14 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -3397,6 +3432,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -3412,6 +3448,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -3479,6 +3516,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
       "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.18.0",
@@ -3590,6 +3628,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
       "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3612,6 +3651,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3628,30 +3668,35 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
@@ -3662,30 +3707,35 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
       "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3962,6 +4012,7 @@
       "version": "3.24.3",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
       "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -3976,6 +4027,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
       "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.3",
@@ -3990,6 +4042,7 @@
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
       "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.3",
@@ -4004,6 +4057,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4016,6 +4070,7 @@
       "version": "4.7.3",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
       "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.3",
@@ -4030,6 +4085,7 @@
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
       "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.24.3",
@@ -4044,6 +4100,7 @@
       "version": "4.14.2",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
       "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4056,6 +4113,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -4069,6 +4127,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -4149,6 +4208,7 @@
       "version": "25.2.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.2.tgz",
       "integrity": "sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -4158,6 +4218,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4533,6 +4594,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -4591,6 +4653,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4600,6 +4663,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4625,6 +4689,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -4678,6 +4743,7 @@
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -4737,12 +4803,14 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
       "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4810,6 +4878,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/bundle-name": {
@@ -5000,6 +5069,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5012,6 +5082,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -5147,6 +5218,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5331,12 +5403,14 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -5359,6 +5433,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -5849,6 +5924,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -5891,6 +5967,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
       "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5907,6 +5984,7 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
       "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5946,6 +6024,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6047,6 +6126,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -6063,6 +6143,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -6075,6 +6156,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
@@ -6135,6 +6217,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
       "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -6150,6 +6233,7 @@
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
       "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "gaxios": "^7.0.0",
@@ -6255,6 +6339,7 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
       "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -6273,6 +6358,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
       "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -6294,6 +6380,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
       "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "gaxios": "^7.0.0",
@@ -6411,6 +6498,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -6424,6 +6512,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -6489,6 +6578,7 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -6563,6 +6653,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6630,6 +6721,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -6686,6 +6778,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
@@ -6702,6 +6795,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -6747,6 +6841,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -6758,6 +6853,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.1",
@@ -7347,6 +7443,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/magic-string": {
@@ -7503,6 +7600,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7578,6 +7676,7 @@
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7597,6 +7696,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -7740,6 +7840,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
       "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
@@ -7839,6 +7940,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
       "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.0",
@@ -7852,6 +7954,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -7861,6 +7964,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parseurl": {
@@ -7876,6 +7980,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
       "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-exists": {
@@ -7892,6 +7997,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
       "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8082,6 +8188,7 @@
       "version": "7.5.6",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
       "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8266,6 +8373,7 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
       "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^10.3.7"
@@ -8282,6 +8390,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -8302,12 +8411,14 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/rimraf/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -8323,6 +8434,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -8738,6 +8850,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8753,6 +8866,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -8767,6 +8881,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8780,6 +8895,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -8801,6 +8917,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
       "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8894,6 +9011,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
@@ -8913,6 +9031,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -8990,6 +9109,7 @@
       "version": "1.1.38",
       "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
       "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
@@ -9040,6 +9160,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpdf": {
@@ -9313,6 +9434,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -9365,6 +9487,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -9388,6 +9511,7 @@
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -9424,6 +9548,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
       "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bin/",
     "extensions/",
     "shared/",
+    "CHANGELOG.md",
     "README.md",
     "LICENSE"
   ],

--- a/shared/whats-new.d.ts
+++ b/shared/whats-new.d.ts
@@ -1,0 +1,31 @@
+// Types for the shell-neutral what's-new logic. Impl is shared/whats-new.js.
+export interface WhatsNewEntry {
+  version: string;
+  date?: string;
+  highlights: string[];
+}
+
+export interface WhatsNewDecision {
+  /** New lastSeen to persist, or null to leave the stamp unchanged. */
+  stamp: string | null;
+  /** Entries to display (possibly empty). */
+  entries: WhatsNewEntry[];
+}
+
+export type WhatsNewMode = "accumulate" | "latest";
+
+export function parseChangelog(markdown: string): WhatsNewEntry[];
+export function selectEntries(
+  all: WhatsNewEntry[],
+  lastSeen: string | undefined,
+  running: string,
+  mode: WhatsNewMode,
+): WhatsNewEntry[];
+export function decideWhatsNew(
+  all: WhatsNewEntry[],
+  lastSeen: string | undefined,
+  running: string,
+  mode: WhatsNewMode,
+): WhatsNewDecision;
+export function releaseUrlFor(version: string): string;
+export function formatHighlightsText(entries: WhatsNewEntry[]): string;

--- a/shared/whats-new.js
+++ b/shared/whats-new.js
@@ -1,0 +1,83 @@
+// Shell-neutral "what's new" logic: parse the curated CHANGELOG, decide whether
+// a freshly-upgraded user should see notes, and select which entries to show.
+// Pure and dependency-light (reuses the shared semver comparator) so it's unit-
+// testable from the root Vitest suite and usable from both Orbit and the CLI.
+
+import { isNewer, parseSemver } from "./version-compare.js";
+
+// "## [1.2.3] - 2026-01-02" or "## 1.2.3" (brackets + date optional).
+const HEADER_RE = /^##\s+\[?(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)\]?\s*(?:-\s*(.+?))?\s*$/;
+const BULLET_RE = /^[-*]\s+(.+?)\s*$/;
+
+/** Parse CHANGELOG markdown into entries (newest-first, file order). Only the
+ * `### Highlights` subsection of each version is collected; a version without
+ * one is skipped. Pure.
+ * @param {string} markdown @returns {import("./whats-new.js").WhatsNewEntry[]} */
+export function parseChangelog(markdown) {
+  const lines = String(markdown).replace(/\r\n/g, "\n").split("\n");
+  const entries = [];
+  let current = null;
+  let inHighlights = false;
+  for (const line of lines) {
+    const header = line.match(HEADER_RE);
+    if (header) {
+      if (current && current.highlights.length) entries.push(current);
+      current = { version: header[1], date: header[2]?.trim() || undefined, highlights: [] };
+      inHighlights = false;
+      continue;
+    }
+    if (!current) continue;
+    if (/^###\s+/.test(line)) {
+      inHighlights = /^###\s+highlights\b/i.test(line.trim());
+      continue;
+    }
+    if (inHighlights) {
+      const bullet = line.match(BULLET_RE);
+      if (bullet) current.highlights.push(bullet[1].trim());
+    }
+  }
+  if (current && current.highlights.length) entries.push(current);
+  return entries;
+}
+
+/** @param {string} a @param {string} b @returns {boolean} */
+function sameVersion(a, b) {
+  if (!parseSemver(a) || !parseSemver(b)) return false;
+  return !isNewer(a, b) && !isNewer(b, a);
+}
+
+/** Which entries to display.
+ * - "latest": just the running version's entry (0 or 1), ignoring lastSeen.
+ * - "accumulate": every entry with lastSeen < version <= running.
+ * Pure. */
+export function selectEntries(all, lastSeen, running, mode) {
+  if (mode === "latest") {
+    return all.filter((e) => sameVersion(e.version, running));
+  }
+  return all.filter(
+    (e) => (lastSeen ? isNewer(lastSeen, e.version) : true) && !isNewer(running, e.version),
+  );
+}
+
+/** Decide stamp + entries for a launch. Pure.
+ * - lastSeen unset (fresh install): stamp running, show nothing.
+ * - running not newer than lastSeen: no stamp, nothing.
+ * - otherwise: stamp running, show selected entries. */
+export function decideWhatsNew(all, lastSeen, running, mode) {
+  if (!lastSeen) return { stamp: running, entries: [] };
+  if (!isNewer(lastSeen, running)) return { stamp: null, entries: [] };
+  return { stamp: running, entries: selectEntries(all, lastSeen, running, mode) };
+}
+
+/** GitHub release page for a tag. @param {string} version @returns {string} */
+export function releaseUrlFor(version) {
+  return `https://github.com/galaxyproject/loom/releases/tag/v${String(version).replace(/^v/, "")}`;
+}
+
+/** Plain-text block for the CLI notice / /whatsnew. Pure.
+ * @param {import("./whats-new.js").WhatsNewEntry[]} entries @returns {string} */
+export function formatHighlightsText(entries) {
+  return entries
+    .map((e) => `What's new in ${e.version}\n${e.highlights.map((h) => `  - ${h}`).join("\n")}`)
+    .join("\n\n");
+}

--- a/tests/whats-new.test.ts
+++ b/tests/whats-new.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseChangelog,
+  selectEntries,
+  decideWhatsNew,
+  releaseUrlFor,
+  formatHighlightsText,
+} from "../shared/whats-new.js";
+
+const SAMPLE = `# Changelog
+
+All notable changes are documented here.
+
+## [0.5.0] - 2026-07-01
+
+### Highlights
+
+- Faster workflow invocation
+- New thing two
+
+### Added
+
+- Internal-only note that must not appear
+
+## [0.4.0] - 2026-06-10
+
+### Highlights
+
+- Gemini geo-block fixed
+* Bulleted with an asterisk
+
+## [0.3.5] - 2026-06-01
+
+### Added
+
+- A version with no Highlights section -- skipped
+`;
+
+describe("parseChangelog", () => {
+  it("extracts only ### Highlights bullets, newest first", () => {
+    const entries = parseChangelog(SAMPLE);
+    expect(entries.map((e) => e.version)).toEqual(["0.5.0", "0.4.0"]);
+    expect(entries[0]).toEqual({
+      version: "0.5.0",
+      date: "2026-07-01",
+      highlights: ["Faster workflow invocation", "New thing two"],
+    });
+    expect(entries[1].highlights).toEqual(["Gemini geo-block fixed", "Bulleted with an asterisk"]);
+  });
+
+  it("skips versions with no Highlights section", () => {
+    expect(parseChangelog(SAMPLE).some((e) => e.version === "0.3.5")).toBe(false);
+  });
+
+  it("handles a missing date and CRLF line endings", () => {
+    const entries = parseChangelog("## [1.0.0]\r\n\r\n### Highlights\r\n\r\n- One\r\n");
+    expect(entries).toEqual([{ version: "1.0.0", date: undefined, highlights: ["One"] }]);
+  });
+
+  it("returns [] for empty or junk input", () => {
+    expect(parseChangelog("")).toEqual([]);
+    expect(parseChangelog("no headers here")).toEqual([]);
+  });
+});
+
+describe("decideWhatsNew", () => {
+  const all = parseChangelog(SAMPLE);
+
+  it("fresh install: stamps silently, shows nothing", () => {
+    expect(decideWhatsNew(all, undefined, "0.5.0", "accumulate")).toEqual({
+      stamp: "0.5.0",
+      entries: [],
+    });
+  });
+
+  it("same version: no stamp, no entries", () => {
+    expect(decideWhatsNew(all, "0.5.0", "0.5.0", "accumulate")).toEqual({
+      stamp: null,
+      entries: [],
+    });
+  });
+
+  it("downgrade / dev: no stamp, no entries", () => {
+    expect(decideWhatsNew(all, "0.5.0", "0.4.0", "accumulate")).toEqual({
+      stamp: null,
+      entries: [],
+    });
+  });
+
+  it("single bump accumulates the running version's entry", () => {
+    const d = decideWhatsNew(all, "0.4.0", "0.5.0", "accumulate");
+    expect(d.stamp).toBe("0.5.0");
+    expect(d.entries.map((e) => e.version)).toEqual(["0.5.0"]);
+  });
+
+  it("multi-version skip accumulates every entry in (lastSeen, running]", () => {
+    const d = decideWhatsNew(all, "0.3.0", "0.5.0", "accumulate");
+    expect(d.entries.map((e) => e.version)).toEqual(["0.5.0", "0.4.0"]);
+  });
+
+  it("latest mode returns only the running version's entry", () => {
+    const d = decideWhatsNew(all, "0.3.0", "0.5.0", "latest");
+    expect(d.entries.map((e) => e.version)).toEqual(["0.5.0"]);
+  });
+});
+
+describe("selectEntries (latest, for /whatsnew)", () => {
+  const all = parseChangelog(SAMPLE);
+  it("returns the running version's entry regardless of lastSeen", () => {
+    expect(selectEntries(all, undefined, "0.4.0", "latest").map((e) => e.version)).toEqual([
+      "0.4.0",
+    ]);
+  });
+  it("returns [] when the running version has no entry", () => {
+    expect(selectEntries(all, undefined, "9.9.9", "latest")).toEqual([]);
+  });
+  it("returns [] when the running version is not valid semver", () => {
+    expect(selectEntries(all, undefined, "dev", "latest")).toEqual([]);
+  });
+});
+
+describe("releaseUrlFor", () => {
+  it("builds the tag URL and tolerates a leading v", () => {
+    expect(releaseUrlFor("0.5.0")).toBe(
+      "https://github.com/galaxyproject/loom/releases/tag/v0.5.0",
+    );
+    expect(releaseUrlFor("v0.5.0")).toBe(
+      "https://github.com/galaxyproject/loom/releases/tag/v0.5.0",
+    );
+  });
+});
+
+describe("formatHighlightsText", () => {
+  it("renders a version header and indented bullets", () => {
+    const text = formatHighlightsText([{ version: "0.5.0", highlights: ["A", "B"] }]);
+    expect(text).toBe("What's new in 0.5.0\n  - A\n  - B");
+  });
+  it("returns an empty string for no entries", () => {
+    expect(formatHighlightsText([])).toBe("");
+  });
+});


### PR DESCRIPTION
When someone updates Orbit or the loom CLI, nothing tells them what changed. The only update-facing thing we have today is forward-looking ("a newer version is available, go get it"). This adds the backward-looking half: the first time you run a version newer than the one you last ran, you get that version's highlights once, then it stamps itself so it doesn't nag.

How it works:
- One curated `CHANGELOG.md` at the repo root is the single source of highlights (Keep-a-Changelog style; only the `### Highlights` block per version is surfaced -- full notes stay on the GitHub release pages). A small pure module `shared/whats-new.js` parses it and decides what to show, reusing the existing `version-compare` semver helper.
- Orbit bundles the changelog at build time (Vite `?raw`) and shows a dismissible banner that opens a highlights modal. It accumulates across skipped versions and only runs on packaged builds.
- The CLI ships the changelog in its npm `files`, prints the running version's highlights once at session start, and adds a `/whatsnew` command to re-view. It no-ops inside Orbit so there's no double notice.

No network calls -- it only reads the version it's already running; the one outbound action is the release-notes link on click.

A few notes for review:
- The seeded CHANGELOG entry is just a starting point -- real highlights get written per release.
- The version that first ships this feature stamps silently on first run (no prior version to be "new" against), so the first real "what's new" shows up on the *next* release.
- `app/forge.config.ts` had to learn about the changelog too -- a packaged Orbit stages the embedded brain from a separate allowlist than the npm `files` array.

Tests: new unit coverage for the parser + decision logic; full suite green, root + app typecheck clean.
