### PR TITLE
Stop dev (npm start) from poisoning the prod macOS Keychain item

### DIFF
--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -37,24 +37,26 @@ function buildSecretEnv(): Record<string, string> {
   const cfg = loadConfig();
 
   const provider = cfg.llm?.active || "anthropic";
-  const llmKey = resolveLlmApiKey(cfg);
   const isCustom = Boolean(cfg.llm?.providers?.[provider]?.baseUrl);
   // OAuth providers ignore env-var keys -- the brain reads ~/.pi/agent/auth.json.
   // If the user switched away from an API-key provider the old key is still in
   // config.json (preserved on purpose so they can switch back); don't leak it
   // into the env under a misrouted variable name.
-  if (llmKey && !OAUTH_PROVIDERS.has(provider)) {
-    if (isCustom) {
-      // Custom OpenAI-compatible endpoint: the brain converts this into
-      // pi's --api-key (a built-in env var wouldn't map to the provider).
-      env.LOOM_ACTIVE_LLM_API_KEY = llmKey;
-    } else {
-      const envVar = PROVIDER_ENV_MAP[provider] || "AI_GATEWAY_API_KEY";
-      env[envVar] = llmKey;
-    }
+  if (!OAUTH_PROVIDERS.has(provider)) {
+    // Custom OpenAI-compatible endpoints route through pi's --api-key via
+    // LOOM_ACTIVE_LLM_API_KEY; built-in providers use their own env var.
+    const targetVar = isCustom
+      ? "LOOM_ACTIVE_LLM_API_KEY"
+      : PROVIDER_ENV_MAP[provider] || "AI_GATEWAY_API_KEY";
+    // Config key wins; otherwise fall back to a key exported into Orbit's own
+    // env (`export ANTHROPIC_API_KEY=...; npm start`). In dev with safeStorage
+    // off this is the only key path; in prod it's a handy CI/power-user override.
+    const llmKey = resolveLlmApiKey(cfg) ?? process.env[targetVar];
+    if (llmKey) env[targetVar] = llmKey;
   }
 
-  const galaxyKey = resolveGalaxyApiKey(cfg);
+  // Galaxy key: config wins, else an exported GALAXY_API_KEY.
+  const galaxyKey = resolveGalaxyApiKey(cfg) ?? process.env.GALAXY_API_KEY;
   if (galaxyKey) {
     env.GALAXY_API_KEY = galaxyKey;
   }

--- a/app/src/main/secure-config.ts
+++ b/app/src/main/secure-config.ts
@@ -1,4 +1,4 @@
-import { safeStorage } from "electron";
+import { app, safeStorage } from "electron";
 import type { LoomConfig } from "../../../shared/loom-config.js";
 import { loadConfig, saveConfig } from "../../../shared/loom-config.js";
 
@@ -13,6 +13,13 @@ export function isAvailable(): boolean {
   // env makes us skip the probe entirely; encrypted secrets just stay
   // unread for the duration of the test.
   if (process.env.LOOM_DISABLE_SAFE_STORAGE === "1") return false;
+  // Dev (`npm start`, unpackaged) shares ~/.loom/config.json with the installed
+  // app but runs as a different, cdhash-pinned Electron binary. If dev touched
+  // safeStorage it would create and own the "<App> Safe Storage" keychain item,
+  // and the installed Developer ID build would no longer match its ACL -- the
+  // cause of every-launch prompts. Skip it in dev so only the packaged signed
+  // build owns the item; dev keys come from the env (see agent.ts buildSecretEnv).
+  if (!app.isPackaged) return false;
   try {
     return safeStorage.isEncryptionAvailable();
   } catch {

--- a/extensions/loom/secret-redaction.ts
+++ b/extensions/loom/secret-redaction.ts
@@ -42,6 +42,10 @@ const SECRET_ENV_VARS = [
   "AZURE_OPENAI_API_KEY",
   "HF_TOKEN",
   "GALAXY_API_KEY",
+  // Custom OpenAI-compatible endpoints carry their key here (pi --api-key). With
+  // the dev/CI env fallback this can be the only place the key lives, so its
+  // value would otherwise dodge redaction.
+  "LOOM_ACTIVE_LLM_API_KEY",
 ];
 
 /** Minimal structural shape for a pi tool-result content item. */

--- a/tests/secret-redaction.test.ts
+++ b/tests/secret-redaction.test.ts
@@ -31,10 +31,15 @@ describe("collectSecretValues", () => {
     const secrets = collectSecretValues({} as never, {
       GALAXY_API_KEY: "galaxy-env-2222222222",
       ANTHROPIC_API_KEY: "sk-ant-env-3333333333",
+      // Custom OpenAI-compatible endpoint key the brain receives as --api-key.
+      // With the dev/CI env fallback it can arrive in the env without ever
+      // touching config, so its value must still be redactable.
+      LOOM_ACTIVE_LLM_API_KEY: "loom-active-env-4444444444",
       PATH: "/usr/bin", // not a secret var -> ignored
     });
     expect(secrets).toContain("galaxy-env-2222222222");
     expect(secrets).toContain("sk-ant-env-3333333333");
+    expect(secrets).toContain("loom-active-env-4444444444");
     expect(secrets).not.toContain("/usr/bin");
   });
 


### PR DESCRIPTION
The installed, signed Orbit owns its `<App> Safe Storage` keychain item via a stable Developer ID requirement, so a clean install never prompts. But `npm start` (unpackaged) shares `~/.loom/config.json` with the installed app while running as a *different*, cdhash-pinned Electron binary -- so when dev touched safeStorage it created and owned that keychain item, and the installed build then no longer matched the ACL and got the every-launch "use ... in your keychain" prompt. A pure dev-environment artifact, but an annoying one.

Two small changes:

- **Skip safeStorage when `!app.isPackaged`**, so only the packaged signed build ever owns the keychain item.
- The brain only ever got provider keys from config (`buildSecretEnv` decrypt) -- `buildBrainEnv` deliberately doesn't forward `ANTHROPIC_API_KEY` & friends -- so **add a config-misses-then-env fallback** in `buildSecretEnv`. Now in dev you just `export ANTHROPIC_API_KEY=...; npm start` and it works; config still wins, and it doubles as a handy CI/power-user override in prod.

No behavior change for a normal packaged install. Typecheck clean, full suite green (514). (No unit test on these two -- both are electron-coupled main-process paths, consistent with the rest of that layer.)
