### PR TITLE
Declare libasound2 as a deb runtime dependency

### DIFF
--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -343,6 +343,12 @@ const config: ForgeConfig = {
         options: {
           maintainer: "Galaxy Project contributors",
           homepage: "https://galaxyproject.org",
+          // electron-installer-debian's computed default depends omit ALSA, but
+          // Electron links libasound.so.2 -- without it Orbit fails to launch on
+          // Ubuntu/WSL2 with "error while loading shared libraries". depends is
+          // unioned with the defaults, so this only adds the missing lib.
+          // libasound2t64 on newer Ubuntu satisfies libasound2 via Provides.
+          depends: ["libasound2"],
         },
       },
     },


### PR DESCRIPTION
The Linux `.deb` -- which is what WSL2/Ubuntu folks install -- was missing `libasound2`, so Orbit died at launch with `error while loading shared libraries: libasound.so.2`. The workaround was a manual `apt install libasound2t64`, but new Windows/WSL users hit this before they ever reach the setup screen.

It's not that Orbit needs audio -- Electron's bundled Chromium has `libasound.so.2` as a hard dynamic-link dependency, so the loader resolves it at startup whether or not anything ever plays a sound. `electron-installer-debian`'s auto-computed default depends (gtk3/nss/atspi/drm/gbm/...) just don't include ALSA, so it never got declared.

Fix is a one-liner: add `libasound2` to the maker-deb `options.depends`. That list gets unioned with the computed defaults rather than replacing them, so nothing else is dropped. On newer Ubuntu the lib ships as `libasound2t64`, which satisfies a `libasound2` dependency via Provides, so no version pin is needed.

Verified `tsc --noEmit` is clean and the root suite stays green (565); there's no unit-test surface for forge packaging config. Couldn't run a full `electron-forge make` here (deb build needs Linux + the heavy prePackage download hook), but simulated the exact `_.union(getDepends(...), ["libasound2"])` path against the installed packages and confirmed the merged `Depends` is the 8 defaults plus libasound2.

Closes #223