### PR TITLE
Humanize the context-overflow 400 instead of dumping it raw

### DIFF
--- a/app/src/renderer/chat/error-humanizer.ts
+++ b/app/src/renderer/chat/error-humanizer.ts
@@ -17,9 +17,52 @@ interface AnthropicLikeError {
 
 const RETRIABLE_TYPES = new Set(["overloaded_error", "rate_limit_error", "api_error"]);
 
+// Context-overflow errors arrive in many provider-specific phrasings, and for
+// OpenAI-compatible endpoints they're a plain (non-JSON) string the humanizer
+// would otherwise echo verbatim -- e.g. deepseek's "400 This model's maximum
+// context length is N tokens. However, you requested M tokens..." (issue #209).
+// Dumping that raw is alarming and unactionable, so we detect the signature and
+// point the user at the real lever (/compact). Patterns mirror pi-ai's
+// isContextOverflow() but stay self-contained so the renderer doesn't pull in
+// the brain's provider layer. request_too_large keeps its own case below.
+const CONTEXT_OVERFLOW_PATTERNS = [
+  /prompt is too long/i, // Anthropic token overflow
+  /exceeds the context window/i, // OpenAI
+  /maximum context length/i, // OpenAI / OpenRouter / LiteLLM proxies
+  /reduce the length of the messages/i, // Groq / deepseek tail
+  /maximum prompt length is \d+/i, // xAI (Grok)
+  /input token count.*exceeds the maximum/i, // Google (Gemini)
+  /too large for model with \d+ maximum context length/i, // Mistral
+  /is longer than the model'?s context length/i, // Together AI
+  /context[_ ]length[_ ]exceeded/i, // OpenAI error code / generic
+];
+
+// Rate-limit / throttling errors sometimes mention "tokens"; resending after a
+// pause is the right move for those, not /compact -- so never treat them as
+// overflow even when an overflow phrase coincidentally matches.
+const NOT_OVERFLOW_PATTERNS = [/rate limit/i, /too many requests/i, /throttl/i];
+
+function isContextOverflowError(text: string): boolean {
+  if (NOT_OVERFLOW_PATTERNS.some((p) => p.test(text))) return false;
+  return CONTEXT_OVERFLOW_PATTERNS.some((p) => p.test(text));
+}
+
 export function humanizeAgentError(raw: string | undefined | null): HumanizedError {
   if (!raw) return { text: "Unknown error", retriable: false };
   const trimmed = raw.trim();
+
+  // Check overflow first, against the whole string: the signature can be a bare
+  // string (OpenAI-compatible) or buried in a JSON error body, and either way
+  // /compact is the actionable answer.
+  if (isContextOverflowError(trimmed)) {
+    return {
+      text:
+        "This conversation is too long for the model's context window. " +
+        "Run /compact to compact it (or start a new session), then resend.",
+      retriable: false,
+    };
+  }
+
   if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
     return { text: raw, retriable: false };
   }

--- a/tests/error-humanizer.test.ts
+++ b/tests/error-humanizer.test.ts
@@ -79,4 +79,64 @@ describe("humanizeAgentError", () => {
     expect(result.text).not.toContain("FAILED_PRECONDITION");
     expect(result.retriable).toBe(false);
   });
+
+  describe("context overflow", () => {
+    it("humanizes the OpenAI-compatible context-length 400 (deepseek-v4-flash) into a /compact nudge", () => {
+      // The verbatim string from issue #209 -- arrives as a plain string, not JSON.
+      const raw =
+        "400 This model's maximum context length is 1048565 tokens. However, you " +
+        "requested 1133502 tokens (1133502 in the messages, 0 in the completion). " +
+        "Please reduce the length of the messages or completion.";
+      const result = humanizeAgentError(raw);
+      expect(result.text).toMatch(/\/compact/);
+      expect(result.text.toLowerCase()).toContain("context");
+      // No raw provider noise (token counts / HTTP status) should leak through.
+      expect(result.text).not.toContain("1048565");
+      expect(result.text).not.toContain("1133502");
+      expect(result.text).not.toContain("400");
+      expect(result.retriable).toBe(false);
+    });
+
+    it("detects context overflow even when the provider wraps it in JSON", () => {
+      const raw = JSON.stringify({
+        error: {
+          message:
+            "This model's maximum context length is 1048565 tokens. However you requested 1133502 tokens.",
+          type: "invalid_request_error",
+          code: "context_length_exceeded",
+        },
+      });
+      const result = humanizeAgentError(raw);
+      expect(result.text).toMatch(/\/compact/);
+      expect(result.text).not.toContain("1133502");
+      expect(result.retriable).toBe(false);
+    });
+
+    it("detects an Anthropic-style prompt-too-long overflow", () => {
+      const raw = JSON.stringify({
+        type: "error",
+        error: {
+          type: "invalid_request_error",
+          message: "prompt is too long: 213462 tokens > 200000 maximum",
+        },
+      });
+      const result = humanizeAgentError(raw);
+      expect(result.text).toMatch(/\/compact/);
+      expect(result.retriable).toBe(false);
+    });
+
+    it("does not misfire on rate-limit errors that mention tokens", () => {
+      const raw = JSON.stringify({
+        type: "error",
+        error: {
+          type: "rate_limit_error",
+          message: "rate limit exceeded: too many tokens per minute",
+        },
+      });
+      const result = humanizeAgentError(raw);
+      // Should stay on the rate-limit path, not the overflow path.
+      expect(result.text).not.toMatch(/\/compact/);
+      expect(result.retriable).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
Closes #209.

On a long session with a large-window model (deepseek-v4-flash, ~1M tokens) the conversation can outgrow the model's context window. pi handles that on its own -- it auto-compacts and retries -- but the intermediate failed turn still surfaces the provider's raw `400 ... maximum context length is N tokens ...` string. `humanizeAgentError` only understood Anthropic's JSON error shape and echoed anything non-JSON verbatim, so the bare deepseek string leaked straight into chat every turn. That's the "I keep getting this error but the tool is working fine" report.

This detects the context-overflow signature (a focused set of provider phrasings, mirroring pi-ai's `isContextOverflow()` but kept self-contained so the renderer doesn't pull in the brain's provider layer) and returns a clean line pointing at `/compact`, with a guard so rate-limit errors that mention "tokens" don't get misrouted onto the overflow path. Catches both the bare-string form and a JSON-wrapped body. Same shape as the Gemini geo-block humanizing in #192.

Scope: this is the raw-400-leak half. The "should loom proactively compact before the window fills" half is a separate design call -- pi already auto-compacts and recognizes this error, so anything proactive on our side would compete with its machinery. Leaving that out deliberately rather than bundling it here.

Added context-overflow cases to `tests/error-humanizer.test.ts` (bare string, JSON-wrapped, Anthropic prompt-too-long, and the rate-limit non-misfire guard). Full suite green, app + root typecheck clean.