### PR TITLE
Surface Galaxy job failures after a single tool run

### DIFF
--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -162,7 +162,7 @@ flip the toggle to Cloud if they want Galaxy back.
  * Galaxy connection status block — replaces the old Local|Remote toggle
  * with agent-side per-plan routing decisions.
  */
-function buildGalaxyContextBlock(): string {
+export function buildGalaxyContextBlock(): string {
   const cfg = loadConfig();
   // Local mode short-circuits — no Galaxy guidance, even if connected.
   if (cfg.executionMode === "local") {
@@ -248,6 +248,19 @@ After invoking via Galaxy MCP and getting an \`invocationId\` back:
    record verification evidence in the notebook, then edit the markdown
    checkbox for the step from \`- [ ]\` to \`- [x]\`. On failure, record
    the error evidence and use \`- [!]\`.
+
+### Running a single tool
+
+A single tool run (\`galaxy_run_tool\` / \`galaxy_run_user_tool\`) is not a
+workflow invocation: it returns a **job**, not an \`invocationId\`, and
+leaves no \`loom-invocation\` block — so nothing polls it for you. The
+"Started tool …" / HTTP 200 response means the job was **submitted, not
+that it finished**. Before you tell the user the step worked, confirm the
+job reached a terminal \`ok\` state: call \`galaxy_get_job_details\` with one
+of the run's output dataset ids (it returns the job that made that dataset,
+with its state), or inspect the output dataset's state directly. If the job
+ends in \`error\`/\`failed\`/\`deleted\`, surface that failure in chat
+immediately — don't wait for the user to ask.
 `;
 }
 
@@ -494,10 +507,18 @@ or telling the user the work is done.
 
 Match the verification check to the artifact or action being completed:
 
-- **Galaxy workflow or tool run** — poll the invocation/job to a terminal
-  state with \`galaxy_invocation_check_all\` or the relevant Galaxy MCP
-  inspection call, then inspect resulting datasets/collections enough to
-  confirm they exist and look plausible for the request.
+- **Galaxy workflow invocation** — poll to a terminal state with
+  \`galaxy_invocation_check_all\`, then inspect resulting
+  datasets/collections enough to confirm they exist and look plausible
+  for the request.
+- **Single Galaxy tool run** (\`galaxy_run_tool\` / \`galaxy_run_user_tool\`)
+  — the "Started tool …" / HTTP 200 response means the job was
+  *submitted*, not that it finished, and no \`loom-invocation\` block
+  polls it for you. Confirm the job reached a terminal \`ok\` state: call
+  \`galaxy_get_job_details\` with one of the run's output dataset ids (or
+  inspect the output dataset state) before claiming the step worked. If
+  the job state is \`error\`/\`failed\`/\`deleted\`, report the failure to the
+  user proactively rather than waiting to be asked.
 - **Authored Galaxy workflow** (\`.ga\` or workflow JSON) —
   upload/import it to Galaxy, invoke it on a small
   appropriate test input, poll to completion, and inspect outputs.

--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -22,6 +22,7 @@ import { isTeamDispatchEnabled } from "./teams/is-enabled";
 import { registerSessionIndexTools } from "./session-index/tools";
 import { isSessionIndexEnabled } from "./session-index/is-enabled";
 import { registerConfusablesHint } from "./confusables-hint";
+import { registerJobStatusHint } from "./job-status-hint";
 import { registerExecGuard } from "./exec-guard";
 import { registerSandbox } from "./sandbox";
 import { registerSecretRedaction } from "./secret-redaction";
@@ -59,6 +60,9 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
   registerExecutionCommands(pi);
   registerFeedbackCommand(pi);
   registerConfusablesHint(pi);
+  // After a single tool run, remind the agent that a submitted job isn't a
+  // finished one so it verifies terminal state and surfaces failures (#210).
+  registerJobStatusHint(pi);
   if (isTeamDispatchEnabled()) {
     registerTeamTools(pi);
   }

--- a/extensions/loom/job-status-hint.ts
+++ b/extensions/loom/job-status-hint.ts
@@ -1,0 +1,77 @@
+/**
+ * Post-run job-status hint (#210).
+ *
+ * `galaxy_run_tool` / `galaxy_run_user_tool` return at job SUBMISSION -- the
+ * "Started tool …" / HTTP 200 response means the job was queued, not that it
+ * finished. A model (especially a low-capability one) reads that as success and
+ * moves on, so a job that errors in Galaxy is never surfaced in chat until the
+ * user explicitly asks. Unlike workflow invocations, single tool runs leave no
+ * `loom-invocation` block, so the background poller never advances them either.
+ *
+ * Mirrors `confusables-hint.ts`: hook the tool-result message and append a
+ * reminder that submission != success, so the agent verifies the job's terminal
+ * state and reports failures in the same turn. This is a deterministic nudge --
+ * it does not itself call Galaxy or resolve the job; it just keeps the model
+ * from mistaking a 200 for a completed run.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+// Galaxy MCP tools that return a SUBMITTED job rather than a finished run.
+// Workflow invocations (galaxy_invoke_workflow) are deliberately excluded --
+// they get their own loom-invocation block + background poller.
+const JOB_RUN_TOOLS = new Set(["galaxy_run_tool", "galaxy_run_user_tool"]);
+
+export const JOB_SUBMITTED_HINT =
+  "[loom] This started a Galaxy job — it is submitted, not finished. A 200 / " +
+  '"Started tool …" response only means the job was submitted. Before telling ' +
+  "the user this step succeeded, confirm the job reached a terminal `ok` state. " +
+  "Call `galaxy_get_job_details` with one of the run's output dataset ids (it " +
+  "returns the job that produced that dataset, with its state), or check the " +
+  "output dataset's state directly. If it ended in `error`/`failed`/`deleted`, " +
+  "report the failure to the user now instead of waiting to be asked.";
+
+// Distinctive opening of the hint, reused as the idempotency guard -- guaranteed
+// present once appended, and unique enough that no Galaxy tool result contains it.
+const HINT_MARKER = "[loom] This started a Galaxy job";
+
+/** A submitted-job result worth nudging: a successful run_tool / run_user_tool. */
+export function shouldHintJobRun(
+  toolName: string | undefined,
+  isError: boolean | undefined,
+): boolean {
+  if (isError) return false;
+  return Boolean(toolName && JOB_RUN_TOOLS.has(toolName));
+}
+
+/**
+ * Append the job-status hint to a tool-result's content. Returns a changed copy,
+ * or `null` if the hint is already present (idempotent). The original array is
+ * never mutated. Appends to the first text block, or adds a new text item when
+ * the result carries none.
+ */
+export function appendJobHint<T extends { type: string; text?: string }>(content: T[]): T[] | null {
+  const alreadyHinted = content.some(
+    (c) => c.type === "text" && typeof c.text === "string" && c.text.includes(HINT_MARKER),
+  );
+  if (alreadyHinted) return null;
+
+  const firstText = content.findIndex((c) => c.type === "text" && typeof c.text === "string");
+  if (firstText === -1) {
+    return [...content, { type: "text", text: JOB_SUBMITTED_HINT } as T];
+  }
+  return content.map((c, i) =>
+    i === firstText ? { ...c, text: `${c.text}\n\n${JOB_SUBMITTED_HINT}` } : c,
+  );
+}
+
+export function registerJobStatusHint(pi: ExtensionAPI): void {
+  pi.on("message_end", (event) => {
+    const msg = event.message;
+    if (msg.role !== "toolResult") return;
+    if (!shouldHintJobRun(msg.toolName, msg.isError)) return;
+
+    const content = appendJobHint(msg.content);
+    if (content) return { message: { ...msg, content } };
+  });
+}

--- a/tests/job-run-context.test.ts
+++ b/tests/job-run-context.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { loadConfigMock } = vi.hoisted(() => ({ loadConfigMock: vi.fn() }));
+vi.mock("../extensions/loom/config", () => ({ loadConfig: loadConfigMock }));
+
+import {
+  buildVerificationDisciplineBlock,
+  buildGalaxyContextBlock,
+} from "../extensions/loom/context";
+
+// #210: a galaxy_run_tool job that fails immediately wasn't surfaced in chat
+// because the agent read the "Started tool" submission as success. The prompt
+// must teach that submission != completion for single tool runs.
+
+describe("buildVerificationDisciplineBlock — single tool run (#210)", () => {
+  it("teaches that a submitted tool run still needs a terminal-state check", () => {
+    const ctx = buildVerificationDisciplineBlock();
+    expect(ctx).toContain("galaxy_run_tool");
+    expect(ctx).toContain("submitted");
+    expect(ctx).toContain("galaxy_get_job_details");
+    expect(ctx).toContain("output dataset id");
+    expect(ctx).toContain("report the failure");
+  });
+});
+
+describe("buildGalaxyContextBlock — running a single tool (#210)", () => {
+  const savedUrl = process.env.GALAXY_URL;
+  const savedKey = process.env.GALAXY_API_KEY;
+
+  beforeEach(() => {
+    loadConfigMock.mockReset();
+    loadConfigMock.mockReturnValue({});
+    process.env.GALAXY_URL = "https://usegalaxy.org";
+    process.env.GALAXY_API_KEY = "k-testtesttest";
+  });
+
+  afterEach(() => {
+    if (savedUrl === undefined) delete process.env.GALAXY_URL;
+    else process.env.GALAXY_URL = savedUrl;
+    if (savedKey === undefined) delete process.env.GALAXY_API_KEY;
+    else process.env.GALAXY_API_KEY = savedKey;
+  });
+
+  it("warns that a single tool run returns a submitted job, not a finished run", () => {
+    const block = buildGalaxyContextBlock();
+    expect(block).toContain("galaxy_run_tool");
+    expect(block).toContain("submitted");
+    expect(block).toContain("galaxy_get_job_details");
+    expect(block).toContain("output dataset id");
+  });
+});

--- a/tests/job-status-hint.test.ts
+++ b/tests/job-status-hint.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldHintJobRun,
+  appendJobHint,
+  registerJobStatusHint,
+  JOB_SUBMITTED_HINT,
+} from "../extensions/loom/job-status-hint";
+
+describe("JOB_SUBMITTED_HINT", () => {
+  it("points get_job_details at an output dataset id, not a job id", () => {
+    // galaxy_get_job_details takes a dataset_id (the output dataset), not a jobId.
+    expect(JOB_SUBMITTED_HINT).toContain("galaxy_get_job_details");
+    expect(JOB_SUBMITTED_HINT).toContain("output dataset id");
+    expect(JOB_SUBMITTED_HINT).not.toContain("job id");
+  });
+});
+
+describe("shouldHintJobRun", () => {
+  it("fires for a successful galaxy_run_tool result", () => {
+    expect(shouldHintJobRun("galaxy_run_tool", false)).toBe(true);
+  });
+
+  it("fires for galaxy_run_user_tool (isError undefined)", () => {
+    expect(shouldHintJobRun("galaxy_run_user_tool", undefined)).toBe(true);
+  });
+
+  it("does not fire when the tool call itself errored", () => {
+    // An errored run_tool already shows the model a failure -- no nudge needed.
+    expect(shouldHintJobRun("galaxy_run_tool", true)).toBe(false);
+  });
+
+  it("does not fire for unrelated tools, incl. workflow invocation (its own poller)", () => {
+    expect(shouldHintJobRun("galaxy_get_history", false)).toBe(false);
+    expect(shouldHintJobRun("galaxy_invoke_workflow", false)).toBe(false);
+    expect(shouldHintJobRun("read", false)).toBe(false);
+  });
+
+  it("does not fire when toolName is missing", () => {
+    expect(shouldHintJobRun(undefined, false)).toBe(false);
+  });
+});
+
+describe("appendJobHint", () => {
+  it("appends the reminder to the first text block, preserving the original text", () => {
+    const content = [{ type: "text", text: "Started tool trim_galore (job abc123)" }];
+    const out = appendJobHint(content);
+    expect(out).not.toBeNull();
+    expect(out![0].text).toContain("Started tool trim_galore");
+    expect(out![0].text).toContain(JOB_SUBMITTED_HINT);
+  });
+
+  it("does not mutate the original content array", () => {
+    const content = [{ type: "text", text: "Started tool x" }];
+    appendJobHint(content);
+    expect(content[0].text).toBe("Started tool x");
+  });
+
+  it("is idempotent -- a second pass adds nothing", () => {
+    const content = [{ type: "text", text: "Started tool x" }];
+    const once = appendJobHint(content)!;
+    expect(appendJobHint(once)).toBeNull();
+  });
+
+  it("adds a text item when the result carries no text block", () => {
+    const content = [{ type: "resource" } as { type: string; text?: string }];
+    const out = appendJobHint(content);
+    expect(out).not.toBeNull();
+    expect(out!.some((c) => c.type === "text" && c.text?.includes(JOB_SUBMITTED_HINT))).toBe(true);
+  });
+});
+
+describe("registerJobStatusHint", () => {
+  function fakePi() {
+    const handlers = new Map<string, (e: unknown) => unknown>();
+    const pi = {
+      on: (evt: string, h: (e: unknown) => unknown) => handlers.set(evt, h),
+    } as unknown as Parameters<typeof registerJobStatusHint>[0];
+    return { pi, handlers };
+  }
+
+  it("appends the hint onto a successful run_tool tool-result message", () => {
+    const { pi, handlers } = fakePi();
+    registerJobStatusHint(pi);
+    const res = handlers.get("message_end")!({
+      message: {
+        role: "toolResult",
+        isError: false,
+        toolName: "galaxy_run_tool",
+        content: [{ type: "text", text: "Started tool trim_galore" }],
+      },
+    }) as { message: { content: { type: string; text?: string }[] } };
+    expect(res.message.content[0].text).toContain(JOB_SUBMITTED_HINT);
+  });
+
+  it("ignores an errored run_tool message", () => {
+    const { pi, handlers } = fakePi();
+    registerJobStatusHint(pi);
+    const res = handlers.get("message_end")!({
+      message: {
+        role: "toolResult",
+        isError: true,
+        toolName: "galaxy_run_tool",
+        content: [{ type: "text", text: "boom" }],
+      },
+    });
+    expect(res).toBeUndefined();
+  });
+
+  it("ignores a non-toolResult message", () => {
+    const { pi, handlers } = fakePi();
+    registerJobStatusHint(pi);
+    const res = handlers.get("message_end")!({
+      message: { role: "assistant", content: [{ type: "text", text: "hi" }] },
+    });
+    expect(res).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes the trust gap in #210: a `galaxy_run_tool` whose job fails immediately wasn't showing up in Orbit chat. `run_tool` returns at submission ("Started tool ..." / HTTP 200), the agent reads that as success and moves on, and -- unlike a workflow invocation -- a single tool run leaves no `loom-invocation` block, so the background poller never advances it either. The failure stayed invisible until the user explicitly asked.

Two parts, both aimed at the within-turn case:

- **Deterministic nudge.** New `job-status-hint.ts`, a `message_end` hook mirroring `confusables-hint.ts`. On a non-error `galaxy_run_tool` / `galaxy_run_user_tool` result it appends a short reminder that a 200 means *submitted, not finished* -- verify the job reached a terminal `ok` state (`galaxy_get_job_details` on one of the run's output dataset ids, or check the output dataset's state) and report failures now rather than waiting to be asked. It's idempotent and format-agnostic (no id parsing, no Galaxy call, no timers); it fires at the exact moment the model is about to misread the 200.
- **Sharper prompt guidance.** The verification block now splits "workflow invocation" from "single tool run" instead of lumping them, and the Galaxy step section gains a "Running a single tool" subsection spelling out the run_tool -> poll get_job_details -> report-errors path. The old generic guidance already existed and a weak model ignored it, which is why the deterministic hook carries the weight here.

Note: `galaxy_get_job_details` takes the *output dataset id* (it returns the job that produced that dataset), not a job id -- the guidance reflects that.

**Scope.** This covers the within-turn case, which is the reported incident ("Galaxy UI immediately showed error"). Proactive *cross-turn* polling of tool-run jobs -- the background-poller equivalent for single jobs -- is a larger design call and intentionally left out. A cleaner durable fix would also live upstream in galaxy-mcp (have `run_tool` return clearer "submitted, not complete" language plus the ids), which would make this brain-side nudge belt-and-suspenders.

Testing: 529 root tests green (15 new across `tests/job-status-hint.test.ts` + `tests/job-run-context.test.ts`), root + app typecheck clean. Not yet live-eyeballed in Orbit.

Mitigates #210.
