### PR TITLE
Keep the in-progress feedback draft when the modal is dismissed

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -9,6 +9,7 @@ import { FeedbackConfirmation } from "./feedback-confirmation.js";
 import { refreshGalaxyInvocations } from "./galaxy-invocations.js";
 import { refreshGalaxyHistory } from "./galaxy-history.js";
 import { PromptQueue, queuedPreview } from "./prompt-queue.js";
+import { FeedbackDraftStore } from "./feedback-draft.js";
 import { LoomWidgetKey, decodeMarkdownWidget } from "../../../shared/loom-shell-contract.js";
 import { ALLOWED_SKILLS_PREFIX, isAllowedSkillUrl } from "../../../shared/loom-config.js";
 import {
@@ -3517,6 +3518,11 @@ const reportConfirmation = new FeedbackConfirmation({
   onClose: () => closeReportModal(),
 });
 
+// Issue #234: hold the in-progress title/body so dismissing the modal to copy
+// something from chat and reopening it doesn't wipe the draft. Module-scope so
+// it survives every open/close within a session; cleared only on a sent report.
+const feedbackDraft = new FeedbackDraftStore();
+
 // Budget for the *encoded* body in the GitHub URL. The whole URL
 // (~"https://github.com/galaxyproject/loom/issues/new?title=…&body=…")
 // has to fit within ~8KB or the OS/browser refuses to open it. Most
@@ -3531,20 +3537,34 @@ function openReportModal(): void {
   reportSuccess.classList.add("hidden");
   reportFormFields.classList.remove("hidden");
   reportFooter.classList.remove("hidden");
-  reportTitle.value = "";
-  reportBody.value = "";
+  // Restore any in-progress draft instead of clearing the fields (#234).
+  const draft = feedbackDraft.load();
+  reportTitle.value = draft.title;
+  reportBody.value = draft.body;
   // Default ON: the primary destination is Loom's private capture store, not a
   // public issue, so opt-out is fine. The user can still uncheck before sending,
   // and the public GitHub fallback (POST failure) sends text only -- no
-  // diagnostics -- so this never auto-publishes logs to a public issue.
+  // diagnostics -- so this never auto-publishes logs to a public issue. The
+  // toggles intentionally reset each open; only the typed text is a draft.
   reportIncludeSysinfo.checked = true;
   reportIncludeLogs.checked = true;
   reportOverlay.classList.remove("hidden");
   reportTitle.focus();
 }
+// Every dismiss path routes through here, so stashing the current text here
+// keeps the draft alive no matter how the modal is closed (#234). A sent report
+// empties the fields first (clearReportForm), so this saves nothing in that case.
 function closeReportModal(): void {
   reportConfirmation.cancel();
+  feedbackDraft.save({ title: reportTitle.value, body: reportBody.value });
   reportOverlay.classList.add("hidden");
+}
+// Report sent: drop the held draft and blank the fields so the next open starts
+// clean. Pair with closeReportModal(), which then has an empty form to stash.
+function clearReportForm(): void {
+  feedbackDraft.clear();
+  reportTitle.value = "";
+  reportBody.value = "";
 }
 
 // Cap a body on its URL-encoded length for the GitHub-issue fallback. The "new
@@ -3669,8 +3689,10 @@ reportSubmit.addEventListener("click", async () => {
     const payload = await buildFeedbackPayload();
     const result = await window.orbit.submitFeedback(payload);
     if (result.ok) {
-      // Show an inline "Feedback received, thank you!" before auto-closing, so a
-      // successful send is visibly confirmed instead of the modal just vanishing.
+      // Clear the held draft and blank the fields first, so the auto-close that
+      // confirm() schedules stashes nothing, then show the inline "Feedback
+      // received, thank you!" before the modal closes itself (#213 + #234).
+      clearReportForm();
       reportConfirmation.confirm();
       return;
     }
@@ -3681,6 +3703,7 @@ reportSubmit.addEventListener("click", async () => {
         "\n\n_(sent via fallback; diagnostics omitted -- the feedback service was unreachable)_",
     );
     await window.orbit.openIssueReport({ title, body: fallbackBody });
+    clearReportForm();
     closeReportModal();
   } finally {
     reportSubmit.disabled = false;

--- a/app/src/renderer/feedback-draft.ts
+++ b/app/src/renderer/feedback-draft.ts
@@ -1,0 +1,37 @@
+// In-progress "Send feedback" form contents worth surviving a modal
+// close/reopen (issue #234). Only the user-typed text is a draft; the
+// include-system-info / include-logs toggles reset to their defaults on every
+// open, so they are deliberately not held here.
+export interface FeedbackDraft {
+  title: string;
+  body: string;
+}
+
+// A form with no real text is worth nothing -- reopening after an empty open
+// should start fresh rather than restore two empty strings.
+export function isEmptyDraft(draft: FeedbackDraft): boolean {
+  return draft.title.trim() === "" && draft.body.trim() === "";
+}
+
+// Retains the in-progress feedback form across modal close/reopen and drops it
+// once the report is sent. In-memory only: the modal is hidden, not torn down,
+// so a single module-scope instance outlives every open/close cycle within a
+// session, while a fresh app launch starts with a clean form. Every dismiss
+// path (close, cancel, escape, backdrop) retains; only a successful send clears.
+export class FeedbackDraftStore {
+  private draft: FeedbackDraft = { title: "", body: "" };
+
+  save(draft: FeedbackDraft): void {
+    this.draft = isEmptyDraft(draft)
+      ? { title: "", body: "" }
+      : { title: draft.title, body: draft.body };
+  }
+
+  load(): FeedbackDraft {
+    return { title: this.draft.title, body: this.draft.body };
+  }
+
+  clear(): void {
+    this.draft = { title: "", body: "" };
+  }
+}

--- a/tests/feedback-draft.test.ts
+++ b/tests/feedback-draft.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { FeedbackDraftStore, isEmptyDraft } from "../app/src/renderer/feedback-draft.js";
+
+/**
+ * Issue #234: typing a feedback report, dismissing the "Send feedback" modal to
+ * copy something from chat, then reopening it dropped the in-progress text --
+ * the modal reset its fields on every open. FeedbackDraftStore holds the typed
+ * title/body so any dismiss (close, cancel, escape, backdrop) survives a
+ * reopen, and drops it only once the report is actually sent. These tests pin
+ * that retain/clear contract without touching the DOM.
+ */
+describe("isEmptyDraft", () => {
+  it("treats blank and whitespace-only fields as empty", () => {
+    expect(isEmptyDraft({ title: "", body: "" })).toBe(true);
+    expect(isEmptyDraft({ title: "   ", body: "\n\t " })).toBe(true);
+  });
+
+  it("is non-empty when either field has real text", () => {
+    expect(isEmptyDraft({ title: "bug", body: "" })).toBe(false);
+    expect(isEmptyDraft({ title: "", body: "it broke" })).toBe(false);
+  });
+});
+
+describe("FeedbackDraftStore", () => {
+  it("starts empty", () => {
+    const store = new FeedbackDraftStore();
+
+    expect(store.load()).toEqual({ title: "", body: "" });
+  });
+
+  it("retains a saved draft across a close/reopen", () => {
+    const store = new FeedbackDraftStore();
+
+    // close: stash whatever was typed
+    store.save({ title: "crash on send", body: "steps: 1, 2, 3" });
+
+    // reopen: the same text comes back
+    expect(store.load()).toEqual({ title: "crash on send", body: "steps: 1, 2, 3" });
+  });
+
+  it("clears the draft once feedback is sent", () => {
+    const store = new FeedbackDraftStore();
+    store.save({ title: "crash on send", body: "steps: 1, 2, 3" });
+
+    store.clear();
+
+    expect(store.load()).toEqual({ title: "", body: "" });
+  });
+
+  it("retains nothing when the form is blank on dismiss", () => {
+    const store = new FeedbackDraftStore();
+
+    store.save({ title: "   ", body: "" });
+
+    expect(store.load()).toEqual({ title: "", body: "" });
+  });
+
+  it("overwrites an earlier draft with the latest edit", () => {
+    const store = new FeedbackDraftStore();
+
+    store.save({ title: "first", body: "first body" });
+    store.save({ title: "second", body: "second body" });
+
+    expect(store.load()).toEqual({ title: "second", body: "second body" });
+  });
+
+  it("snapshots on save -- later edits to the source object don't leak in", () => {
+    const store = new FeedbackDraftStore();
+    const live = { title: "draft", body: "typing..." };
+
+    store.save(live);
+    live.title = "mutated";
+    live.body = "still typing";
+
+    expect(store.load()).toEqual({ title: "draft", body: "typing..." });
+  });
+
+  it("hands back a copy from load -- mutating it doesn't corrupt the store", () => {
+    const store = new FeedbackDraftStore();
+    store.save({ title: "draft", body: "body" });
+
+    const got = store.load();
+    got.title = "tampered";
+
+    expect(store.load()).toEqual({ title: "draft", body: "body" });
+  });
+});


### PR DESCRIPTION
Fixes #234. If you start typing a feedback report in the Send-feedback modal, dismiss it to copy something out of the chat, then reopen it, the form came back empty -- `openReportModal()` reset the fields on every open, so the in-progress draft was lost.

This stashes the typed title/body in a small in-memory `FeedbackDraftStore` (`app/src/renderer/feedback-draft.ts`). The modal wiring loads the draft on open, saves the current fields on close, and clears it on a successful send:

- **Retain on every dismiss** -- close (×), Cancel, Escape, and backdrop click all route through `closeReportModal()`, which now saves before hiding. Whichever way you step back to the chat, your text is waiting when you return.
- **Clear only on send** -- both send paths (the private capture store and the GitHub fallback) clear the draft and blank the fields first, so the next open starts fresh.
- The store is DOM-free and module-scope: it survives every open/close within a session (the modal is hidden, not torn down) and a fresh launch starts clean. A whitespace-only form retains nothing.
- The include-system-info / include-logs toggles still reset to their defaults on open -- only the typed text is treated as a draft.

### On "explicitly discarded"

The issue mentions clearing the draft when it's "successfully sent or explicitly discarded." I deliberately did *not* make Cancel a discard: a tester hitting Cancel to step back to the chat is exactly the case the bug is about, so discarding there would re-create it. Retaining on every dismiss is harmless (you see your own old text, still editable, and it clears on send anyway), so send is the only clear trigger.

### Tests

`tests/feedback-draft.test.ts` pins the retain/clear contract without touching the DOM -- round-trip across close/reopen, clear-on-send, whitespace-retains-nothing, latest-edit-wins, and save/load snapshot isolation. Full root suite green (618), and `cd app && npx tsc --noEmit` is clean.

This also composes with the send-confirmation already on this modal: the success path clears the draft before the confirmation auto-closes, so the trailing close stashes an empty form rather than a stale draft.
