### PR TITLE
Fix #221: stop listing retired models in the picker

### DIFF
--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -8,6 +8,7 @@ import { execSync } from "node:child_process";
 import { loadConfig, saveConfig, type LoomConfig } from "./config.js";
 import { encryptSecret, isAvailable as safeStorageAvailable } from "./secure-config.js";
 import { getProviders, getModels } from "@earendil-works/pi-ai";
+import { isDeprecatedModelId } from "./model-catalog.js";
 import { checkLatestVersion } from "./version-check.js";
 import { postFeedback } from "./feedback.js";
 import type { FeedbackPayload } from "../../../shared/feedback-contract.js";
@@ -634,7 +635,9 @@ export function registerIpcHandlers(agent: AgentManager): void {
     try {
       for (const provider of getProviders()) {
         if (!USER_FACING_PROVIDERS.has(provider)) continue;
-        const models = getModels(provider);
+        // Drop generations the provider's live API has retired -- pi's registry
+        // still lists them but they 404 on use, so they shouldn't reach the picker (#221).
+        const models = getModels(provider).filter((m) => !isDeprecatedModelId(provider, m.id));
         if (!models.length) continue;
         out[provider] = models.map((m) => {
           const cleanName = m.name.replace(/^Claude\s+/i, "");

--- a/app/src/main/model-catalog.ts
+++ b/app/src/main/model-catalog.ts
@@ -1,0 +1,22 @@
+// pi-ai's bundled registry lists every model it has ever known per provider,
+// including generations the provider's live API has since retired (e.g.
+// gemini-2.0-flash, gemini-1.5-*). Those still appear in the picker via
+// models:list-all but 404 the moment they're selected (#221). pi's Model carries
+// no "deprecated" flag, so we filter on known-legacy id patterns. Keep this list
+// tight and provider-scoped -- it only needs to drop clearly-superseded families,
+// and a retired model that slips through is still caught at send time by the
+// error-humanizer backstop.
+
+const LEGACY_MODEL_PATTERNS: Record<string, RegExp[]> = {
+  // Gemini 1.x and 2.0 are superseded by 2.5 / 3.x; the API rejects them.
+  google: [/^gemini-1\./i, /^gemini-2\.0\b/i],
+  // gpt-3.5, the original gpt-4-* (turbo/32k/dated), the o1 line, and the
+  // legacy completion families are no longer the supported chat models.
+  openai: [/^gpt-3\.5/i, /^gpt-4-turbo/i, /^gpt-4-32k/i, /^gpt-4-\d{3,}/i, /^o1(?:-|$)/i, /^text-/i, /^davinci/i, /^babbage/i],
+};
+
+export function isDeprecatedModelId(provider: string, id: string): boolean {
+  const patterns = LEGACY_MODEL_PATTERNS[provider];
+  if (!patterns) return false;
+  return patterns.some((re) => re.test(id));
+}

--- a/app/src/main/model-catalog.ts
+++ b/app/src/main/model-catalog.ts
@@ -12,6 +12,9 @@ const LEGACY_MODEL_PATTERNS: Record<string, RegExp[]> = {
   google: [/^gemini-1\./i, /^gemini-2\.0\b/i],
   // gpt-3.5, the original gpt-4-* (turbo/32k/dated), the o1 line, and the
   // legacy completion families are no longer the supported chat models.
+  // Note: bare ids with no version suffix (e.g. plain `gpt-4`) deliberately
+  // slip through here rather than risk matching a still-current family -- the
+  // backstop catches them at send time. Don't "tighten" this to grab them.
   openai: [/^gpt-3\.5/i, /^gpt-4-turbo/i, /^gpt-4-32k/i, /^gpt-4-\d{3,}/i, /^o1(?:-|$)/i, /^text-/i, /^davinci/i, /^babbage/i],
 };
 

--- a/app/src/renderer/chat/error-humanizer.ts
+++ b/app/src/renderer/chat/error-humanizer.ts
@@ -11,7 +11,7 @@ export interface HumanizedError {
 
 interface AnthropicLikeError {
   type?: string;
-  error?: { type?: string; message?: string };
+  error?: { type?: string; message?: string; code?: string | number };
   message?: string;
 }
 
@@ -33,6 +33,7 @@ export function humanizeAgentError(raw: string | undefined | null): HumanizedErr
 
   const inner = parsed.error;
   const errType = inner?.type;
+  const errCode = inner?.code;
   const errMsg = inner?.message ?? parsed.message ?? "";
 
   // Google's consumer Generative Language API geo-blocks unsupported regions
@@ -42,6 +43,24 @@ export function humanizeAgentError(raw: string | undefined | null): HumanizedErr
   if (/user location is not supported/i.test(errMsg)) {
     return {
       text: "Gemini isn't available in your region -- Google blocked the request. Switch to a non-Google provider (e.g. Anthropic, OpenAI, or DeepSeek) in Preferences.",
+      retriable: false,
+    };
+  }
+
+  // Backstop for #221: a retired model selected from the picker fails at the
+  // provider. Google keys these on code/status (404 "not found for API version"),
+  // OpenAI returns code "model_not_found" / "has been deprecated" -- neither maps
+  // to an Anthropic `type`, so catch the stable phrasing before the switch and
+  // point the user back to a current model instead of echoing the wire payload.
+  if (
+    errCode === "model_not_found" ||
+    /is not found for API version/i.test(errMsg) ||
+    /\bhas been deprecated\b/i.test(errMsg) ||
+    /\bmodel\b[^.]*\bdoes not exist\b/i.test(errMsg) ||
+    /\bno longer (available|supported)\b/i.test(errMsg)
+  ) {
+    return {
+      text: "That model is no longer available from the provider. Pick a current model in Preferences.",
       retriable: false,
     };
   }

--- a/tests/error-humanizer-retired-model.test.ts
+++ b/tests/error-humanizer-retired-model.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { humanizeAgentError } from "../app/src/renderer/chat/error-humanizer.js";
+
+// Backstop for #221: a retired model selected from the picker errors at the
+// provider. Google keys these on code/status (no Anthropic-style `type`), and
+// OpenAI returns model_not_found -- both should produce an actionable message
+// telling the user to pick a current model, not the raw wire payload.
+describe("humanizeAgentError -- retired/unavailable model", () => {
+  it("explains a Google 'not found for API version' error", () => {
+    const raw = JSON.stringify({
+      error: {
+        code: 404,
+        message:
+          "models/gemini-2.0-flash is not found for API version v1beta, or is not supported for generateContent. Call ListModels to see the list of available models and their supported methods.",
+        status: "NOT_FOUND",
+      },
+    });
+    const result = humanizeAgentError(raw);
+    expect(result.text).toMatch(/no longer available|not available/i);
+    expect(result.text).toMatch(/Preferences|current model/i);
+    expect(result.text).not.toContain("{");
+    expect(result.retriable).toBe(false);
+  });
+
+  it("explains an OpenAI deprecated/model_not_found error", () => {
+    const raw = JSON.stringify({
+      error: {
+        message: "The model `gpt-4-turbo-preview` has been deprecated. Learn more at https://example",
+        type: "invalid_request_error",
+        code: "model_not_found",
+      },
+    });
+    const result = humanizeAgentError(raw);
+    expect(result.text).toMatch(/no longer available|not available/i);
+    expect(result.text).toMatch(/Preferences|current model/i);
+    expect(result.retriable).toBe(false);
+  });
+
+  it("does not misfire on the region geo-block message", () => {
+    const raw = JSON.stringify({
+      error: { code: 400, status: "FAILED_PRECONDITION", message: "User location is not supported for the API use." },
+    });
+    const result = humanizeAgentError(raw);
+    expect(result.text).toMatch(/region/i);
+  });
+});

--- a/tests/model-catalog.test.ts
+++ b/tests/model-catalog.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { isDeprecatedModelId } from "../app/src/main/model-catalog.js";
+
+describe("isDeprecatedModelId", () => {
+  it("flags legacy Google generations (1.x and 2.0)", () => {
+    expect(isDeprecatedModelId("google", "gemini-2.0-flash")).toBe(true);
+    expect(isDeprecatedModelId("google", "gemini-2.0-flash-lite")).toBe(true);
+    expect(isDeprecatedModelId("google", "gemini-1.5-pro")).toBe(true);
+    expect(isDeprecatedModelId("google", "gemini-1.5-flash-8b")).toBe(true);
+  });
+
+  it("keeps current Google models (2.5+, 3.x, latest aliases)", () => {
+    expect(isDeprecatedModelId("google", "gemini-2.5-flash")).toBe(false);
+    expect(isDeprecatedModelId("google", "gemini-2.5-pro")).toBe(false);
+    expect(isDeprecatedModelId("google", "gemini-3.5-flash")).toBe(false);
+    expect(isDeprecatedModelId("google", "gemini-flash-latest")).toBe(false);
+  });
+
+  it("flags legacy OpenAI models", () => {
+    expect(isDeprecatedModelId("openai", "gpt-4-turbo")).toBe(true);
+    expect(isDeprecatedModelId("openai", "gpt-3.5-turbo")).toBe(true);
+    expect(isDeprecatedModelId("openai", "o1")).toBe(true);
+    expect(isDeprecatedModelId("openai", "o1-mini")).toBe(true);
+  });
+
+  it("keeps current OpenAI models", () => {
+    expect(isDeprecatedModelId("openai", "gpt-4o")).toBe(false);
+    expect(isDeprecatedModelId("openai", "gpt-4o-mini")).toBe(false);
+  });
+
+  it("never hides models for providers without a legacy list", () => {
+    expect(isDeprecatedModelId("anthropic", "claude-opus-4-8")).toBe(false);
+    expect(isDeprecatedModelId("deepseek", "deepseek-v4-pro")).toBe(false);
+    expect(isDeprecatedModelId("some-custom-provider", "whatever-1.0")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #221.

## Problem

`models:list-all` populates the Orbit model picker straight from pi-ai's full registry, which still lists generations the provider API has retired -- gemini-2.0-flash, gemini-1.5-*, the old gpt-4/o1 families. Picking one just 404s at send time, and the raw wire payload lands in chat.

Dropping `models:list-all` isn't the answer -- it's what keeps pricing/context-window data current and auto-surfaces *new* models (gemini-3.x and the `-latest` aliases testers are already using). The bug is using its raw output as the selectable picker list. pi's model metadata has no `deprecated` flag, so there's no authoritative signal to filter on.

## Change

- New `app/src/main/model-catalog.ts` -- `isDeprecatedModelId(provider, id)`, a tight per-provider legacy-pattern list (google `gemini-1.*` / `gemini-2.0`; openai `gpt-3.5` / `gpt-4-turbo` / `-32k` / dated / `o1*` / legacy completion families). Providers without a list never hide anything, so new models keep flowing through automatically -- only a newly-dead generation needs a pattern added.
- `models:list-all` filters `getModels(provider)` through it before building the picker entries.
- Error-humanizer backstop: a retired model that slips the denylist (Google "not found for API version", OpenAI `model_not_found` / "has been deprecated") now yields *"That model is no longer available from the provider. Pick a current model in Preferences."* instead of the raw payload. The region geo-block message is verified not to misfire into it.

## Follow-up

#236 tracks the durable version -- probe each provider's live `/models` endpoint and intersect with pi's registry, so availability is authoritative and self-maintaining for both new and retired models. Larger change (per-provider auth, network, offline fallback), kept out of this PR.

## Tests

8 new (5 denylist + 3 backstop). Full root suite 573 green; root + app typecheck clean.
