### PR TITLE
feat(orbit): Galaxy history link in the Activity tab

### DIFF
--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -579,6 +579,44 @@ export function registerIpcHandlers(agent: AgentManager): void {
     return { opened: true };
   });
 
+  // Opens the bound Galaxy history in the user's default browser when the user
+  // clicks the link in the Activity tab. The renderer never gets a generic
+  // openExternal capability. We pin the destination to the configured Galaxy
+  // server: the URL must be http(s), its origin must match the active Galaxy
+  // profile, and its path must end in the canonical /histories/view view. The
+  // origin pin is the real trust boundary; the path suffix is a sanity check.
+  // pathname.endsWith (not ===) is required so subpath deployments
+  // (https://example.org/galaxy/histories/view) are accepted.
+  ipcMain.handle("galaxy:open-history", async (_e, url: unknown) => {
+    if (typeof url !== "string") return { opened: false };
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return { opened: false };
+    }
+    const httpScheme = parsed.protocol === "https:" || parsed.protocol === "http:";
+    if (!httpScheme || !parsed.pathname.endsWith("/histories/view")) {
+      return { opened: false };
+    }
+    // Pin the host to the active Galaxy profile so a compromised renderer
+    // cannot point this at an attacker-controlled host that also serves
+    // /histories/view.
+    const cfg = loadConfig();
+    const active = cfg.galaxy?.active;
+    const serverUrl = active ? cfg.galaxy?.profiles?.[active]?.url : undefined;
+    if (!serverUrl) return { opened: false };
+    let expectedOrigin: string;
+    try {
+      expectedOrigin = new URL(serverUrl).origin;
+    } catch {
+      return { opened: false };
+    }
+    if (parsed.origin !== expectedOrigin) return { opened: false };
+    await shell.openExternal(parsed.toString());
+    return { opened: true };
+  });
+
   // Apply a downloaded macOS update + relaunch. autoUpdater.quitAndInstall is a
   // no-op unless an update was actually downloaded, so this is safe to call.
   ipcMain.handle("update:restart", () => {

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -153,6 +153,7 @@ export interface OrbitAPI {
   } | null>;
   getVersion(): Promise<{ version: string; isPackaged: boolean }>;
   openReleasePage(url?: string): Promise<{ opened: boolean }>;
+  openGalaxyHistory(url: string): Promise<{ opened: boolean }>;
   restartToUpdate(): Promise<{ restarting: boolean }>;
   onUpdateDownloaded(cb: (info: { version: string }) => void): void;
   onUpdateError(cb: (info: { message: string }) => void): void;
@@ -260,6 +261,7 @@ const api: OrbitAPI = {
   checkVersion: () => ipcRenderer.invoke("version:check"),
   getVersion: () => ipcRenderer.invoke("version:current"),
   openReleasePage: (url) => ipcRenderer.invoke("version:open-release", url),
+  openGalaxyHistory: (url) => ipcRenderer.invoke("galaxy:open-history", url),
   restartToUpdate: () => ipcRenderer.invoke("update:restart"),
   onUpdateDownloaded: (cb) => {
     ipcRenderer.on("update:downloaded", (_e, info) => cb(info));

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -6,6 +6,7 @@ import { ArtifactPanel } from "./artifacts/artifact-panel.js";
 import { FilesPanel } from "./files/files-panel.js";
 import { FileViewer } from "./files/file-viewer.js";
 import { refreshGalaxyInvocations } from "./galaxy-invocations.js";
+import { refreshGalaxyHistory } from "./galaxy-history.js";
 import { PromptQueue, queuedPreview } from "./prompt-queue.js";
 import { LoomWidgetKey, decodeMarkdownWidget } from "../../../shared/loom-shell-contract.js";
 import { ALLOWED_SKILLS_PREFIX, isAllowedSkillUrl } from "../../../shared/loom-config.js";
@@ -573,10 +574,12 @@ document.addEventListener("mouseup", () => {
 // Initial tree population + live updates from the main-process watcher.
 void filesPanel.refresh();
 void refreshGalaxyInvocations(window.orbit);
+void refreshGalaxyHistory(window.orbit);
 window.orbit.onFilesChanged(() => {
   void filesPanel.refresh();
   void fileViewer.refreshFromDisk();
   void refreshGalaxyInvocations(window.orbit);
+  void refreshGalaxyHistory(window.orbit);
 });
 
 // ── Galaxy connection indicator ──────────────────────────────────────────────
@@ -605,6 +608,11 @@ async function refreshGalaxyStatus(): Promise<void> {
     galaxyStatus.classList.remove("status-dot-connected");
     galaxyStatus.title = "Galaxy: not configured (open Preferences to add a profile)";
   }
+
+  // The Galaxy history section is driven off the same connection signal so it
+  // hides on disconnect and tracks profile switches (which file changes alone
+  // would miss — disconnect doesn't touch notebook.md).
+  void refreshGalaxyHistory(window.orbit);
 }
 
 void refreshGalaxyStatus();

--- a/app/src/renderer/galaxy-history.ts
+++ b/app/src/renderer/galaxy-history.ts
@@ -1,0 +1,186 @@
+/**
+ * Galaxy history panel — the "Galaxy history" section in the Activity tab.
+ * Surfaces the Galaxy history the notebook is bound to as a clickable link that
+ * opens the history in the user's default browser.
+ *
+ * Data sources, and why:
+ *  - history id comes from the `loom-galaxy-page` YAML block the brain writes
+ *    into notebook.md (the same on-disk pattern the invocations panel reads).
+ *    This is the notebook's bound page history, not the brain's live
+ *    `state.currentHistoryId` — the brain does not persist the live history
+ *    anywhere the shell can read, so surfacing it would require a new
+ *    brain->shell channel. See the test+fix notes for that follow-up.
+ *  - the server origin comes from the *active Galaxy profile* (live config),
+ *    not the server recorded in the binding. The binding records the server at
+ *    bind time; the active profile is the connection the user is on right now.
+ *    Driving off the live profile means the section hides on disconnect and
+ *    tracks profile switches, and the opened link always targets the server
+ *    Orbit is actually connected to.
+ *
+ * Hidden when Galaxy is not connected, when no binding exists, or when the URL
+ * can't be built. Building the web URL is a shell concern — the Loom brain
+ * stays shell-neutral.
+ */
+
+const BINDING_FENCE_OPEN = "```loom-galaxy-page";
+const BINDING_FENCE_CLOSE = "```";
+
+interface GalaxyHistoryBinding {
+  historyId: string;
+}
+
+function unescape(value: string): string {
+  if (value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\"/g, '"');
+  }
+  return value;
+}
+
+/**
+ * Parse `loom-galaxy-page` blocks from notebook.md, keeping the history id the
+ * link needs. Mirrors the brain-side findGalaxyPageBlocks() grammar
+ * (extensions/loom/galaxy-page-binding.ts).
+ */
+export function parseGalaxyHistoryBindings(content: string): GalaxyHistoryBinding[] {
+  const out: GalaxyHistoryBinding[] = [];
+  const lines = content.split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    if (lines[i].trim() === BINDING_FENCE_OPEN) {
+      const start = i + 1;
+      let end = start;
+      while (end < lines.length && lines[end].trim() !== BINDING_FENCE_CLOSE) end++;
+      const fields: Record<string, string> = {};
+      for (const line of lines.slice(start, end)) {
+        const m = line.match(/^([a-z_]+):\s*(.*)$/);
+        if (m) fields[m[1]] = unescape(m[2].trim());
+      }
+      if (fields.history_id) {
+        out.push({ historyId: fields.history_id });
+      }
+      i = end + 1;
+    } else {
+      i++;
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the canonical Galaxy history-view URL. Appends to the full server URL
+ * (after stripping trailing slashes) so subpath deployments like
+ * `https://example.org/galaxy` resolve to `https://example.org/galaxy/histories/view`,
+ * matching how galaxy-api.ts builds `${url}/api...`. Resolving against the
+ * origin (`new URL("/histories/view", serverUrl)`) would drop the prefix.
+ * Returns null when the server URL is unparseable so we never render a broken
+ * or unsafe link.
+ */
+export function buildHistoryUrl(serverUrl: string, historyId: string): string | null {
+  try {
+    const base = serverUrl.replace(/\/+$/, "");
+    const url = new URL(`${base}/histories/view`);
+    url.searchParams.set("id", historyId);
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read the active Galaxy profile's server URL from masked config, or null when
+ * Galaxy is not connected. Mirrors refreshGalaxyStatus()'s connection check so
+ * the section appears/hides on the same connect/disconnect/profile-switch
+ * signal as the connection indicator.
+ */
+function activeGalaxyServerUrl(cfg: Record<string, unknown>): string | null {
+  const galaxy = cfg.galaxy as
+    | { active?: string | null; profiles?: Record<string, { url?: string; hasApiKey?: boolean }> }
+    | undefined;
+  const active = galaxy?.active;
+  const profile = active ? galaxy?.profiles?.[active] : undefined;
+  if (!profile?.url || !profile?.hasApiKey) return null;
+  return profile.url;
+}
+
+/**
+ * Render the Galaxy history section. Uses the first binding block (today's MVP
+ * is one binding per notebook) for the history id and the active Galaxy profile
+ * for the server. Hides the section when Galaxy is not connected, there's no
+ * binding, or the URL can't be built.
+ */
+export async function refreshGalaxyHistory(api: {
+  readFile: (p: string) => Promise<{ ok: true; bytes: Uint8Array } | { ok: false }>;
+  getConfig: () => Promise<Record<string, unknown>>;
+  openGalaxyHistory: (url: string) => Promise<{ opened: boolean }>;
+}): Promise<void> {
+  const section = document.getElementById("activity-galaxy-history-section");
+  const body = document.getElementById("galaxy-history-body");
+  if (!section || !body) return;
+
+  const hide = (): void => {
+    section.classList.add("hidden");
+    body.replaceChildren();
+  };
+
+  let serverUrl: string | null = null;
+  try {
+    serverUrl = activeGalaxyServerUrl(await api.getConfig());
+  } catch {
+    /* config unavailable — treat as not connected */
+  }
+  if (!serverUrl) {
+    hide();
+    return;
+  }
+
+  let bindings: GalaxyHistoryBinding[] = [];
+  try {
+    const res = await api.readFile("notebook.md");
+    if (res.ok) {
+      const text = new TextDecoder("utf-8").decode(res.bytes);
+      bindings = parseGalaxyHistoryBindings(text);
+    }
+  } catch {
+    /* notebook missing — no binding */
+  }
+
+  const binding = bindings[0];
+  const historyUrl = binding ? buildHistoryUrl(serverUrl, binding.historyId) : null;
+
+  if (!binding || !historyUrl) {
+    hide();
+    return;
+  }
+
+  let host: string;
+  try {
+    host = new URL(serverUrl).host;
+  } catch {
+    host = serverUrl;
+  }
+
+  const row = document.createElement("div");
+  row.className = "galaxy-history-row";
+
+  const link = document.createElement("a");
+  link.className = "galaxy-history-link";
+  // Real destination in href (hover/copy-link shows where it goes); the click
+  // handler preventDefaults and routes through the host-pinned IPC path so the
+  // Electron window never navigates. main.ts's will-navigate guard backstops
+  // this if the handler ever fails to attach.
+  link.href = historyUrl;
+  link.textContent = "History";
+  link.title = `Open history ${binding.historyId} in Galaxy (${host})`;
+  link.addEventListener("click", (e) => {
+    e.preventDefault();
+    void api.openGalaxyHistory(historyUrl);
+  });
+
+  const meta = document.createElement("span");
+  meta.className = "galaxy-history-meta";
+  meta.textContent = host;
+
+  row.append(link, meta);
+  body.replaceChildren(row);
+  section.classList.remove("hidden");
+}

--- a/app/src/renderer/galaxy-invocations.ts
+++ b/app/src/renderer/galaxy-invocations.ts
@@ -1,5 +1,6 @@
 /**
- * Galaxy invocations panel — third section in the Activity tab. Parses
+ * Galaxy invocations panel — an Activity-tab section (rendered after the
+ * Galaxy history section). Parses
  * `loom-invocation` YAML blocks from `notebook.md` and draws a live
  * progress row per active workflow.
  *

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -271,6 +271,12 @@
               </div>
             </div>
             <div id="activity-view" class="pane-body hidden">
+              <div id="activity-galaxy-history-section" class="hidden">
+                <div class="activity-section-header">
+                  <span>Galaxy history</span>
+                </div>
+                <div id="galaxy-history-body"></div>
+              </div>
               <div id="activity-galaxy-section" class="hidden">
                 <div class="activity-section-header">
                   <span

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -1599,6 +1599,45 @@ body.platform-darwin #files-title {
   padding: 6px 12px 8px;
 }
 
+#activity-galaxy-history-section {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  background: var(--masthead);
+  color: var(--text);
+  overflow: hidden;
+}
+#activity-galaxy-history-section.hidden {
+  display: none;
+}
+
+#galaxy-history-body {
+  padding: 6px 12px 8px;
+}
+
+.galaxy-history-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+}
+.galaxy-history-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+  cursor: pointer;
+}
+.galaxy-history-link:hover {
+  text-decoration: underline;
+}
+.galaxy-history-meta {
+  color: var(--text-dim);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .galaxy-invocation-row {
   padding: 6px 0;
   border-bottom: 1px solid var(--border);

--- a/tests/galaxy-history.test.ts
+++ b/tests/galaxy-history.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { buildHistoryUrl, parseGalaxyHistoryBindings } from "../app/src/renderer/galaxy-history";
+
+describe("buildHistoryUrl", () => {
+  it("builds the canonical view URL for a root-path server", () => {
+    expect(buildHistoryUrl("https://usegalaxy.org", "abc123")).toBe(
+      "https://usegalaxy.org/histories/view?id=abc123",
+    );
+  });
+
+  it("preserves a subpath prefix instead of resolving against the origin", () => {
+    // Regression: new URL("/histories/view", base) would drop "/galaxy".
+    expect(buildHistoryUrl("https://example.org/galaxy", "h1")).toBe(
+      "https://example.org/galaxy/histories/view?id=h1",
+    );
+  });
+
+  it("strips trailing slashes on the server URL", () => {
+    expect(buildHistoryUrl("https://example.org/galaxy/", "h1")).toBe(
+      "https://example.org/galaxy/histories/view?id=h1",
+    );
+    expect(buildHistoryUrl("https://usegalaxy.org///", "h1")).toBe(
+      "https://usegalaxy.org/histories/view?id=h1",
+    );
+  });
+
+  it("URL-encodes the history id query param", () => {
+    expect(buildHistoryUrl("https://usegalaxy.org", "a b&c")).toBe(
+      "https://usegalaxy.org/histories/view?id=a+b%26c",
+    );
+  });
+
+  it("returns null for an unparseable server URL", () => {
+    expect(buildHistoryUrl("not a url", "h1")).toBeNull();
+    expect(buildHistoryUrl("", "h1")).toBeNull();
+  });
+});
+
+describe("parseGalaxyHistoryBindings", () => {
+  it("parses the history id from a well-formed block", () => {
+    const md = [
+      "# Notebook",
+      "",
+      "```loom-galaxy-page",
+      "page_id: page123",
+      'galaxy_server_url: "https://usegalaxy.org"',
+      "history_id: hist456",
+      "bound_at: 2026-01-01T00:00:00Z",
+      "```",
+      "",
+    ].join("\n");
+    expect(parseGalaxyHistoryBindings(md)).toEqual([{ historyId: "hist456" }]);
+  });
+
+  it("returns no bindings when the block lacks a history_id", () => {
+    const md = [
+      "```loom-galaxy-page",
+      "page_id: page123",
+      'galaxy_server_url: "https://usegalaxy.org"',
+      "```",
+    ].join("\n");
+    expect(parseGalaxyHistoryBindings(md)).toEqual([]);
+  });
+
+  it("ignores other fenced blocks", () => {
+    const md = [
+      "```loom-invocation",
+      "history_id: not_this_one",
+      "```",
+      "```python",
+      "history_id = 'nope'",
+      "```",
+    ].join("\n");
+    expect(parseGalaxyHistoryBindings(md)).toEqual([]);
+  });
+
+  it("returns an empty array for content with no blocks", () => {
+    expect(parseGalaxyHistoryBindings("just some prose")).toEqual([]);
+    expect(parseGalaxyHistoryBindings("")).toEqual([]);
+  });
+
+  it("parses multiple blocks in document order", () => {
+    const md = [
+      "```loom-galaxy-page",
+      "history_id: first",
+      "```",
+      "text",
+      "```loom-galaxy-page",
+      "history_id: second",
+      "```",
+    ].join("\n");
+    expect(parseGalaxyHistoryBindings(md)).toEqual([
+      { historyId: "first" },
+      { historyId: "second" },
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Adds a **"Galaxy history"** section to the Activity tab — a clickable link that opens the bound Galaxy history in the user's default browser. Requested so there's a prominent, one-click way to jump to the history Orbit is working in.

It mirrors the existing Activity-tab section pattern (it renders just above the Galaxy invocations list).

## How

- **`galaxy-history.ts`** (renderer): parses the `loom-galaxy-page` binding from `notebook.md` (same on-disk pattern the invocations panel uses) for the history id, and takes the **server origin from the live active Galaxy profile** — so the section hides on disconnect and follows profile switches, and the opened link always points at the server Orbit is actually connected to.
- **`galaxy:open-history` IPC** (main): host-pinned. The URL must be http(s), end in `/histories/view`, and its origin must match the active profile. The renderer never gets a generic `openExternal`. The link `preventDefault`s and routes through IPC; the Electron window never navigates (the existing `will-navigate` guard backstops it).
- URL building is subpath-aware (`https://host/galaxy/histories/view?id=…`) and lives in the shell — **Loom stays shell-neutral** (brain supplies the binding; the shell builds the URL).
- Refreshes on load, notebook change, and connect/disconnect/profile switch. Hides cleanly when not connected / no binding / URL unbuildable.

## Known limitation (design decision — feedback welcome)

The history id is the notebook's **bound-page history** (`loom-galaxy-page` block), **not** the brain's live `state.currentHistoryId`. The live value isn't persisted anywhere the shell can read, and `state.ts` discards the server URL — surfacing it would require a **new brain→shell channel**. In the common case (a notebook bound to a Galaxy page/history) they're the same; they can diverge if a session creates a fresh history mid-run without re-binding. Filing the live-history channel as a follow-up if we want exact "current history" semantics.

## Process / validation

Built via a multi-agent workflow (explore → implement → 3-lens review incl. link-safety → test+fix). Root + app `tsc --noEmit` clean; **575 tests pass** (10 new in `tests/galaxy-history.test.ts`).

To see it: `cd app && npm start`, connect Galaxy, open the Activity tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)