### PR TITLE
Hide the model's thinking in the terminal by default

### DIFF
--- a/bin/loom.js
+++ b/bin/loom.js
@@ -12,6 +12,7 @@ import {
 import { spawn } from "child_process";
 import { getLoomVersion, detectInstall } from "./update-check.js";
 import { isUvxAvailable, uvxMissingNotice } from "./uvx-check.js";
+import { resolveHideThinking, isInteractiveTerminal } from "./thinking-pref.js";
 import { pickChannel } from "../shared/version-compare.js";
 import {
   isCustomProvider,
@@ -619,12 +620,21 @@ if (userArgs[0] === "update") {
     return null;
   }
 
-  // Suppress Pi's keybinding banner, resource listing, and "What's New"
-  // changelog. Loom is the product identity -- users shouldn't see Pi internals
-  // unless they pass --verbose. The changelog draws from pi-coding-agent's own
-  // CHANGELOG.md and is gated on lastChangelogVersion; pinning that to Pi's
-  // current version means getNewEntries() never finds anything newer to show.
-  if (!hasArg("--verbose")) {
+  // Reconcile the Pi settings loom manages. Two concerns share one read/write:
+  //  - Startup quiet (banner, resource listing, "What's New" changelog): loom is
+  //    the product identity, so users shouldn't see Pi internals unless they
+  //    pass --verbose. The changelog is gated on lastChangelogVersion; pinning
+  //    it to Pi's current version means getNewEntries() finds nothing newer.
+  //  - Thinking visibility (interactive terminal only): Pi streams the model's
+  //    reasoning into the TUI, which is noisy, so loom hides it by default.
+  //    `hideThinkingBlock` is a persisted global Pi setting that only the
+  //    interactive renderer reads, so only reconcile it for an interactive
+  //    terminal launch -- never for the non-interactive modes (rpc for Orbit
+  //    and the web server, json for evals, headless --print), which would
+  //    churn the global file for a setting they never read. Override
+  //    persistently with `ui.showThinking: true` in ~/.loom/config.json, or
+  //    just toggle it live in-session with Ctrl+T.
+  {
     const piSettingsPath = join(agentDir, "settings.json");
     try {
       let piSettings = {};
@@ -632,15 +642,29 @@ if (userArgs[0] === "update") {
         piSettings = JSON.parse(readFileSync(piSettingsPath, "utf-8"));
       }
       let changed = false;
-      if (!piSettings.quietStartup) {
-        piSettings.quietStartup = true;
-        changed = true;
+
+      if (!hasArg("--verbose")) {
+        if (!piSettings.quietStartup) {
+          piSettings.quietStartup = true;
+          changed = true;
+        }
+        const piVersion = resolvePiVersion();
+        if (piVersion && piSettings.lastChangelogVersion !== piVersion) {
+          piSettings.lastChangelogVersion = piVersion;
+          changed = true;
+        }
       }
-      const piVersion = resolvePiVersion();
-      if (piVersion && piSettings.lastChangelogVersion !== piVersion) {
-        piSettings.lastChangelogVersion = piVersion;
-        changed = true;
+
+      if (isInteractiveTerminal(userArgs)) {
+        const hideThinking = resolveHideThinking({
+          configShowThinking: loomConfig.ui?.showThinking,
+        });
+        if (piSettings.hideThinkingBlock !== hideThinking) {
+          piSettings.hideThinkingBlock = hideThinking;
+          changed = true;
+        }
       }
+
       if (changed) {
         mkdirSync(dirname(piSettingsPath), { recursive: true });
         writeFileSync(piSettingsPath, JSON.stringify(piSettings, null, 2));

--- a/bin/thinking-pref.js
+++ b/bin/thinking-pref.js
@@ -1,0 +1,38 @@
+// Terminal "thinking block" visibility. Pi streams the model's reasoning into
+// the interactive TUI by default, which makes the loom terminal noisy. Loom
+// hides it by default and writes the resolved value to pi's `hideThinkingBlock`
+// setting (the same ~/.pi/agent/settings.json loom already manages for
+// `quietStartup`). That setting is global and only the interactive renderer
+// reads it, so bin/loom.js only reconciles it for interactive terminal launches.
+//
+// Override the default persistently with `ui.showThinking: true` in
+// ~/.loom/config.json; for a one-off, pi's built-in Ctrl+T toggles it live.
+//
+// Pure so it can be unit-tested; bin/loom.js supplies the config value.
+
+/**
+ * Resolve whether pi should hide thinking blocks in the terminal.
+ * @param {{ configShowThinking?: boolean }} [opts] `ui.showThinking` from ~/.loom/config.json
+ * @returns {boolean} true = hide (the default); false = show (config opted in)
+ */
+export function resolveHideThinking({ configShowThinking } = {}) {
+  return configShowThinking !== true;
+}
+
+/**
+ * Is this loom launch an interactive terminal TUI? `hideThinkingBlock` only
+ * affects pi's interactive renderer, so non-interactive launches must not
+ * write it (it would churn the global settings file for a setting they never
+ * read): `--mode rpc` (Orbit and the web dev server), `--mode json` (evals),
+ * and headless `--print` / `-p`. Gating on the mode rather than a per-spawner
+ * env var means new non-interactive callers are covered automatically.
+ * @param {string[]} [argv] loom's user args (process.argv.slice(2))
+ * @returns {boolean}
+ */
+export function isInteractiveTerminal(argv = []) {
+  if (argv.includes("--print") || argv.includes("-p")) return false;
+  const i = argv.indexOf("--mode");
+  const mode =
+    i !== -1 ? argv[i + 1] : argv.find((a) => a.startsWith("--mode="))?.slice("--mode=".length);
+  return mode !== "rpc" && mode !== "json";
+}

--- a/shared/loom-config.d.ts
+++ b/shared/loom-config.d.ts
@@ -78,6 +78,19 @@ export interface LoomConfig {
     sessionIndex?: boolean;
   };
   /**
+   * Terminal/display preferences for the loom CLI.
+   */
+  ui?: {
+    /**
+     * Show the model's "thinking" blocks in the interactive terminal. Off by
+     * default -- loom hides them (writes pi's `hideThinkingBlock`) to keep the
+     * chat readable. Set true to restore pi's reasoning stream persistently.
+     * For a one-off, pi's built-in Ctrl+T toggles thinking live in-session.
+     * Terminal-only: Orbit and headless (--print) launches don't touch it.
+     */
+    showThinking?: boolean;
+  };
+  /**
    * Local-execution safety gate (exec-guard). Secure by default: the gate is
    * enabled, never bypassed, and trusts nothing until the user says otherwise.
    */

--- a/tests/cli-thinking-pref.test.ts
+++ b/tests/cli-thinking-pref.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { resolveHideThinking, isInteractiveTerminal } from "../bin/thinking-pref.js";
+
+describe("resolveHideThinking", () => {
+  it("hides thinking by default (no config)", () => {
+    expect(resolveHideThinking()).toBe(true);
+    expect(resolveHideThinking({})).toBe(true);
+    expect(resolveHideThinking({ configShowThinking: undefined })).toBe(true);
+  });
+
+  it("shows thinking when ui.showThinking is true", () => {
+    expect(resolveHideThinking({ configShowThinking: true })).toBe(false);
+  });
+
+  it("stays hidden when ui.showThinking is explicitly false", () => {
+    expect(resolveHideThinking({ configShowThinking: false })).toBe(true);
+  });
+
+  it("only literal true opts in (not other truthy values)", () => {
+    // Guards against a stray non-boolean in config flipping the default.
+    expect(resolveHideThinking({ configShowThinking: 1 })).toBe(true);
+    expect(resolveHideThinking({ configShowThinking: "true" })).toBe(true);
+  });
+});
+
+describe("isInteractiveTerminal", () => {
+  it("treats a plain terminal launch (no args / text mode) as interactive", () => {
+    expect(isInteractiveTerminal([])).toBe(true);
+    expect(isInteractiveTerminal(["--continue"])).toBe(true);
+    expect(isInteractiveTerminal(["--mode", "text"])).toBe(true);
+  });
+
+  it("excludes rpc and json modes (Orbit, web server, evals)", () => {
+    expect(isInteractiveTerminal(["--mode", "rpc"])).toBe(false);
+    expect(isInteractiveTerminal(["--mode", "json"])).toBe(false);
+    expect(isInteractiveTerminal(["--mode=rpc"])).toBe(false);
+  });
+
+  it("excludes headless --print / -p", () => {
+    expect(isInteractiveTerminal(["--print", "hi"])).toBe(false);
+    expect(isInteractiveTerminal(["-p", "hi"])).toBe(false);
+  });
+});


### PR DESCRIPTION
Pi streams the model's reasoning into the interactive TUI, so every turn in the loom terminal opens with a paragraph of "I need to figure out..." before anything useful -- it reads as noise. This defaults that off.

Loom hides thinking by writing pi's `hideThinkingBlock` setting -- the same `~/.pi/agent/settings.json` it already manages for `quietStartup`. Pi has no per-launch knob for it (it's read only from that persisted global file, and only by the interactive renderer), so:

- It's reconciled **only on interactive terminal launches**, gated on the run mode -- non-interactive callers are excluded automatically: `rpc` (Orbit and the web dev server), `json` (evals), and headless `--print`. No churning the global file for a setting they never read.
- Override persistently with `ui.showThinking: true` in `~/.loom/config.json`.
- For a one-off, pi's built-in `Ctrl+T` toggles thinking live in-session.

Display-only and terminal-only: `hideThinkingBlock` only affects pi's interactive rendering (not model context/replay), and Orbit -- which never showed thinking text anyway -- is untouched.

Unit tests cover the config resolver and the interactive-mode gate; 616 green, root + app typecheck clean.
