### PR TITLE
feat: chat export, clipboard markdown, and selection copy button

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -418,6 +418,7 @@ modelIndicatorEl.addEventListener("click", () => {
 // ── Artifact pane collapse/expand ────────────────────────────────────────────
 
 const ARTIFACT_COLLAPSED_KEY = "orbit.artifactCollapsed";
+const exportChatBtn = document.getElementById("export-chat-btn")!;
 const artifactToggleBtn = document.getElementById("artifact-toggle")!;
 
 // Apply visual state without persisting; used by responsive auto-collapse.
@@ -436,6 +437,18 @@ setArtifactCollapsed(savedCollapsed === null ? true : savedCollapsed === "1");
 
 artifactToggleBtn.addEventListener("click", () => {
   setArtifactCollapsed(!document.body.classList.contains("artifact-collapsed"));
+});
+
+exportChatBtn.addEventListener("click", () => {
+  const md = chat.exportAsMarkdown();
+  if (!md.trim()) return;
+  const blob = new Blob([md], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `orbit-chat-${new Date().toISOString().slice(0, 19).replace(/[T:]/g, "-")}.md`;
+  a.click();
+  URL.revokeObjectURL(url);
 });
 
 // Cmd/Ctrl+\ keyboard shortcut

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -36,9 +36,11 @@ export class ChatPanel {
   private lastErrorText = "";
   private lastErrorCount = 0;
   private history: MessageRecord[] = [];
+  private copyBtn: HTMLElement;
 
   constructor(container: HTMLElement) {
     this.container = container;
+    this.copyBtn = this.initCopyButton();
 
     this.container.addEventListener("scroll", () => {
       const { scrollTop, scrollHeight, clientHeight } = this.container;
@@ -423,6 +425,51 @@ export class ChatPanel {
     return lines.join("\n---\n\n");
   }
 
+  private initCopyButton(): HTMLElement {
+    const btn = document.createElement("button");
+    btn.className = "chat-copy-btn";
+    btn.hidden = true;
+    btn.innerHTML = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy`;
+    document.body.appendChild(btn);
+
+    // Prevent the click from clearing the selection before we read it
+    btn.addEventListener("mousedown", (e) => e.preventDefault());
+
+    btn.addEventListener("click", () => {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0) return;
+      const frag = sel.getRangeAt(0).cloneContents();
+      const tmp = document.createElement("div");
+      tmp.appendChild(frag);
+      const md = fragmentToMarkdown(tmp);
+      navigator.clipboard.writeText(md).then(() => {
+        btn.textContent = "✓ Copied";
+        setTimeout(() => {
+          btn.innerHTML = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy`;
+          btn.hidden = true;
+          sel.removeAllRanges();
+        }, 1200);
+      });
+    });
+
+    document.addEventListener("selectionchange", () => {
+      const sel = window.getSelection();
+      if (!sel || sel.isCollapsed || sel.rangeCount === 0) { btn.hidden = true; return; }
+      const range = sel.getRangeAt(0);
+      if (!this.container.contains(range.commonAncestorContainer)) { btn.hidden = true; return; }
+      const rect = range.getBoundingClientRect();
+      if (!rect.width && !rect.height) { btn.hidden = true; return; }
+      btn.hidden = false;
+      const bh = 28, bw = 80;
+      const top = rect.bottom + 6 + bh > window.innerHeight ? rect.top - bh - 4 : rect.bottom + 4;
+      const left = Math.max(4, Math.min(rect.right - bw, window.innerWidth - bw - 4));
+      btn.style.top = `${top}px`;
+      btn.style.left = `${left}px`;
+    });
+
+    return btn;
+  }
+
   private renderCurrentMessage(): void {
     if (!this.currentMessage) return;
 
@@ -451,6 +498,47 @@ export class ChatPanel {
         this.container.scrollTop = this.container.scrollHeight;
       });
     }
+  }
+}
+
+function fragmentToMarkdown(el: HTMLElement): string {
+  return nodeToMd(el).trim();
+}
+
+function nodeToMd(node: Node): string {
+  if (node.nodeType === Node.TEXT_NODE) return node.textContent ?? "";
+  if (node.nodeType !== Node.ELEMENT_NODE) return "";
+  const el = node as HTMLElement;
+  const tag = el.tagName.toLowerCase();
+  const inner = () => Array.from(el.childNodes).map(nodeToMd).join("");
+
+  switch (tag) {
+    case "strong": case "b": return `**${inner()}**`;
+    case "em": case "i": return `*${inner()}*`;
+    case "del": case "s": return `~~${inner()}~~`;
+    case "code":
+      if (el.closest("pre")) return el.textContent ?? "";
+      return `\`${el.textContent ?? ""}\``;
+    case "pre": {
+      const code = el.querySelector("code");
+      const lang = (code?.className ?? "").match(/language-(\w+)/)?.[1] ?? "";
+      return `\`\`\`${lang}\n${(code ?? el).textContent ?? ""}\n\`\`\``;
+    }
+    case "h1": return `# ${inner()}\n`;
+    case "h2": return `## ${inner()}\n`;
+    case "h3": return `### ${inner()}\n`;
+    case "h4": return `#### ${inner()}\n`;
+    case "h5": return `##### ${inner()}\n`;
+    case "h6": return `###### ${inner()}\n`;
+    case "p": return `${inner()}\n\n`;
+    case "br": return "\n";
+    case "ul": return Array.from(el.children).map(li => `- ${nodeToMd(li)}`).join("\n") + "\n";
+    case "ol": return Array.from(el.children).map((li, i) => `${i + 1}. ${nodeToMd(li)}`).join("\n") + "\n";
+    case "li": return inner();
+    case "a": return `[${inner()}](${el.getAttribute("href") ?? ""})`;
+    case "blockquote": return inner().split("\n").map(l => `> ${l}`).join("\n");
+    case "hr": return "---\n";
+    default: return inner();
   }
 }
 

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -42,6 +42,17 @@ export class ChatPanel {
     this.container = container;
     this.copyBtn = this.initCopyButton();
 
+    this.container.addEventListener("copy", (e) => {
+      const sel = window.getSelection();
+      if (!sel || sel.rangeCount === 0) return;
+      const frag = sel.getRangeAt(0).cloneContents();
+      const tmp = document.createElement("div");
+      tmp.appendChild(frag);
+      const md = fragmentToMarkdown(tmp);
+      e.preventDefault();
+      e.clipboardData!.setData("text/plain", md);
+    });
+
     this.container.addEventListener("scroll", () => {
       const { scrollTop, scrollHeight, clientHeight } = this.container;
       this.scrollLocked = scrollHeight - scrollTop - clientHeight < 40;

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -10,7 +10,7 @@ import type {
   ParameterSpec,
 } from "../../../../shared/loom-shell-contract.js";
 
-type MessageRecord =
+export type MessageRecord =
   | { role: "user"; text: string }
   | { role: "assistant"; text: string }
   | { role: "tool"; name: string; status: string; result?: string }
@@ -420,20 +420,7 @@ export class ChatPanel {
 
   /** Export the current conversation as a Markdown string. */
   exportAsMarkdown(): string {
-    const lines: string[] = [];
-    for (const rec of this.history) {
-      if (rec.role === "user") {
-        lines.push(`**You**\n\n${rec.text}\n`);
-      } else if (rec.role === "assistant") {
-        lines.push(`**Assistant**\n\n${rec.text}\n`);
-      } else if (rec.role === "tool") {
-        const badge = rec.status === "done" ? "✓" : rec.status === "error" ? "✗" : "…";
-        lines.push(`*Tool call ${badge}: \`${rec.name}\`*${rec.result ? `\n\n\`\`\`\n${rec.result}\n\`\`\`` : ""}\n`);
-      } else if (rec.role === "error") {
-        lines.push(`*Error: ${rec.text}*\n`);
-      }
-    }
-    return lines.join("\n---\n\n");
+    return historyToMarkdown(this.history);
   }
 
   private initCopyButton(): HTMLElement {
@@ -532,7 +519,24 @@ export class ChatPanel {
   }
 }
 
-function fragmentToMarkdown(el: HTMLElement): string {
+export function historyToMarkdown(records: MessageRecord[]): string {
+  const lines: string[] = [];
+  for (const rec of records) {
+    if (rec.role === "user") {
+      lines.push(`**You**\n\n${rec.text}\n`);
+    } else if (rec.role === "assistant") {
+      lines.push(`**Assistant**\n\n${rec.text}\n`);
+    } else if (rec.role === "tool") {
+      const badge = rec.status === "done" ? "✓" : rec.status === "error" ? "✗" : "…";
+      lines.push(`*Tool call ${badge}: \`${rec.name}\`*${rec.result ? `\n\n\`\`\`\n${rec.result}\n\`\`\`` : ""}\n`);
+    } else if (rec.role === "error") {
+      lines.push(`*Error: ${rec.text}*\n`);
+    }
+  }
+  return lines.join("\n---\n\n");
+}
+
+export function fragmentToMarkdown(el: HTMLElement): string {
   return nodeToMd(el).trim();
 }
 

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -432,8 +432,21 @@ export class ChatPanel {
     btn.innerHTML = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy`;
     document.body.appendChild(btn);
 
-    // Prevent the click from clearing the selection before we read it
-    btn.addEventListener("mousedown", (e) => e.preventDefault());
+    // selectionchange fires while a mousedown is still in progress and the old
+    // selection is still live, which would immediately re-show the button we
+    // just hid. Track mousedown state so selectionchange can't re-show it.
+    let mouseIsDown = false;
+
+    btn.addEventListener("mousedown", (e) => e.preventDefault()); // keep selection alive on button click
+
+    document.addEventListener("mousedown", (e) => {
+      if (e.target !== btn) { btn.hidden = true; mouseIsDown = true; }
+    });
+    document.addEventListener("mouseup", () => {
+      mouseIsDown = false;
+      updateBtn();
+    });
+    window.addEventListener("blur", () => { btn.hidden = true; });
 
     btn.addEventListener("click", () => {
       const sel = window.getSelection();
@@ -452,7 +465,14 @@ export class ChatPanel {
       });
     });
 
+    // Keyboard selection (Shift+arrow, Ctrl+A, etc.) — selectionchange is safe
+    // here because there's no mousedown race.
     document.addEventListener("selectionchange", () => {
+      if (mouseIsDown) return;
+      updateBtn();
+    });
+
+    const updateBtn = () => {
       const sel = window.getSelection();
       if (!sel || sel.isCollapsed || sel.rangeCount === 0) { btn.hidden = true; return; }
       const range = sel.getRangeAt(0);
@@ -465,7 +485,7 @@ export class ChatPanel {
       const left = Math.max(4, Math.min(rect.right - bw, window.innerWidth - bw - 4));
       btn.style.top = `${top}px`;
       btn.style.left = `${left}px`;
-    });
+    };
 
     return btn;
   }

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -10,6 +10,13 @@ import type {
   ParameterSpec,
 } from "../../../../shared/loom-shell-contract.js";
 
+type MessageRecord =
+  | { role: "user"; text: string }
+  | { role: "assistant"; text: string }
+  | { role: "tool"; name: string; status: string; result?: string }
+  | { role: "info"; text: string }
+  | { role: "error"; text: string };
+
 export class ChatPanel {
   private container: HTMLElement;
   private currentMessage: HTMLElement | null = null;
@@ -28,6 +35,7 @@ export class ChatPanel {
   private lastErrorEl: HTMLElement | null = null;
   private lastErrorText = "";
   private lastErrorCount = 0;
+  private history: MessageRecord[] = [];
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -90,6 +98,7 @@ export class ChatPanel {
   }
 
   addUserMessage(text: string): void {
+    this.history.push({ role: "user", text });
     this.resetErrorDedup();
     const n = ++this.promptCounter;
     const turn = document.createElement("div");
@@ -122,6 +131,7 @@ export class ChatPanel {
    * counter equals the replay's count. Live numbers continue from there.
    */
   addReplayUserMessage(text: string, promptNum: number): void {
+    this.history.push({ role: "user", text });
     this.resetErrorDedup();
     this.promptCounter = promptNum;
     const turn = document.createElement("div");
@@ -155,6 +165,7 @@ export class ChatPanel {
     this.pendingBlockBreak = false;
     this.toolCards.clear();
     this.thinkingEl = null;
+    this.history = [];
   }
 
   showThinking(): void {
@@ -272,12 +283,16 @@ export class ChatPanel {
     }
     // Clean up any stray cursors across the whole container
     this.container.querySelectorAll(".cursor-blink").forEach((c) => c.remove());
+    if (this.currentText) {
+      this.history.push({ role: "assistant", text: this.currentText });
+    }
     this.currentMessage = null;
     this.currentText = "";
     this.pendingBlockBreak = false;
   }
 
   addToolCard(id: string, name: string): void {
+    this.history.push({ role: "tool", name, status: "running" });
     const card = document.createElement("div");
     card.className = "tool-card";
     card.innerHTML = `
@@ -334,6 +349,12 @@ export class ChatPanel {
       const body = card.querySelector(".tool-card-body")!;
       body.textContent = result.slice(0, 2000);
     }
+
+    const rec = this.history.findLast(r => r.role === "tool" && r.name === card.querySelector("span:last-child")?.textContent);
+    if (rec && rec.role === "tool") {
+      rec.status = status;
+      if (result) rec.result = result.slice(0, 2000);
+    }
   }
 
   private resetErrorDedup(): void {
@@ -343,6 +364,7 @@ export class ChatPanel {
   }
 
   addErrorMessage(text: string): void {
+    this.history.push({ role: "error", text });
     if (this.lastErrorEl && this.lastErrorText === text) {
       this.lastErrorCount += 1;
       this.lastErrorEl.textContent = `${text}  (x${this.lastErrorCount})`;
@@ -381,6 +403,24 @@ export class ChatPanel {
     el.innerHTML = html;
     this.container.appendChild(el);
     this.scrollToBottom();
+  }
+
+  /** Export the current conversation as a Markdown string. */
+  exportAsMarkdown(): string {
+    const lines: string[] = [];
+    for (const rec of this.history) {
+      if (rec.role === "user") {
+        lines.push(`**You**\n\n${rec.text}\n`);
+      } else if (rec.role === "assistant") {
+        lines.push(`**Assistant**\n\n${rec.text}\n`);
+      } else if (rec.role === "tool") {
+        const badge = rec.status === "done" ? "✓" : rec.status === "error" ? "✗" : "…";
+        lines.push(`*Tool call ${badge}: \`${rec.name}\`*${rec.result ? `\n\n\`\`\`\n${rec.result}\n\`\`\`` : ""}\n`);
+      } else if (rec.role === "error") {
+        lines.push(`*Error: ${rec.text}*\n`);
+      }
+    }
+    return lines.join("\n---\n\n");
   }
 
   private renderCurrentMessage(): void {

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -438,7 +438,9 @@ export class ChatPanel {
     btn.addEventListener("mousedown", (e) => e.preventDefault()); // keep selection alive on button click
 
     document.addEventListener("mousedown", (e) => {
-      if (e.target !== btn) { btn.hidden = true; mouseIsDown = true; }
+      // contains() so clicking the button's inner <svg> (a child) still counts
+      // as the button -- otherwise the icon hit hides it before the copy fires.
+      if (!btn.contains(e.target as Node)) { btn.hidden = true; mouseIsDown = true; }
     });
     document.addEventListener("mouseup", () => {
       mouseIsDown = false;

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -157,6 +157,18 @@
             </button>
             <span class="pane-title-label">Chat</span>
             <button
+              id="export-chat-btn"
+              class="pane-title-btn"
+              title="Export chat as Markdown"
+              aria-label="Export chat as Markdown"
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                <polyline points="7 10 12 15 17 10"/>
+                <line x1="12" y1="15" x2="12" y2="3"/>
+              </svg>
+            </button>
+            <button
               id="artifact-toggle"
               class="pane-title-btn"
               title="Toggle notebook pane (Ctrl+\)"

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -453,6 +453,30 @@ body.files-collapsed #files-divider {
 
 /* Pane-toggle buttons (files/artifact) live in the chat-pane title bar.
    Subtle by default, brighten on hover, gold when their pane is open. */
+.chat-copy-btn {
+  position: fixed;
+  z-index: 200;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: var(--font-sans);
+  background: var(--bg-surface);
+  color: var(--text);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.4);
+  transition: background 0.1s, color 0.1s;
+  white-space: nowrap;
+}
+.chat-copy-btn:hover {
+  background: var(--bg-hover);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .pane-title-btn {
   appearance: none;
   background: transparent;

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "eslint": "^10.2.1",
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.5.0",
+        "happy-dom": "^20.10.2",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "prettier": "^3.8.3",
@@ -562,6 +563,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2576,6 +2578,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2600,29 +2603,6 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -4068,6 +4048,23 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.61.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
@@ -4113,6 +4110,7 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -4443,6 +4441,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4744,6 +4743,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4787,6 +4787,19 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -5424,6 +5437,7 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5661,6 +5675,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6132,6 +6147,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/happy-dom": {
+      "version": "20.10.2",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.2.tgz",
+      "integrity": "sha512-5p9Sxis3eowDJKqx90QCsgbNA02XXqJ59NOHvD4V6cxp+rP4d/xOyVx7uY3hS8hiUbY1VeiFH8lbJ81AyuDVLQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -6187,6 +6235,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8571,6 +8620,7 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -8665,6 +8715,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8807,6 +8858,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8976,6 +9028,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {
@@ -9153,6 +9215,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.19.tgz",
-      "integrity": "sha512-SMNfLCU/41xxfFaC5Slwy8V/f1FRhakvyeeMeDeIxqNF0DzhDlXsXnJDELJYke1EtnJbfzfilW7tvulGfxMY6A==",
+      "version": "3.974.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.20.tgz",
+      "integrity": "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.12",
@@ -191,12 +191,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.45.tgz",
-      "integrity": "sha512-ZPsnLyrpDRmojKrBbJykASyLLVFkjyD+fWATeSuYgaqablijGOzxPxEKyrwUvNg+bgSQ7PkW2FTu65Xco19Gag==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.46.tgz",
+      "integrity": "sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/core": "^3.974.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -207,12 +207,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.47",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.47.tgz",
-      "integrity": "sha512-1XdgHDIPbARHuzZXM7ouzIbSUZFU9dTi9k+ryMhiZU4QCam4dvwOyUEFjEHNxAZehCYUIOmsSUZ2un6BIgUkWg==",
+      "version": "3.972.48",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.48.tgz",
+      "integrity": "sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/core": "^3.974.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/fetch-http-handler": "^5.4.6",
@@ -239,19 +239,19 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.51",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.51.tgz",
-      "integrity": "sha512-f8sRTVyM+9BbzQKPlUP9dVVpgNEu65jFckNAAGzRfCrlaSi5AWUbCKEHIMcIYokv8pWblSKEqHkqKYZtwINnhw==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.52.tgz",
+      "integrity": "sha512-szg1nnebqC+Svv6Vfsdf6P/QK8x5g/ghG2CKa/1WkHifRnq0BBmDELj2Qnqk9nPsUvEu/OEcYic97CPLpKqF9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/credential-provider-env": "^3.972.45",
-        "@aws-sdk/credential-provider-http": "^3.972.47",
-        "@aws-sdk/credential-provider-login": "^3.972.50",
-        "@aws-sdk/credential-provider-process": "^3.972.45",
-        "@aws-sdk/credential-provider-sso": "^3.972.50",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.50",
-        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-login": "^3.972.51",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
+        "@aws-sdk/nested-clients": "^3.997.19",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/credential-provider-imds": "^4.3.7",
@@ -263,13 +263,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.50.tgz",
-      "integrity": "sha512-NHHsKoMhw6UylSU0XDnDc87+IQW8tRBTIe6vnOX12GSIlBDtoce6bSzONleIglCyu8d3H9bmTSfk+sIN5yh3WA==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.51.tgz",
+      "integrity": "sha512-csHFsH+/VjnI40oqm1l1OqMY4B4kza36DbfcbHcgcbobgjebasqUbTU34xvwUkvtoNGGizbfyMSlMzJWUPv3dQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -280,17 +280,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.53",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.53.tgz",
-      "integrity": "sha512-z/JJ8Qvf2GiTn4bw+x8k7wQjxmPpNsiwZ7ls/h1cZHikrSpS0+65lB+lafnXZlxv1lqH4k6rQwh+2UsycC662g==",
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.54.tgz",
+      "integrity": "sha512-vinTSQtziNHxi2nqXF+76jr2sO44q88Ind1qFFVaotNgBaC1rcWDjBug8yoE8n0ov33s21xks9WY5XDHH9SENw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.45",
-        "@aws-sdk/credential-provider-http": "^3.972.47",
-        "@aws-sdk/credential-provider-ini": "^3.972.51",
-        "@aws-sdk/credential-provider-process": "^3.972.45",
-        "@aws-sdk/credential-provider-sso": "^3.972.50",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.50",
+        "@aws-sdk/credential-provider-env": "^3.972.46",
+        "@aws-sdk/credential-provider-http": "^3.972.48",
+        "@aws-sdk/credential-provider-ini": "^3.972.52",
+        "@aws-sdk/credential-provider-process": "^3.972.46",
+        "@aws-sdk/credential-provider-sso": "^3.972.51",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.51",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/credential-provider-imds": "^4.3.7",
@@ -302,12 +302,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.45.tgz",
-      "integrity": "sha512-QMJXjTGLmHE4Ie03T5H4hHOLfcvMc9DaODO6b5dgte3S8ECf5bBuHUJW4cQREcYZyRkOU8iymqtiBxqF4icxZg==",
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.46.tgz",
+      "integrity": "sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/core": "^3.974.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -318,14 +318,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.50.tgz",
-      "integrity": "sha512-pQ9ww4G53gwHlon1NMz25JhaBo13E9Jv+VVgjh39C/yzvby+xhSnEOb+VDYShKNCh1TbttMF/5CFCHkZrIqOcA==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.51.tgz",
+      "integrity": "sha512-60qhpQcSDIKIr0AuBlmJezKX0b5nbJPCINiR49N9yJXrEI5tTRwsXVBr0IdSvvsNJyqgiINyoBd++Ed0yvggbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
-        "@aws-sdk/token-providers": "3.1064.0",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
+        "@aws-sdk/token-providers": "3.1065.0",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -336,13 +336,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1064.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1064.0.tgz",
-      "integrity": "sha512-sjI+iA4JtgeckBgKwPQF7KzWillRoNDmtpiM0TRa0syiAKFHKUSf84kPXSO3+gA7aMMSxrcxzOM2oPSecaJvEA==",
+      "version": "3.1065.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1065.0.tgz",
+      "integrity": "sha512-qdHQntq82gMqG6Tf8xrgmhJxacaYkxW4PEeDg/ISMVJ84EWe7iD6JyCTgbyox3uNDH6vqEJ8GUiTaXCq307zVw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -353,13 +353,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.50.tgz",
-      "integrity": "sha512-9DbaPaT2aMbz18wtSpq9HVBErjBQwxykqTFgG6n8Bn05GN68mITz+G1869ekYx0mVT/BDjETj5czz/3cPgLwxA==",
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.51.tgz",
+      "integrity": "sha512-0X5eWsUIp8ItRJeJBBrhQAPzc9AQelDetRTVTsycCAISCCzM17R4hs/vFAPeQ0o0B35sciLiqe/Pwmml909cZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
-        "@aws-sdk/nested-clients": "^3.997.18",
+        "@aws-sdk/core": "^3.974.20",
+        "@aws-sdk/nested-clients": "^3.997.19",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/types": "^4.14.3",
@@ -400,12 +400,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.27.tgz",
-      "integrity": "sha512-V/IgUogQm/NSGlNglDCkREirQXgjyrrq64vPt5qcRTGhEJJwPcUB3RyYE6iZ63WNGp4Ezc+JtVRA4QlSbhDvVQ==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.28.tgz",
+      "integrity": "sha512-SCW06Zjugn86pq7+dxGnFcyWJuEWHT753HTU/Vj/OzVxP+NoShwdAr4ynxAcvWL883OgRVbSqW3ohnjIxwXjjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/core": "^3.974.20",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
         "@smithy/fetch-http-handler": "^5.4.6",
@@ -418,14 +418,14 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.18.tgz",
-      "integrity": "sha512-xBWrodBvW5SHCZV11UZUJG0pSHkLCEREIBoNbff1C1sacOUCmxJnTCPE80sCGLCtqgXg98I2MQJe2z28tcZSsw==",
+      "version": "3.997.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.19.tgz",
+      "integrity": "sha512-P2Otgf15GBJMKzG6j5Ddf7w+Kz6z2jvesMy874TD3jlMfDWNK7clJeUd7hgigdeVOotjoUP4emcTWVdS9sfZDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.19",
+        "@aws-sdk/core": "^3.974.20",
         "@aws-sdk/signature-v4-multi-region": "^3.996.33",
         "@aws-sdk/types": "^3.973.12",
         "@smithy/core": "^3.24.6",
@@ -563,7 +563,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2578,7 +2577,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2603,6 +2601,29 @@
       },
       "engines": {
         "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3456,14 +3477,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -4110,7 +4131,6 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -4255,9 +4275,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
-      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4441,7 +4461,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4743,7 +4762,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5196,6 +5214,18 @@
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
       }
     },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -5267,9 +5297,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.370",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.370.tgz",
-      "integrity": "sha512-D5tSHJReAb/Kf3Hu9F/GO4lJuSWzEWHwvQ/kKSUP7pimNgvxkSKj+gUQhHpKKACwrin7rS3byU7IxreF56rl5g==",
+      "version": "1.5.371",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
+      "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
       "dev": true,
       "license": "ISC"
     },
@@ -5299,9 +5329,10 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -5437,7 +5468,6 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5675,7 +5705,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6153,7 +6182,6 @@
       "integrity": "sha512-5p9Sxis3eowDJKqx90QCsgbNA02XXqJ59NOHvD4V6cxp+rP4d/xOyVx7uY3hS8hiUbY1VeiFH8lbJ81AyuDVLQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -6165,19 +6193,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/happy-dom/node_modules/entities": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/has-symbols": {
@@ -6235,7 +6250,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
       "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -6263,6 +6277,18 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.1.0",
         "entities": "^4.5.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-errors": {
@@ -7247,9 +7273,9 @@
       }
     },
     "node_modules/node-abi/node_modules/semver": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
-      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7790,9 +7816,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
-      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.3.tgz",
+      "integrity": "sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -8620,7 +8646,6 @@
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -8715,7 +8740,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8858,7 +8882,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -9215,7 +9238,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "eslint": "^10.2.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.5.0",
+    "happy-dom": "^20.10.2",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.3",

--- a/tests/chat-panel.test.ts
+++ b/tests/chat-panel.test.ts
@@ -1,0 +1,186 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+import {
+  historyToMarkdown,
+  fragmentToMarkdown,
+  type MessageRecord,
+} from "../app/src/renderer/chat/chat-panel.js";
+
+// ── historyToMarkdown ────────────────────────────────────────────────────────
+
+describe("historyToMarkdown", () => {
+  it("returns empty string for empty history", () => {
+    expect(historyToMarkdown([])).toBe("");
+  });
+
+  it("formats a user message", () => {
+    const records: MessageRecord[] = [{ role: "user", text: "hello" }];
+    expect(historyToMarkdown(records)).toBe("**You**\n\nhello\n");
+  });
+
+  it("formats an assistant message", () => {
+    const records: MessageRecord[] = [{ role: "assistant", text: "hi there" }];
+    expect(historyToMarkdown(records)).toBe("**Assistant**\n\nhi there\n");
+  });
+
+  it("formats a tool call with done status and no result", () => {
+    const records: MessageRecord[] = [{ role: "tool", name: "bash", status: "done" }];
+    expect(historyToMarkdown(records)).toBe("*Tool call ✓: `bash`*\n");
+  });
+
+  it("formats a tool call with error status", () => {
+    const records: MessageRecord[] = [{ role: "tool", name: "bash", status: "error" }];
+    expect(historyToMarkdown(records)).toBe("*Tool call ✗: `bash`*\n");
+  });
+
+  it("formats a running tool call", () => {
+    const records: MessageRecord[] = [{ role: "tool", name: "bash", status: "running" }];
+    expect(historyToMarkdown(records)).toBe("*Tool call …: `bash`*\n");
+  });
+
+  it("includes tool result in a code fence when present", () => {
+    const records: MessageRecord[] = [
+      { role: "tool", name: "bash", status: "done", result: "hello world" },
+    ];
+    expect(historyToMarkdown(records)).toBe(
+      "*Tool call ✓: `bash`*\n\n```\nhello world\n```\n",
+    );
+  });
+
+  it("formats an error message", () => {
+    const records: MessageRecord[] = [{ role: "error", text: "something broke" }];
+    expect(historyToMarkdown(records)).toBe("*Error: something broke*\n");
+  });
+
+  it("skips info records", () => {
+    const records: MessageRecord[] = [{ role: "info", text: "— Resumed —" }];
+    expect(historyToMarkdown(records)).toBe("");
+  });
+
+  it("joins multiple records with --- separators", () => {
+    const records: MessageRecord[] = [
+      { role: "user", text: "question" },
+      { role: "assistant", text: "answer" },
+    ];
+    expect(historyToMarkdown(records)).toBe(
+      "**You**\n\nquestion\n\n---\n\n**Assistant**\n\nanswer\n",
+    );
+  });
+});
+
+// ── fragmentToMarkdown ───────────────────────────────────────────────────────
+
+function html(markup: string): HTMLElement {
+  const div = document.createElement("div");
+  div.innerHTML = markup;
+  return div;
+}
+
+describe("fragmentToMarkdown", () => {
+  it("converts plain text", () => {
+    expect(fragmentToMarkdown(html("hello world"))).toBe("hello world");
+  });
+
+  it("converts <strong>", () => {
+    expect(fragmentToMarkdown(html("<strong>bold</strong>"))).toBe("**bold**");
+  });
+
+  it("converts <b>", () => {
+    expect(fragmentToMarkdown(html("<b>bold</b>"))).toBe("**bold**");
+  });
+
+  it("converts <em>", () => {
+    expect(fragmentToMarkdown(html("<em>italic</em>"))).toBe("*italic*");
+  });
+
+  it("converts <i>", () => {
+    expect(fragmentToMarkdown(html("<i>italic</i>"))).toBe("*italic*");
+  });
+
+  it("converts <del>", () => {
+    expect(fragmentToMarkdown(html("<del>struck</del>"))).toBe("~~struck~~");
+  });
+
+  it("converts <s>", () => {
+    expect(fragmentToMarkdown(html("<s>struck</s>"))).toBe("~~struck~~");
+  });
+
+  it("converts inline <code>", () => {
+    expect(fragmentToMarkdown(html("<code>fn()</code>"))).toBe("`fn()`");
+  });
+
+  it("converts <pre><code> with language", () => {
+    expect(
+      fragmentToMarkdown(html('<pre><code class="language-python">x = 1</code></pre>')),
+    ).toBe("```python\nx = 1\n```");
+  });
+
+  it("converts <pre><code> without language", () => {
+    expect(fragmentToMarkdown(html("<pre><code>x = 1</code></pre>"))).toBe(
+      "```\nx = 1\n```",
+    );
+  });
+
+  it("does not double-wrap <code> inside <pre>", () => {
+    const result = fragmentToMarkdown(html("<pre><code>x</code></pre>"));
+    expect(result).not.toContain("``x``");
+    expect(result).toBe("```\nx\n```");
+  });
+
+  it("converts <h1>", () => {
+    expect(fragmentToMarkdown(html("<h1>Title</h1>"))).toBe("# Title");
+  });
+
+  it("converts <h2>", () => {
+    expect(fragmentToMarkdown(html("<h2>Sub</h2>"))).toBe("## Sub");
+  });
+
+  it("converts <h3> through <h6>", () => {
+    expect(fragmentToMarkdown(html("<h3>A</h3>"))).toBe("### A");
+    expect(fragmentToMarkdown(html("<h4>A</h4>"))).toBe("#### A");
+    expect(fragmentToMarkdown(html("<h5>A</h5>"))).toBe("##### A");
+    expect(fragmentToMarkdown(html("<h6>A</h6>"))).toBe("###### A");
+  });
+
+  it("converts <p>", () => {
+    expect(fragmentToMarkdown(html("<p>paragraph</p>"))).toBe("paragraph");
+  });
+
+  it("converts <br>", () => {
+    expect(fragmentToMarkdown(html("line1<br>line2"))).toBe("line1\nline2");
+  });
+
+  it("converts <ul>", () => {
+    expect(fragmentToMarkdown(html("<ul><li>a</li><li>b</li></ul>"))).toBe("- a\n- b");
+  });
+
+  it("converts <ol> with sequential numbering", () => {
+    expect(fragmentToMarkdown(html("<ol><li>first</li><li>second</li></ol>"))).toBe(
+      "1. first\n2. second",
+    );
+  });
+
+  it("converts <a>", () => {
+    expect(fragmentToMarkdown(html('<a href="https://example.com">link</a>'))).toBe(
+      "[link](https://example.com)",
+    );
+  });
+
+  it("converts <blockquote>", () => {
+    expect(fragmentToMarkdown(html("<blockquote>quoted</blockquote>"))).toBe("> quoted");
+  });
+
+  it("converts <hr>", () => {
+    expect(fragmentToMarkdown(html("<hr>"))).toBe("---");
+  });
+
+  it("handles nested formatting: bold inside paragraph", () => {
+    expect(fragmentToMarkdown(html("<p><strong>bold</strong> plain</p>"))).toBe(
+      "**bold** plain",
+    );
+  });
+
+  it("handles nested formatting: italic inside bold", () => {
+    expect(fragmentToMarkdown(html("<strong><em>both</em></strong>"))).toBe("***both***");
+  });
+});


### PR DESCRIPTION
## Summary

- **Export chat** — adds a download button (↓) in the chat header that saves the full conversation as a timestamped `.md` file. Works for both live and restored sessions.
- **Clipboard markdown** — Ctrl+C / Cmd+C within the messages pane now writes markdown (preserving bold, italic, code fences, headings, lists) instead of the browser's plain-text rendering.
- **Selection copy button** — a floating "Copy" button appears near any text selection in the chat; clicking it copies the selected text as markdown to the clipboard. Disappears on click-away or window blur.

## Test plan

- [ ] Start a session, send a few messages including one with code. Click the ↓ button — verify a `.md` file downloads with both user and assistant turns.
- [ ] Restore a previous session, export — verify replayed turns are included.
- [ ] Select text spanning bold/italic/code in an assistant message, press Cmd+C, paste into a text editor — verify markdown syntax is preserved.
- [ ] Select text, click the floating Copy button — verify "✓ Copied" feedback and button disappears.
- [ ] Click elsewhere after a selection — verify the copy button disappears immediately.