### PR TITLE
Fix chat output running together between streamed segments

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -2285,6 +2285,11 @@ window.orbit.onAgentEvent((event) => {
       const msg = (event as { message?: { role?: string } }).message;
       if (msg?.role === "user") {
         chat.finishAssistantMessage();
+      } else if (msg?.role === "assistant") {
+        // A new assistant message in the same turn (agentic loop step) keeps
+        // streaming into the active chat message, so separate its text from the
+        // previous message's prose with a blank line (issue #200).
+        chat.separateNextBlock();
       }
       break;
     }
@@ -2322,7 +2327,10 @@ window.orbit.onAgentEvent((event) => {
         const delta = ame.delta as string;
         if (delta) chat.appendDelta(delta);
       } else if (ameType === "text_end") {
-        // text block finished, but agent turn might continue
+        // Text block finished, but the agent turn might continue with a tool
+        // call and then more text. Separate that next block from this one so
+        // they don't render butted together (issue #200).
+        chat.separateNextBlock();
       }
       break;
     }

--- a/app/src/renderer/chat/block-spacing.ts
+++ b/app/src/renderer/chat/block-spacing.ts
@@ -1,0 +1,24 @@
+/**
+ * Spacing between consecutive assistant text blocks (issue #200).
+ *
+ * A multi-step turn streams several text blocks into one accumulating buffer:
+ * the model writes some prose, calls a tool, writes more prose, and so on, all
+ * within a single chat message. The deltas are concatenated verbatim, so two
+ * blocks render butted together once marked parses them -- "…upload to
+ * Galaxy.Creating the conda env…" with no break between "Galaxy" and
+ * "Creating". A blank line is markdown's paragraph separator, so inserting one
+ * at each block boundary makes marked emit separate <p> elements.
+ *
+ * `joinTextBlocks` is called when the first delta of a *new* block arrives;
+ * within a block, deltas keep appending verbatim.
+ */
+export function joinTextBlocks(prev: string, next: string): string {
+  const left = prev.replace(/\s+$/, "");
+  // Nothing meaningful before this block -- don't open with a stray break.
+  if (left.length === 0) return next;
+  const right = next.replace(/^\s+/, "");
+  // The new block opened with only whitespace; apply the break now and let the
+  // following (normal) delta append the real text after it.
+  if (right.length === 0) return `${left}\n\n`;
+  return `${left}\n\n${right}`;
+}

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -1,4 +1,5 @@
 import { renderMarkdown } from "./markdown.js";
+import { joinTextBlocks } from "./block-spacing.js";
 import {
   TEAM_DISPATCH_KIND,
   type TeamDispatchDetails,
@@ -13,6 +14,10 @@ export class ChatPanel {
   private container: HTMLElement;
   private currentMessage: HTMLElement | null = null;
   private currentText = "";
+  // When true, the next streamed delta starts a new assistant text block and is
+  // separated from the prior block with a blank line (issue #200) so successive
+  // segments around tool calls don't render butted together ("Galaxy.Creating").
+  private pendingBlockBreak = false;
   private toolCards = new Map<string, HTMLElement>();
   private scrollLocked = true;
   private thinkingEl: HTMLElement | null = null;
@@ -147,6 +152,7 @@ export class ChatPanel {
     this.container.innerHTML = "";
     this.currentMessage = null;
     this.currentText = "";
+    this.pendingBlockBreak = false;
     this.toolCards.clear();
     this.thinkingEl = null;
   }
@@ -229,6 +235,7 @@ export class ChatPanel {
 
   startAssistantMessage(): void {
     this.currentText = "";
+    this.pendingBlockBreak = false;
     const el = document.createElement("div");
     el.className = "message assistant";
     el.innerHTML = '<span class="cursor-blink"></span>';
@@ -237,9 +244,24 @@ export class ChatPanel {
     this.scrollToBottom();
   }
 
+  /**
+   * Mark that the current assistant text block has ended (a tool call or a new
+   * assistant message follows). The next streamed delta then opens a new block,
+   * separated from the previous one by a blank line so they don't run together
+   * in the rendered markdown (issue #200). No-op once the message is finished.
+   */
+  separateNextBlock(): void {
+    if (this.currentMessage) this.pendingBlockBreak = true;
+  }
+
   appendDelta(delta: string): void {
     if (!this.currentMessage) return;
-    this.currentText += delta;
+    if (this.pendingBlockBreak) {
+      this.pendingBlockBreak = false;
+      this.currentText = joinTextBlocks(this.currentText, delta);
+    } else {
+      this.currentText += delta;
+    }
     this.renderCurrentMessage();
     this.scrollToBottom();
   }
@@ -252,6 +274,7 @@ export class ChatPanel {
     this.container.querySelectorAll(".cursor-blink").forEach((c) => c.remove());
     this.currentMessage = null;
     this.currentText = "";
+    this.pendingBlockBreak = false;
   }
 
   addToolCard(id: string, name: string): void {

--- a/tests/block-spacing.test.ts
+++ b/tests/block-spacing.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { joinTextBlocks } from "../app/src/renderer/chat/block-spacing.js";
+
+/**
+ * Issue #200: a multi-step assistant turn (text → tool call → text → …) streams
+ * each text block into one accumulating buffer. Without a separator between
+ * blocks the rendered markdown collapses into one dense paragraph, e.g.
+ * "…upload to Galaxy.Creating the conda env…" with "Galaxy.Creating" butted
+ * together. `joinTextBlocks` inserts a paragraph break (blank line) between the
+ * previous prose and the next block so marked renders them as separate <p>s.
+ */
+describe("joinTextBlocks", () => {
+  it("separates two prose blocks with a blank line", () => {
+    expect(joinTextBlocks("first block", "second block")).toBe("first block\n\nsecond block");
+  });
+
+  it("fixes the reported run-together case (Galaxy.Creating)", () => {
+    const prev = "I'll install FastQC locally and upload to Galaxy.";
+    const next = "Creating the conda env and uploading to Galaxy in parallel.";
+    expect(joinTextBlocks(prev, next)).toBe(`${prev}\n\n${next}`);
+  });
+
+  it("does not add a leading break when there is no previous prose", () => {
+    expect(joinTextBlocks("", "first block")).toBe("first block");
+  });
+
+  it("treats whitespace-only previous text as empty (no leading break)", () => {
+    expect(joinTextBlocks("   \n  ", "first block")).toBe("first block");
+  });
+
+  it("collapses the model's own trailing newline into a single break", () => {
+    expect(joinTextBlocks("done.\n", "next")).toBe("done.\n\nnext");
+  });
+
+  it("does not double the break when previous already ends with a blank line", () => {
+    expect(joinTextBlocks("done.\n\n", "next")).toBe("done.\n\nnext");
+  });
+
+  it("strips leading whitespace on the next block so the break stays single", () => {
+    expect(joinTextBlocks("done.", "\n\nCreating…")).toBe("done.\n\nCreating…");
+  });
+
+  it("keeps the break pending when the next block starts with only whitespace", () => {
+    // First delta of a new block is whitespace; the break is applied now and
+    // the real text appended by the following (normal) delta lands after it.
+    expect(joinTextBlocks("done.", "  ")).toBe("done.\n\n");
+  });
+
+  it("preserves internal structure of the next block", () => {
+    expect(joinTextBlocks("intro", "- a\n- b")).toBe("intro\n\n- a\n- b");
+  });
+});


### PR DESCRIPTION
Reported via Orbit beta feedback (#200): chat output renders as one dense block, e.g. `...upload to Galaxy.Creating the conda env...parallel.conda isn't available...` with "Galaxy.Creating" and "parallel.conda" butted together.

## Root cause

In the live streaming path, a multi-step turn keeps **one** assistant chat message active across the whole agentic loop -- the message is only finished at `agent_end` (or a user message / error). So every assistant text block -- each LLM call in the loop, plus the text blocks around tool calls -- appends into a single `currentText` buffer with no separator, and `marked` renders the lot as one paragraph. The replay path doesn't hit this because it gives each saved message its own bubble.

## Fix

Insert a blank line (markdown's paragraph separator) at each block boundary:

- New pure helper `block-spacing.ts` `joinTextBlocks(prev, next)` -- joins with `\n\n`, and no-ops when there's no prior prose so the first message never gets a leading break.
- `ChatPanel` gains a `pendingBlockBreak` flag + `separateNextBlock()`; `appendDelta` joins through the helper when a break is pending.
- `app.ts` arms the break at each assistant `message_start` (cross-message boundary -- the reported DeepSeek loop case) and at `text_end` (block boundary within a message).

Went with separator insertion rather than restructuring to one-bubble-per-message, since the latter would disturb where `team_dispatch` tool cards land.

## Tests / verification

- New `tests/block-spacing.test.ts` (9 cases) covering the join logic and edge cases.
- 523/523 root tests pass; `app` `tsc --noEmit`, prettier, and eslint all clean.
- Rendered the exact report string through `marked`: before = 1 `<p>` (with "Galaxy.Creating"); after = 3 `<p>`, neither concatenation present.

Not yet eyeballed live in a running Orbit.

Closes #200.