### PR TITLE
Let a cold session discover and resume a Galaxy notebook

### DIFF
--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -200,7 +200,28 @@ once — don't badger.
   return `
 ## Galaxy connection: ${galaxyUrl}
 
-Galaxy is connected. When drafting a plan, **first** consult Galaxy
+Galaxy is connected.
+
+### Resuming existing Galaxy work ("pick up where I left off")
+
+If the user asks to connect to, catch up on, or resume work they did in
+the Galaxy interface (a history notebook / Page) and hasn't handed you a
+page id:
+1. Call \`notebook_list_galaxy_pages\` — their pages, most-recent first.
+2. Prefer the most-recent entry that **has** a \`history_id\` (a real
+   history notebook you can read back). An entry with \`history_id: null\`
+   is a workflow *invocation report* — no bound history to read, so don't
+   resume it for "catch up" unless the user names it specifically.
+3. Echo your pick back and confirm before resuming ("Looks like you were
+   working on <title> — picking that up.").
+4. Call \`notebook_resume_from_galaxy\` with the chosen \`page_id\`. This
+   binds the notebook and pulls the Page body into \`notebook.md\`.
+5. Then read the bound history (its datasets/results) to see what actually
+   happened before proposing new analysis.
+
+### Drafting a new plan
+
+When drafting a plan, **first** consult Galaxy
 resources before deciding what runs where:
 
 1. Search the IWC workflow registry for matching workflows

--- a/extensions/loom/galaxy-api.ts
+++ b/extensions/loom/galaxy-api.ts
@@ -55,7 +55,12 @@ export function getGalaxyConfig(): GalaxyConfig | null {
   const url = process.env.GALAXY_URL;
   const apiKey = process.env.GALAXY_API_KEY;
   if (!url || !apiKey) return null;
-  return { url: url.replace(/\/+$/, ""), apiKey };
+  // Galaxy URLs from the config profile / env often arrive scheme-less
+  // (e.g. "test.galaxyproject.org/"). The MCP layer tolerates that, but
+  // fetch() can't parse a schemeless URL, so default to https here.
+  const trimmed = url.trim().replace(/\/+$/, "");
+  const normalized = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  return { url: normalized, apiKey };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/extensions/loom/galaxy-pages-api.ts
+++ b/extensions/loom/galaxy-pages-api.ts
@@ -103,6 +103,42 @@ export async function listHistoryPages(
   );
 }
 
+/** A page entry trimmed to what the discovery tool surfaces. `history_id` is
+ *  the load-bearing field: a real history notebook has one, a workflow
+ *  *invocation report* has `null` -- only the former can be resumed and read
+ *  back as a bound history. */
+export interface RecentPage {
+  page_id: string;
+  title: string;
+  slug: string | null;
+  history_id: string | null;
+  update_time: string;
+}
+
+/**
+ * List the user's own pages, most-recently-updated first. Wraps the unscoped
+ * `GET /api/pages` (which Galaxy returns in ascending update order, so we sort
+ * client-side) and projects each entry down to the fields a cold-start resume
+ * needs to pick a page. `limit` caps the returned list; pass 0 / omit for all.
+ */
+export async function listRecentPages(
+  opts: { limit?: number } = {},
+  signal?: AbortSignal,
+): Promise<RecentPage[]> {
+  const pages = await galaxyGet<GalaxyPageSummary[]>("/pages", signal);
+  const sorted = [...pages].sort((a, b) =>
+    (b.update_time ?? "").localeCompare(a.update_time ?? ""),
+  );
+  const limited = opts.limit && opts.limit > 0 ? sorted.slice(0, opts.limit) : sorted;
+  return limited.map((p) => ({
+    page_id: p.id,
+    title: p.title,
+    slug: p.slug ?? null,
+    history_id: p.history_id ?? null,
+    update_time: p.update_time,
+  }));
+}
+
 export async function getPage(pageId: string, signal?: AbortSignal): Promise<GalaxyPage> {
   return galaxyGet<GalaxyPage>(`/pages/${encodeURIComponent(pageId)}`, signal);
 }

--- a/extensions/loom/tools-sync.ts
+++ b/extensions/loom/tools-sync.ts
@@ -15,6 +15,7 @@ import {
   linkGalaxyPage,
   resumeGalaxyPage,
 } from "./galaxy-pages-sync";
+import { listRecentPages } from "./galaxy-pages-api";
 
 function errorContent(e: unknown) {
   return {
@@ -29,6 +30,52 @@ function errorContent(e: unknown) {
 }
 
 export function registerNotebookSyncTools(pi: ExtensionAPI): void {
+  pi.registerTool({
+    name: "notebook_list_galaxy_pages",
+    label: "List recent Galaxy pages",
+    description: `List the user's Galaxy pages (history notebooks), most-recently-edited
+first, so you can find one to resume when the user asks to pick up Galaxy work
+but hasn't given a page id. Each entry has page_id, title, slug, update_time,
+and history_id. history_id is the field that matters: an entry WITH a history_id
+is a real history notebook you can resume and read its bound history back; an
+entry with history_id null is a workflow invocation report (no bound history) --
+prefer a history-bound page for resume. After picking one (usually the most
+recent history-bound page), confirm it with the user, then call
+notebook_resume_from_galaxy with its page_id.`,
+    parameters: Type.Object({
+      limit: Type.Optional(
+        Type.Number({
+          description: "Max pages to return, most-recent first. Defaults to 20.",
+        }),
+      ),
+    }),
+    async execute(_callId, params, _signal, _onUpdate, _ctx) {
+      try {
+        const pages = await listRecentPages({ limit: params.limit ?? 20 });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  pages,
+                  hint:
+                    "Entries with a history_id are resumable history notebooks; " +
+                    "history_id null means a workflow invocation report (not resumable as a bound history).",
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+          details: { count: pages.length },
+        };
+      } catch (e) {
+        return errorContent(e);
+      }
+    },
+  });
+
   pi.registerTool({
     name: "notebook_push_to_galaxy",
     label: "Push notebook to Galaxy page",

--- a/tests/galaxy-api.test.ts
+++ b/tests/galaxy-api.test.ts
@@ -41,4 +41,22 @@ describe("getGalaxyConfig", () => {
     const config = getGalaxyConfig();
     expect(config!.url).toBe("https://usegalaxy.org");
   });
+
+  it("prepends https:// when the URL is scheme-less", () => {
+    // Config profiles / env often store the host without a scheme
+    // ("test.galaxyproject.org/"), which fetch() cannot parse.
+    process.env.GALAXY_URL = "test.galaxyproject.org/";
+    process.env.GALAXY_API_KEY = "key";
+
+    const config = getGalaxyConfig();
+    expect(config!.url).toBe("https://test.galaxyproject.org");
+  });
+
+  it("preserves an explicit http:// scheme", () => {
+    process.env.GALAXY_URL = "http://localhost:8080/";
+    process.env.GALAXY_API_KEY = "key";
+
+    const config = getGalaxyConfig();
+    expect(config!.url).toBe("http://localhost:8080");
+  });
 });

--- a/tests/galaxy-pages-api.test.ts
+++ b/tests/galaxy-pages-api.test.ts
@@ -14,6 +14,7 @@ import {
   getPageRevisionDetails,
   getPageRevisions,
   listHistoryPages,
+  listRecentPages,
   updatePage,
   type GalaxyPage,
   type GalaxyPageRevisionDetails,
@@ -51,6 +52,66 @@ describe("listHistoryPages", () => {
       "/pages?history_id=hist%20with%20spaces%2Fand%20slashes",
       undefined,
     );
+  });
+});
+
+describe("listRecentPages", () => {
+  // Mirrors the live /api/pages shape: ascending update_time, a mix of
+  // history-bound notebooks and a history_id-null invocation report.
+  function fixture(): GalaxyPageSummary[] {
+    return [
+      {
+        id: "old-report",
+        title: "End-to-End Tissue Microarray Analysis",
+        slug: "invocation-abc",
+        history_id: null,
+        latest_revision_id: "r1",
+        create_time: "2025-06-02T17:00:00Z",
+        update_time: "2025-06-02T17:29:07Z",
+      },
+      {
+        id: "notebook-1",
+        title: "Untitled Notebook",
+        slug: null,
+        history_id: "hist-1",
+        latest_revision_id: "r2",
+        create_time: "2026-05-29T18:00:00Z",
+        update_time: "2026-05-29T18:09:07Z",
+      },
+    ];
+  }
+
+  it("hits the unscoped /pages endpoint", async () => {
+    const get = vi.spyOn(galaxyApi, "galaxyGet").mockResolvedValue([] as GalaxyPageSummary[]);
+    await listRecentPages();
+    expect(get).toHaveBeenCalledWith("/pages", undefined);
+  });
+
+  it("sorts most-recently-updated first and projects to RecentPage", async () => {
+    vi.spyOn(galaxyApi, "galaxyGet").mockResolvedValue(fixture());
+    const got = await listRecentPages();
+    expect(got.map((p) => p.page_id)).toEqual(["notebook-1", "old-report"]);
+    expect(got[0]).toEqual({
+      page_id: "notebook-1",
+      title: "Untitled Notebook",
+      slug: null,
+      history_id: "hist-1",
+      update_time: "2026-05-29T18:09:07Z",
+    });
+  });
+
+  it("preserves null history_id so invocation reports stay distinguishable", async () => {
+    vi.spyOn(galaxyApi, "galaxyGet").mockResolvedValue(fixture());
+    const got = await listRecentPages();
+    const report = got.find((p) => p.page_id === "old-report");
+    expect(report?.history_id).toBeNull();
+  });
+
+  it("caps the list to the given limit (after sorting)", async () => {
+    vi.spyOn(galaxyApi, "galaxyGet").mockResolvedValue(fixture());
+    const got = await listRecentPages({ limit: 1 });
+    expect(got).toHaveLength(1);
+    expect(got[0].page_id).toBe("notebook-1");
   });
 });
 


### PR DESCRIPTION
A fresh Loom session could resume a Galaxy page only if you already knew its page id -- there was no way to find one from inside the session. `listHistoryPages` existed but was dead code and history-scoped, so a prompt like "connect to my Galaxy notebook and catch up" had nowhere to go but asking the user for an id.

This adds the missing discovery half on top of the Pages sync work (#114, #144):

- `listRecentPages` wraps the unscoped `GET /api/pages` (Galaxy returns it ascending, so we sort most-recent first) and projects each entry to `{page_id, title, slug, history_id, update_time}`. `history_id` is the load-bearing field -- a real history notebook has one; a workflow invocation report has null and can't be resumed as a bound history.
- A `notebook_list_galaxy_pages` tool exposes it and surfaces that distinction so the agent prefers a real notebook over a report.
- Connected-Galaxy context guidance so a vague "catch up on what I did in Galaxy" routes to list -> prefer the most-recent history-bound page -> confirm -> `notebook_resume_from_galaxy` -> read the bound history, instead of flailing.

All native extension code over Galaxy's REST API -- no MCP in the discover/resume path. Verified live against a real server (ranks a history-bound notebook above invocation reports) plus unit tests for the sort/projection/limit; 613 green overall.

This lives next to the other notebook tools (resume/push/pull/link) rather than in the Galaxy MCP server -- our notebook handling is already Loom/pi.dev-plugin-specific, so it made sense to keep discovery with the rest of it. It could be migrated into MCP tooling later if we'd rather it live server-side; nothing here depends on it staying local.


Additional feedback came in that got filed as #264 -- a scheme-less `GALAXY_URL` (no `https://`) made `notebook_list_galaxy_pages` blow up with "Failed to parse URL" and silently fall back to listing histories. The `getGalaxyConfig` normalization here fixes that too. Resolves #264.
