### PR TITLE
Confirm feedback sends instead of silently closing the modal

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -5,6 +5,7 @@ import { ShellPanel } from "./chat/shell-panel.js";
 import { ArtifactPanel } from "./artifacts/artifact-panel.js";
 import { FilesPanel } from "./files/files-panel.js";
 import { FileViewer } from "./files/file-viewer.js";
+import { FeedbackConfirmation } from "./feedback-confirmation.js";
 import { refreshGalaxyInvocations } from "./galaxy-invocations.js";
 import { PromptQueue, queuedPreview } from "./prompt-queue.js";
 import { LoomWidgetKey, decodeMarkdownWidget } from "../../../shared/loom-shell-contract.js";
@@ -3491,6 +3492,22 @@ const reportTitle = document.getElementById("report-title") as HTMLInputElement;
 const reportBody = document.getElementById("report-body") as HTMLTextAreaElement;
 const reportIncludeSysinfo = document.getElementById("report-include-sysinfo") as HTMLInputElement;
 const reportIncludeLogs = document.getElementById("report-include-logs") as HTMLInputElement;
+const reportFormFields = document.getElementById("report-form-fields")!;
+const reportSuccess = document.getElementById("report-success")!;
+const reportFooter = document.getElementById("report-footer")!;
+
+// How long the "Feedback received, thank you!" state stays up before the modal
+// closes itself -- long enough to read, short enough to not nag.
+const REPORT_CONFIRM_MS = 1500;
+const reportConfirmation = new FeedbackConfirmation({
+  delayMs: REPORT_CONFIRM_MS,
+  onShowSuccess: () => {
+    reportFormFields.classList.add("hidden");
+    reportFooter.classList.add("hidden");
+    reportSuccess.classList.remove("hidden");
+  },
+  onClose: () => closeReportModal(),
+});
 
 // Budget for the *encoded* body in the GitHub URL. The whole URL
 // (~"https://github.com/galaxyproject/loom/issues/new?title=…&body=…")
@@ -3500,6 +3517,12 @@ const reportIncludeLogs = document.getElementById("report-include-logs") as HTML
 const REPORT_URL_BUDGET = 7000;
 
 function openReportModal(): void {
+  // Drop any pending auto-close so reopening within the thank-you window can't
+  // close the freshly opened modal, and reset back to the form state.
+  reportConfirmation.cancel();
+  reportSuccess.classList.add("hidden");
+  reportFormFields.classList.remove("hidden");
+  reportFooter.classList.remove("hidden");
   reportTitle.value = "";
   reportBody.value = "";
   // Default ON: the primary destination is Loom's private capture store, not a
@@ -3512,6 +3535,7 @@ function openReportModal(): void {
   reportTitle.focus();
 }
 function closeReportModal(): void {
+  reportConfirmation.cancel();
   reportOverlay.classList.add("hidden");
 }
 
@@ -3637,7 +3661,9 @@ reportSubmit.addEventListener("click", async () => {
     const payload = await buildFeedbackPayload();
     const result = await window.orbit.submitFeedback(payload);
     if (result.ok) {
-      closeReportModal();
+      // Show an inline "Feedback received, thank you!" before auto-closing, so a
+      // successful send is visibly confirmed instead of the modal just vanishing.
+      reportConfirmation.confirm();
       return;
     }
     // Fallback: the private store was unreachable. Open a PUBLIC GitHub issue

--- a/app/src/renderer/feedback-confirmation.ts
+++ b/app/src/renderer/feedback-confirmation.ts
@@ -1,0 +1,44 @@
+/**
+ * Owns the "Feedback received, thank you!" confirmation lifecycle for the
+ * Send-feedback modal.
+ *
+ * The modal used to close silently on a successful send, so the user had no way
+ * to tell success from a no-op (the reported complaint). On success we now show
+ * an inline thank-you and auto-close after a short delay. The only subtlety is
+ * the timer: if the user reopens the modal inside that window, the stale timer
+ * must not close the freshly opened modal -- so this controller owns the single
+ * pending timer and re-arms / cancels it cleanly. DOM-free so it's unit-testable
+ * under the node test environment.
+ */
+export interface FeedbackConfirmationConfig {
+  /** How long the thank-you state stays up before the modal auto-closes. */
+  delayMs: number;
+  /** Swap the form for the inline thank-you state. */
+  onShowSuccess: () => void;
+  /** Close the modal once the thank-you has been shown long enough. */
+  onClose: () => void;
+}
+
+export class FeedbackConfirmation {
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly config: FeedbackConfirmationConfig) {}
+
+  /** Show the thank-you state now and schedule the auto-close. */
+  confirm(): void {
+    this.cancel();
+    this.config.onShowSuccess();
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.config.onClose();
+    }, this.config.delayMs);
+  }
+
+  /** Drop any pending auto-close (manual close, reopen, Esc). No-op when idle. */
+  cancel(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -799,55 +799,63 @@
           <button id="report-close" class="modal-close" title="Close" aria-label="Close">×</button>
         </div>
         <div class="modal-body">
-          <div class="report-account-note">
-            Your feedback goes straight to the Loom team's private feedback store — no GitHub
-            account needed. If that service is unreachable, Orbit falls back to opening a pre-filled
-            issue on
-            <a
-              href="https://github.com/galaxyproject/loom"
-              target="_blank"
-              rel="noopener noreferrer"
-              >github.com/galaxyproject/loom</a
-            >
-            with only your title and description (no diagnostics), which you submit there.
+          <div id="report-form-fields">
+            <div class="report-account-note">
+              Your feedback goes straight to the Loom team's private feedback store — no GitHub
+              account needed. If that service is unreachable, Orbit falls back to opening a
+              pre-filled issue on
+              <a
+                href="https://github.com/galaxyproject/loom"
+                target="_blank"
+                rel="noopener noreferrer"
+                >github.com/galaxyproject/loom</a
+              >
+              with only your title and description (no diagnostics), which you submit there.
+            </div>
+            <div class="prefs-row">
+              <label for="report-title">Title</label>
+              <input id="report-title" type="text" placeholder="Short summary" required />
+            </div>
+            <div class="prefs-row">
+              <label for="report-body">What happened?</label>
+              <textarea
+                id="report-body"
+                rows="6"
+                placeholder="Steps to reproduce, expected vs actual, screenshots if relevant..."
+              ></textarea>
+            </div>
+            <div class="report-options">
+              <label
+                ><input type="checkbox" id="report-include-sysinfo" /> Include system info</label
+              >
+              <label><input type="checkbox" id="report-include-logs" /> Include logs</label>
+            </div>
+            <details class="report-disclosure">
+              <summary>What's included?</summary>
+              <p>
+                <b>System info:</b> Orbit version, OS, Electron/Node versions, LLM model + provider
+                name (no API key), Galaxy connection state (no credentials).
+              </p>
+              <p>
+                <b>Logs:</b> last 60 events of <code>activity.jsonl</code> (one line each: tool
+                name, arguments, and a truncated result -- credentials and API keys redacted) and
+                the last ~200 lines of the in-app shell stream. These can include filenames, tool
+                arguments, and command output.
+              </p>
+              <p>
+                Both are on by default for the beta so we get useful diagnostics. Feedback goes to
+                Loom's private feedback store; uncheck either box to leave it out. If the store is
+                unreachable and we fall back to a public GitHub issue, only your text is sent —
+                never these diagnostics.
+              </p>
+            </details>
           </div>
-          <div class="prefs-row">
-            <label for="report-title">Title</label>
-            <input id="report-title" type="text" placeholder="Short summary" required />
+          <div id="report-success" class="report-success hidden" role="status" aria-live="polite">
+            <div class="report-success-check" aria-hidden="true">✓</div>
+            <div class="report-success-text">Feedback received, thank you!</div>
           </div>
-          <div class="prefs-row">
-            <label for="report-body">What happened?</label>
-            <textarea
-              id="report-body"
-              rows="6"
-              placeholder="Steps to reproduce, expected vs actual, screenshots if relevant..."
-            ></textarea>
-          </div>
-          <div class="report-options">
-            <label><input type="checkbox" id="report-include-sysinfo" /> Include system info</label>
-            <label><input type="checkbox" id="report-include-logs" /> Include logs</label>
-          </div>
-          <details class="report-disclosure">
-            <summary>What's included?</summary>
-            <p>
-              <b>System info:</b> Orbit version, OS, Electron/Node versions, LLM model + provider
-              name (no API key), Galaxy connection state (no credentials).
-            </p>
-            <p>
-              <b>Logs:</b> last 60 events of <code>activity.jsonl</code> (one line each: tool name,
-              arguments, and a truncated result -- credentials and API keys redacted) and the last
-              ~200 lines of the in-app shell stream. These can include filenames, tool arguments,
-              and command output.
-            </p>
-            <p>
-              Both are on by default for the beta so we get useful diagnostics. Feedback goes to
-              Loom's private feedback store; uncheck either box to leave it out. If the store is
-              unreachable and we fall back to a public GitHub issue, only your text is sent — never
-              these diagnostics.
-            </p>
-          </details>
         </div>
-        <div class="modal-footer">
+        <div class="modal-footer" id="report-footer">
           <div class="modal-actions">
             <button id="report-cancel" class="plan-btn">Cancel</button>
             <button id="report-submit" class="plan-btn primary">Send feedback</button>

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -2094,6 +2094,30 @@ body.platform-darwin #files-title {
   line-height: 1.5;
 }
 
+.report-success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 32px 20px;
+  text-align: center;
+}
+.report-success-check {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--success-bg);
+  color: var(--success);
+  font-size: 26px;
+  line-height: 48px;
+}
+.report-success-text {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
 .prefs-row-with-btn {
   display: flex;
   flex: 1;

--- a/tests/feedback-confirmation.test.ts
+++ b/tests/feedback-confirmation.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FeedbackConfirmation } from "../app/src/renderer/feedback-confirmation.js";
+
+const DELAY = 1500;
+
+describe("FeedbackConfirmation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function make() {
+    const onShowSuccess = vi.fn();
+    const onClose = vi.fn();
+    const confirmation = new FeedbackConfirmation({ delayMs: DELAY, onShowSuccess, onClose });
+    return { confirmation, onShowSuccess, onClose };
+  }
+
+  it("shows the success state immediately on confirm", () => {
+    const { confirmation, onShowSuccess, onClose } = make();
+
+    confirmation.confirm();
+
+    expect(onShowSuccess).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("auto-closes once after the configured delay", () => {
+    const { confirmation, onClose } = make();
+    confirmation.confirm();
+
+    vi.advanceTimersByTime(DELAY - 1);
+    expect(onClose).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel before the delay prevents the auto-close", () => {
+    const { confirmation, onClose } = make();
+    confirmation.confirm();
+
+    confirmation.cancel();
+    vi.advanceTimersByTime(DELAY * 5);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("leaves only one live timer when confirm is called again (reopen within the window)", () => {
+    const { confirmation, onShowSuccess, onClose } = make();
+
+    confirmation.confirm();
+    vi.advanceTimersByTime(DELAY - 1); // first window almost elapsed
+    confirmation.confirm(); // a second send re-arms; the stale timer must not also fire
+
+    expect(onShowSuccess).toHaveBeenCalledTimes(2);
+
+    vi.advanceTimersByTime(DELAY);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel is a no-op when nothing is pending", () => {
+    const { confirmation, onClose } = make();
+
+    expect(() => confirmation.cancel()).not.toThrow();
+    vi.advanceTimersByTime(DELAY * 5);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The Send feedback modal closed silently on a successful send, so there was no on-screen sign the report went through -- no way to tell success from a no-op. A tester hit exactly this and assumed their reports weren't landing (they were).

On a successful send the modal now swaps the form for an inline "Feedback received, thank you!" and auto-closes after 1.5s. The store-unreachable fallback (opening a pre-filled GitHub issue) is unchanged, since "received" wouldn't be accurate there.

The auto-close lives in a small DOM-free `FeedbackConfirmation` controller rather than an inline `setTimeout`, so the one bit with real bug potential -- a stale timer closing the modal after the user reopened it within the window -- is guarded and unit-tested. The `app.ts` wiring stays thin.

**Testing**
- 5 new unit tests for the controller: shows on confirm, auto-close fires once, cancel prevents it, reopen leaves only one live timer, cancel-when-idle is a no-op.
- Full suite green (570 tests), `app` typecheck clean, prettier + eslint clean.
- Inline success state not yet eyeballed in a running Orbit.
