### PR TITLE
Make aborting a stuck turn reliable and discoverable (#225)

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -1409,6 +1409,11 @@ messagesEl.addEventListener("click", (e) => {
   target.replaceWith(document.createTextNode("(dismissed)"));
 });
 
+function clearInput(): void {
+  inputEl.value = "";
+  inputEl.style.height = "auto";
+}
+
 function submit(): void {
   const text = inputEl.value.trim();
   if (!text) return;
@@ -1428,8 +1433,7 @@ function submit(): void {
   if (streaming && detectStopIntent(text)) {
     abortCurrentTurn();
     chat.addInfoMessage("<i>Stopping the current response...</i>");
-    inputEl.value = "";
-    inputEl.style.height = "auto";
+    clearInput();
     return;
   }
 
@@ -1438,14 +1442,12 @@ function submit(): void {
   // prompt the agent must join the FIFO queue like any other LLM turn.
   if (streaming && !isLocalSlashCommand(text)) {
     enqueueMessage(text);
-    inputEl.value = "";
-    inputEl.style.height = "auto";
+    clearInput();
     return;
   }
 
   dispatchSubmittedText(text);
-  inputEl.value = "";
-  inputEl.style.height = "auto";
+  clearInput();
 }
 
 function dispatchSubmittedText(text: string): void {

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -1,6 +1,7 @@
 import { ChatPanel } from "./chat/chat-panel.js";
 import { detectCompactIntent } from "./chat/compact-intent.js";
 import { humanizeAgentError } from "./chat/error-humanizer.js";
+import { detectStopIntent } from "./chat/stop-intent.js";
 import { ShellPanel } from "./chat/shell-panel.js";
 import { ArtifactPanel } from "./artifacts/artifact-panel.js";
 import { FilesPanel } from "./files/files-panel.js";
@@ -1420,6 +1421,17 @@ function submit(): void {
 
   // Nudge plain-text "compact"/"reduce context" requests toward /compact (#171).
   maybeShowCompactIntentHint(text);
+
+  // A bare "stop"/"abort" typed during an active turn is a halt intent, not a
+  // prompt to queue behind the very turn the user is trying to kill (#225).
+  // Abort instead of enqueueing, and acknowledge so the intent isn't silent.
+  if (streaming && detectStopIntent(text)) {
+    abortCurrentTurn();
+    chat.addInfoMessage("<i>Stopping the current response...</i>");
+    inputEl.value = "";
+    inputEl.style.height = "auto";
+    return;
+  }
 
   // If the agent is mid-turn, queue the message and flush when agent_end fires.
   // Purely local slash commands still run immediately; slash commands that

--- a/app/src/renderer/chat/stop-intent.ts
+++ b/app/src/renderer/chat/stop-intent.ts
@@ -17,23 +17,20 @@
  * err quiet.
  */
 
-// Polite/filler lead-ins that don't change the intent.
-const LEAD_IN =
-  /(please\s+|can\s+you\s+|could\s+you\s+|would\s+you\s+|just\s+|ok,?\s+|okay,?\s+|hey,?\s+)*/
-    .source;
-// The stop verbs themselves.
-const STOP_VERB = /(stop|abort|halt|cancel)/.source;
-// The only objects allowed after the verb. Each clearly refers to the turn
-// itself, never to a Galaxy/genomic noun -- "stop the response" is in, but
-// "stop the workflow" is deliberately out (it has no "the workflow" object).
-const TURN_OBJECT =
-  /(\s+(it|this|that|now|please|thinking|responding|generating|the\s+response|what\s+you'?re\s+doing|what\s+you\s+are\s+doing))*/
-    .source;
-
-const STOP_INTENT = new RegExp(`^${LEAD_IN}${STOP_VERB}${TURN_OBJECT}[\\s.!?]*$`);
+// A bare stop imperative, in three segments: an optional politeness lead-in
+// ("please ", "can you "...), a stop verb, then only turn-referring objects
+// ("it", "thinking", "the response"...). The object list is the precision
+// knob -- "stop the response" matches, but "stop the FastQC tool" has no
+// matching object and falls through to a normal prompt. Deictic objects
+// ("this"/"that") are deliberately excluded: "cancel that" can mean a Galaxy
+// job, not the turn, and we'd rather miss it than abort something wanted.
+const STOP_INTENT =
+  /^(please\s+|can\s+you\s+|could\s+you\s+|would\s+you\s+|just\s+|ok,?\s+|okay,?\s+|hey,?\s+)*(stop|abort|halt|cancel)(\s+(it|now|please|thinking|responding|generating|the\s+response|what\s+you'?re\s+doing|what\s+you\s+are\s+doing))*[\s.!?]*$/;
 
 export function detectStopIntent(text: string): boolean {
-  const t = text.trim().toLowerCase();
+  // Normalize curly apostrophes (macOS smart-quotes mangle "you're") to ASCII
+  // so the typed phrase still matches the regex.
+  const t = text.trim().toLowerCase().replace(/[‘’]/g, "'");
   if (!t) return false;
   // Slash commands are dispatched, never read as a chat intent.
   if (t.startsWith("/")) return false;

--- a/app/src/renderer/chat/stop-intent.ts
+++ b/app/src/renderer/chat/stop-intent.ts
@@ -1,0 +1,41 @@
+/**
+ * Plain-text "stop the current response" intent detection (issue #225).
+ *
+ * With a slow model, users try to halt a long "thinking" turn by typing
+ * "stop"/"abort thinking"/"stop what you are doing" into chat. While a turn is
+ * streaming those just queue as the next prompt and nothing stops. We detect a
+ * bare stop command shell-side and treat it as an abort instead.
+ *
+ * The hard part is precision: this runs in a bioinformatics tool where "stop"
+ * (a stop codon), "cancel" (cancel a Galaxy workflow invocation), and "abort"
+ * (abort a running job) are real instructions the agent should act on, not
+ * meta-commands to halt the turn. So we only fire on a *bare* stop imperative:
+ * the whole message is a stop word, optionally wrapped in politeness and one of
+ * a small fixed set of objects ("it", "now", "thinking", "the response", ...).
+ * Anything with a real object ("stop the FastQC tool") falls through. False
+ * negatives are cheap -- the labeled Stop button is still right there -- so we
+ * err quiet.
+ */
+
+// Polite/filler lead-ins that don't change the intent.
+const LEAD_IN =
+  /(please\s+|can\s+you\s+|could\s+you\s+|would\s+you\s+|just\s+|ok,?\s+|okay,?\s+|hey,?\s+)*/
+    .source;
+// The stop verbs themselves.
+const STOP_VERB = /(stop|abort|halt|cancel)/.source;
+// The only objects allowed after the verb. Each clearly refers to the turn
+// itself, never to a Galaxy/genomic noun -- "stop the response" is in, but
+// "stop the workflow" is deliberately out (it has no "the workflow" object).
+const TURN_OBJECT =
+  /(\s+(it|this|that|now|please|thinking|responding|generating|the\s+response|what\s+you'?re\s+doing|what\s+you\s+are\s+doing))*/
+    .source;
+
+const STOP_INTENT = new RegExp(`^${LEAD_IN}${STOP_VERB}${TURN_OBJECT}[\\s.!?]*$`);
+
+export function detectStopIntent(text: string): boolean {
+  const t = text.trim().toLowerCase();
+  if (!t) return false;
+  // Slash commands are dispatched, never read as a chat intent.
+  if (t.startsWith("/")) return false;
+  return STOP_INTENT.test(t);
+}

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -228,13 +228,14 @@
               </button>
               <button
                 id="abort-btn"
-                title="Stop"
+                title="Stop (Esc)"
                 class="hidden"
-                aria-label="Stop streaming response"
+                aria-label="Stop the current response"
               >
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                   <rect x="6" y="6" width="12" height="12" rx="2" />
                 </svg>
+                <span>Stop</span>
               </button>
             </div>
           </div>

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -1894,8 +1894,15 @@ body.platform-darwin #files-title {
   opacity: 0.85;
 }
 
+/* Stop carries a visible label (not just an icon) so it's unmistakable while a
+   slow turn is "thinking" -- the bare red square went unnoticed (#225). */
 #abort-btn {
   background: var(--error);
+  width: auto;
+  gap: 6px;
+  padding: 0 14px;
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .hidden {

--- a/tests/stop-intent.test.ts
+++ b/tests/stop-intent.test.ts
@@ -31,11 +31,11 @@ describe("detectStopIntent", () => {
       "stop the response",
       "stop what you are doing", // verbatim from the bug report
       "stop what you're doing",
+      "stop what you’re doing", // macOS smart-quote apostrophe (U+2019)
       "abort",
       "abort it",
       "abort thinking", // verbatim from the bug report
       "cancel",
-      "cancel that",
       "halt",
       "STOP NOW",
       "  stop  ", // surrounding whitespace
@@ -53,6 +53,8 @@ describe("detectStopIntent", () => {
       "/stop", // a slash command, never a chat intent
       "stop the FastQC tool from running on every sample", // real instruction
       "cancel the workflow invocation in Galaxy", // real Galaxy action
+      "cancel that job", // deictic + object: a Galaxy action, not a halt
+      "stop that", // deictic "that" deliberately excluded
       "abort the upload and use the local file instead", // real instruction
       "how do I abort a running job?", // a question
       "find the stop codon in this sequence", // biology, not a command

--- a/tests/stop-intent.test.ts
+++ b/tests/stop-intent.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { detectStopIntent } from "../app/src/renderer/chat/stop-intent.js";
+
+/**
+ * Issue #225: with a slow model, a tester tried to halt a long "thinking" turn
+ * by typing "stop what you are doing" / "abort thinking" into chat. Those just
+ * queued as the next prompt instead of stopping anything. The shell should read
+ * a bare stop command typed during an active turn as an abort.
+ *
+ * The detector must catch the real intent (the two prompts from the bug report)
+ * without firing on real instructions that merely contain "stop"/"abort"/
+ * "cancel" -- including bioinformatics phrasing ("stop codon") and Galaxy
+ * actions ("cancel the workflow invocation"). False negatives are cheap (the
+ * now-labeled Stop button is still right there); false positives abort a turn
+ * the user wanted, so we err quiet.
+ */
+describe("detectStopIntent", () => {
+  describe("fires on a bare stop command", () => {
+    const positives = [
+      "stop",
+      "Stop",
+      "stop.",
+      "stop!",
+      "stop it",
+      "stop now",
+      "stop please",
+      "please stop",
+      "stop thinking", // verbatim-ish from the bug report ("abort thinking")
+      "stop responding",
+      "stop generating",
+      "stop the response",
+      "stop what you are doing", // verbatim from the bug report
+      "stop what you're doing",
+      "abort",
+      "abort it",
+      "abort thinking", // verbatim from the bug report
+      "cancel",
+      "cancel that",
+      "halt",
+      "STOP NOW",
+      "  stop  ", // surrounding whitespace
+    ];
+    for (const text of positives) {
+      it(`fires on: ${JSON.stringify(text)}`, () => {
+        expect(detectStopIntent(text)).toBe(true);
+      });
+    }
+  });
+
+  describe("stays quiet on real instructions and unrelated input", () => {
+    const negatives = [
+      "", // empty
+      "/stop", // a slash command, never a chat intent
+      "stop the FastQC tool from running on every sample", // real instruction
+      "cancel the workflow invocation in Galaxy", // real Galaxy action
+      "abort the upload and use the local file instead", // real instruction
+      "how do I abort a running job?", // a question
+      "find the stop codon in this sequence", // biology, not a command
+      "don't stop until all samples are processed", // negated
+      "the reads stop at position 50", // descriptive
+      "please cancel my last galaxy job and rerun it", // real instruction
+      "stop and summarize what you found so far", // continuation, not a pure halt
+    ];
+    for (const text of negatives) {
+      it(`stays quiet on: ${JSON.stringify(text)}`, () => {
+        expect(detectStopIntent(text)).toBe(false);
+      });
+    }
+  });
+});


### PR DESCRIPTION
Two small shell-side changes so a user can reliably stop a turn that's "thinking too long."

## What this does

1. **Honor a bare "stop"/"abort" typed during a turn.** While a turn is streaming, a message that's purely a stop command ("stop", "abort thinking", "stop what you are doing", ...) now aborts the turn instead of silently queuing as the next prompt. A new `detectStopIntent` classifier (mirrors the `detectCompactIntent` pattern) is deliberately conservative -- it only fires on a pure stop imperative, so real instructions like "stop the FastQC tool" or "cancel the workflow invocation" still queue like any other prompt.

2. **Give the Stop button a visible label.** The abort control was a bare red square that swapped in where Send had been; it's now labeled "Stop" (with the Esc shortcut in the tooltip) so it's obvious while a slow turn is thinking.

## Triage notes (does abort even reach the thinking phase?)

The issue asked whether Stop interrupts a long pre-stream thinking phase or only token streaming. Tracing the path end to end:

- `agent_start` is emitted before the first LLM call, so the renderer already shows the abort button and enables Esc *during* thinking.
- pi's abort is wired through: RPC `abort` -> `session.abort()` -> `agent.abort()` -> `abortController.abort()`, and that signal threads all the way into the provider fetch. So aborting genuinely cancels an in-flight thinking/reasoning call, not just visible token streaming. This isn't blocked by anything we don't control.

So the real gaps were shell-side: the typed "stop" got queued, and the button wasn't discoverable. Both are addressed here.

## Not changed (noted for follow-up)

- There's a sub-second window between submitting a prompt and `agent_start` arriving where the abort affordance isn't shown yet (`streaming` flips on `agent_start`). It's not the reported scenario -- a slow model's long thinking happens after `agent_start` -- and closing it touches the `streaming` flag's follow-up semantics, so I left it alone.
- Distinct from #63 (Stop button stuck visible after a brain restart).

## Tests

`tests/stop-intent.test.ts` -- 33 cases covering the bug-report phrases plus the bioinformatics/Galaxy false-positive guards. Full suite green, root + app typecheck clean. The button-label change is CSS/markup and hasn't been eyeballed in a running Orbit yet.

Closes #225
