### PR TITLE
Add a /tester-id command so testers can set their ID without editing config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,16 @@ export GALAXY_API_KEY="your-api-key"
 
 Galaxy credentials can also be provided via environment variables (`GALAXY_URL`, `GALAXY_API_KEY`) for CI or testing, but `~/.loom/config.json` is the primary source.
 
+#### Beta tester ID
+
+If you have a tester ID, you can set it like this:
+
+```
+/tester-id orbit-007
+```
+
+Run `/tester-id` with no argument to see the current value. It writes only the `testerId` key to `~/.loom/config.json` (the rest of the file is left untouched), and Orbit attaches it to any feedback you send so reports can be traced back to your session. It can also be supplied via the `LOOM_TESTER_ID` environment variable.
+
 ### Local LLMs
 
 Loom works with any OpenAI-compatible API -- a hosted service like [Jetstream](https://docs.jetstream-cloud.org/inference-service/overview/), or a local backend like [LiteLLM](https://litellm.ai/) or [Ollama](https://ollama.com/).

--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -17,6 +17,7 @@ import { registerSessionLifecycle } from "./session-lifecycle";
 import { registerActivityHooks } from "./activity-hooks";
 import { registerExecutionCommands } from "./execution-commands";
 import { registerFeedbackCommand } from "./feedback-command";
+import { registerTesterIdCommand } from "./tester-id-command";
 import { registerTeamTools } from "./teams/tool";
 import { isTeamDispatchEnabled } from "./teams/is-enabled";
 import { registerSessionIndexTools } from "./session-index/tools";
@@ -58,6 +59,7 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
   registerSyncCommand(pi);
   registerExecutionCommands(pi);
   registerFeedbackCommand(pi);
+  registerTesterIdCommand(pi);
   registerConfusablesHint(pi);
   if (isTeamDispatchEnabled()) {
     registerTeamTools(pi);

--- a/extensions/loom/tester-id-command.ts
+++ b/extensions/loom/tester-id-command.ts
@@ -1,0 +1,132 @@
+/**
+ * /tester-id -- the get-or-set counterpart to buildTesterIdBlock (#189/#191).
+ *
+ * With no argument it prints the current tester ID; with an argument it sets it.
+ *
+ * Beta onboarding asks testers to put a `testerId` in ~/.loom/config.json. That
+ * file is a credential store, so the agent's edit/write to it is floored by the
+ * exec-guard -- a hard deny on low-capability models and an unreachable
+ * read-then-edit on every tier once #194 landed (issue #222). This gives the
+ * user a deterministic, model-independent path that sets ONLY the testerId key.
+ *
+ * It deliberately reads/echoes ONLY the testerId field (a non-secret tester code
+ * like "orbit-007", which already passes #194 redaction), never any other config
+ * value, so it cannot become a way to surface the API keys that #183/#194 lock
+ * down.
+ */
+
+import fs from "node:fs";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { getConfigPath, loadConfig, saveConfig } from "./config.js";
+
+// Tester codes are opaque, non-secret strings (e.g. "orbit-007"). Constrain the
+// shape so neither a fat-fingered user nor a pasted blob can smuggle a newline,
+// JSON, or a giant value into the key: first char alphanumeric, then a few safe
+// separators, capped length.
+const TESTER_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+export type ValidateResult = { ok: true; id: string } | { ok: false; error: string };
+
+export function validateTesterId(raw: string): ValidateResult {
+  const id = (raw ?? "").trim();
+  if (!id) {
+    return { ok: false, error: "Usage: /tester-id <id>  (e.g. /tester-id orbit-007)" };
+  }
+  if (!TESTER_ID_RE.test(id)) {
+    return {
+      ok: false,
+      error:
+        "Tester ID must be 1-64 characters: letters, digits, and . _ - only, " +
+        "starting with a letter or digit (e.g. orbit-007).",
+    };
+  }
+  return { ok: true, id };
+}
+
+/**
+ * The currently-effective tester ID and where it came from. Mirrors
+ * buildTesterIdBlock's precedence (config wins over the env override). Reads
+ * ONLY testerId -- never another config field.
+ */
+export function getCurrentTesterId(): { id: string; source: "config" | "env" } | null {
+  const fromConfig = loadConfig().testerId;
+  if (fromConfig) return { id: fromConfig, source: "config" };
+  const fromEnv = process.env.LOOM_TESTER_ID;
+  if (fromEnv) return { id: fromEnv, source: "env" };
+  return null;
+}
+
+/**
+ * Set ONLY the testerId key. Loads the full config so existing fields (API keys
+ * included) ride straight back to disk unchanged, mutates the single key, and
+ * persists via the shared atomic writer. No other field is read out, returned,
+ * or echoed.
+ *
+ * Fails closed: loadConfig() silently returns {} when an existing config can't
+ * be read or parsed, so writing that back would wipe the user's stored API
+ * keys. We refuse rather than clobber -- a genuinely absent file is still fine
+ * to create. A save failure is rewrapped in a fixed message so the raw error
+ * (whatever it carries) can never be surfaced through this command.
+ */
+export function setTesterId(id: string): void {
+  const configPath = getConfigPath();
+  if (fs.existsSync(configPath)) {
+    try {
+      JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    } catch (err) {
+      throw new Error(
+        "~/.loom/config.json couldn't be read, so it wasn't changed -- fix or remove the file and try again.",
+        { cause: err },
+      );
+    }
+  }
+  const cfg = loadConfig();
+  cfg.testerId = id;
+  try {
+    saveConfig(cfg);
+  } catch (err) {
+    throw new Error(
+      "Couldn't write ~/.loom/config.json -- check file permissions and free space, then try again.",
+      { cause: err },
+    );
+  }
+}
+
+export function registerTesterIdCommand(pi: ExtensionAPI): void {
+  pi.registerCommand("tester-id", {
+    description:
+      "Show or set your Orbit beta tester ID (writes only testerId to ~/.loom/config.json).",
+    handler: async (args: string | undefined, ctx: ExtensionContext) => {
+      const raw = (args ?? "").trim();
+
+      if (!raw) {
+        const current = getCurrentTesterId();
+        if (!current) {
+          ctx.ui.notify(
+            "No tester ID set. Set one with /tester-id <id>  (e.g. /tester-id orbit-007).",
+            "info",
+          );
+          return;
+        }
+        const suffix = current.source === "env" ? " (from LOOM_TESTER_ID)" : "";
+        ctx.ui.notify(`Tester ID: ${current.id}${suffix}`, "info");
+        return;
+      }
+
+      const result = validateTesterId(raw);
+      if (!result.ok) {
+        ctx.ui.notify(result.error, "error");
+        return;
+      }
+      try {
+        setTesterId(result.id);
+      } catch (err) {
+        // setTesterId only throws messages it authored -- never a raw error
+        // that could carry config contents -- so showing it is safe.
+        ctx.ui.notify(err instanceof Error ? err.message : "Failed to save tester ID.", "error");
+        return;
+      }
+      ctx.ui.notify(`Tester ID set to ${result.id}.`, "info");
+    },
+  });
+}

--- a/tests/tester-id-command.test.ts
+++ b/tests/tester-id-command.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  validateTesterId,
+  setTesterId,
+  getCurrentTesterId,
+  registerTesterIdCommand,
+} from "../extensions/loom/tester-id-command";
+
+describe("validateTesterId", () => {
+  it("accepts a normal tester code", () => {
+    expect(validateTesterId("orbit-007")).toEqual({ ok: true, id: "orbit-007" });
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    expect(validateTesterId("  orbit-007  ")).toEqual({ ok: true, id: "orbit-007" });
+  });
+
+  it("rejects an empty / whitespace-only id", () => {
+    expect(validateTesterId("").ok).toBe(false);
+    expect(validateTesterId("   ").ok).toBe(false);
+  });
+
+  it("rejects ids with spaces, newlines, or path/JSON characters", () => {
+    for (const bad of ["a b", "a\nb", "a/b", "a;b", '{"x":1}', "../etc"]) {
+      expect(validateTesterId(bad).ok).toBe(false);
+    }
+  });
+
+  it("rejects a leading separator (first char must be alphanumeric)", () => {
+    expect(validateTesterId("-orbit").ok).toBe(false);
+    expect(validateTesterId(".orbit").ok).toBe(false);
+  });
+
+  it("rejects an over-long id", () => {
+    expect(validateTesterId("a".repeat(65)).ok).toBe(false);
+  });
+});
+
+describe("setTesterId (disk round-trip)", () => {
+  let tmp: string;
+  const configFile = () => path.join(tmp, ".loom", "config.json");
+  const readConfig = () => JSON.parse(fs.readFileSync(configFile(), "utf-8"));
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "loom-testerid-"));
+    vi.spyOn(os, "homedir").mockReturnValue(tmp);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("writes only the testerId key and preserves existing secrets", () => {
+    fs.mkdirSync(path.join(tmp, ".loom"), { recursive: true });
+    fs.writeFileSync(
+      configFile(),
+      JSON.stringify({
+        llm: {
+          active: "anthropic",
+          providers: { anthropic: { apiKey: "sk-SECRET-keep-me", model: "claude" } },
+        },
+      }),
+    );
+
+    setTesterId("orbit-007");
+
+    const cfg = readConfig();
+    expect(cfg.testerId).toBe("orbit-007");
+    // The existing API key must survive untouched.
+    expect(cfg.llm.providers.anthropic.apiKey).toBe("sk-SECRET-keep-me");
+  });
+
+  it("creates the config when none exists yet", () => {
+    setTesterId("orbit-042");
+    expect(readConfig().testerId).toBe("orbit-042");
+  });
+
+  it("overwrites a previously-set testerId", () => {
+    setTesterId("orbit-001");
+    setTesterId("orbit-002");
+    expect(readConfig().testerId).toBe("orbit-002");
+  });
+
+  it("fails closed on an unreadable config instead of clobbering secrets", () => {
+    fs.mkdirSync(path.join(tmp, ".loom"), { recursive: true });
+    // Invalid JSON that still holds a secret-shaped value loadConfig would drop.
+    const corrupt = '{ "llm": broken, "apiKey": "sk-SECRET-keep-me"';
+    fs.writeFileSync(configFile(), corrupt);
+
+    expect(() => setTesterId("orbit-007")).toThrow(/couldn't be read/i);
+    // The file is left byte-for-byte intact -- the secret survives.
+    expect(fs.readFileSync(configFile(), "utf-8")).toBe(corrupt);
+  });
+
+  it("rewraps a save failure in a fixed message, never reflecting the raw error", () => {
+    // Make ~/.loom a regular file so saveConfig's mkdir fails for real.
+    fs.writeFileSync(path.join(tmp, ".loom"), "not a directory");
+
+    let caught: unknown;
+    try {
+      setTesterId("orbit-007");
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const msg = (caught as Error).message;
+    expect(msg).toMatch(/couldn't write .*config\.json/i);
+    // No raw fs error leaks through: no errno, no real on-disk path.
+    expect(msg).not.toMatch(/ENOTDIR|EEXIST|EACCES|ENOSPC/);
+    expect(msg).not.toContain(tmp);
+  });
+});
+
+describe("registerTesterIdCommand handler", () => {
+  let tmp: string;
+  const readConfig = () =>
+    JSON.parse(fs.readFileSync(path.join(tmp, ".loom", "config.json"), "utf-8"));
+
+  // Capture the registered handler + every notify call.
+  function harness() {
+    const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
+    const notifications: { msg: string; level: string }[] = [];
+    const pi = {
+      registerCommand: (
+        name: string,
+        def: { handler: (args: string, ctx: unknown) => Promise<void> },
+      ) => commands.set(name, def),
+    };
+    const ctx = {
+      hasUI: true,
+      ui: { notify: (msg: string, level: string) => notifications.push({ msg, level }) },
+    };
+    registerTesterIdCommand(pi as never);
+    return { commands, notifications, ctx };
+  }
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "loom-testerid-cmd-"));
+    vi.spyOn(os, "homedir").mockReturnValue(tmp);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("registers the tester-id command", () => {
+    const { commands } = harness();
+    expect(commands.has("tester-id")).toBe(true);
+  });
+
+  it("sets the id from args and confirms with an info notification", async () => {
+    const { commands, notifications, ctx } = harness();
+    await commands.get("tester-id")!.handler("orbit-007", ctx);
+
+    expect(readConfig().testerId).toBe("orbit-007");
+    expect(notifications.some((n) => n.level === "info" && n.msg.includes("orbit-007"))).toBe(true);
+  });
+
+  it("with no argument, reports the current tester ID", async () => {
+    setTesterId("orbit-099");
+    const { commands, notifications, ctx } = harness();
+    await commands.get("tester-id")!.handler("", ctx);
+
+    expect(notifications.some((n) => n.level === "info" && n.msg.includes("orbit-099"))).toBe(true);
+  });
+
+  it("with no argument and none set, says so without erroring", async () => {
+    const { commands, notifications, ctx } = harness();
+    await commands.get("tester-id")!.handler(undefined as never, ctx);
+
+    expect(notifications.length).toBe(1);
+    expect(notifications[0].level).toBe("info");
+    expect(notifications[0].msg).toMatch(/no tester id set/i);
+  });
+
+  it("rejects an invalid id without writing config", async () => {
+    const { commands, notifications, ctx } = harness();
+    await commands.get("tester-id")!.handler("not valid!!", ctx);
+
+    expect(fs.existsSync(path.join(tmp, ".loom", "config.json"))).toBe(false);
+    expect(notifications.some((n) => n.level === "error")).toBe(true);
+  });
+
+  it("never echoes another config value in its confirmation (#183)", async () => {
+    fs.mkdirSync(path.join(tmp, ".loom"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, ".loom", "config.json"),
+      JSON.stringify({
+        llm: {
+          active: "anthropic",
+          providers: { anthropic: { apiKey: "sk-SECRET-should-never-appear" } },
+        },
+      }),
+    );
+
+    const { commands, notifications, ctx } = harness();
+    await commands.get("tester-id")!.handler("orbit-007", ctx);
+
+    // The key is preserved on disk...
+    expect(readConfig().llm.providers.anthropic.apiKey).toBe("sk-SECRET-should-never-appear");
+    // ...but never surfaced back to the user/model in any notification.
+    for (const n of notifications) {
+      expect(n.msg).not.toContain("sk-SECRET-should-never-appear");
+    }
+  });
+});
+
+describe("getCurrentTesterId", () => {
+  let tmp: string;
+  const savedEnv = process.env.LOOM_TESTER_ID;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "loom-testerid-get-"));
+    vi.spyOn(os, "homedir").mockReturnValue(tmp);
+    delete process.env.LOOM_TESTER_ID;
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmp, { recursive: true, force: true });
+    if (savedEnv === undefined) delete process.env.LOOM_TESTER_ID;
+    else process.env.LOOM_TESTER_ID = savedEnv;
+  });
+
+  it("returns null when nothing is set", () => {
+    expect(getCurrentTesterId()).toBeNull();
+  });
+
+  it("reads the configured id (source: config)", () => {
+    setTesterId("orbit-007");
+    expect(getCurrentTesterId()).toEqual({ id: "orbit-007", source: "config" });
+  });
+
+  it("falls back to the env override when config is empty (source: env)", () => {
+    process.env.LOOM_TESTER_ID = "orbit-env";
+    expect(getCurrentTesterId()).toEqual({ id: "orbit-env", source: "env" });
+  });
+
+  it("prefers the configured id over the env override", () => {
+    process.env.LOOM_TESTER_ID = "orbit-env";
+    setTesterId("orbit-config");
+    expect(getCurrentTesterId()).toEqual({ id: "orbit-config", source: "config" });
+  });
+});


### PR DESCRIPTION
Closes #222.

## What's going on

Beta onboarding asks testers to put their `testerId` into `~/.loom/config.json`. That file also holds LLM provider API keys, so #183/#194 hardened it into a credential store -- the exec-guard hard-denies the agent reading it (all tiers) and floors writes. So when a tester asks the agent "add my tester ID to config.json," weak models hard-deny and hallucinate a model-tier restriction, and even capable models can't do the read-then-edit anymore. A few testers hit exactly this.

## The fix

A deterministic `/tester-id` slash command -- the set-side counterpart to the read-side `buildTesterIdBlock` (#189/#191). Because it's a user-typed command, the model is never in the loop, so it behaves the same on every model tier.

- `/tester-id orbit-007` sets it; `/tester-id` with no arg prints the current value (and notes when it's coming from `LOOM_TESTER_ID`).
- It writes *only* the `testerId` key: the full config loads, that one key changes, everything else (API keys included) rides straight back to disk untouched. Nothing other than `testerId` is ever read out or echoed, so it can't become a way to surface the keys #183/#194 lock down. (`testerId` is the non-secret tester code that already passes #194 redaction and that #191 injects into the system prompt.)

## Safety hardening

- **Fails closed.** `loadConfig()` silently returns `{}` if an existing config can't be read/parsed -- writing that back would wipe stored API keys. So if a config file exists but won't parse, the command refuses rather than clobbering it. A genuinely absent file is still fine to create.
- **No raw error reflection.** A save failure is rewrapped in a fixed, actionable message; the raw error never reaches the user.

## Tests

`tests/tester-id-command.test.ts` covers validation edge cases, a disk round-trip proving only `testerId` changes and existing secrets survive, the get/set handler, a guard that the confirmation never echoes another config value, the fail-closed-on-corrupt-config case, and the no-reflection-on-save-failure case. 633 root tests green, typecheck clean.

## Follow-ups (not in this PR)

This command is the in-repo building block. To fully close the loop for the reported scenario, the beta onboarding instructions (which live outside this repo) should point testers at `/tester-id <id>` instead of "ask the agent to edit config.json." Optionally, a small system-prompt nudge could make the agent redirect conversational "set my tester id" asks to the command -- happy to do that as a separate change if we want it.
