### PR TITLE
Chat export follow-ups: ordering, error dedup, and tool-record sync

### DIFF
--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -13,7 +13,7 @@ import type {
 export type MessageRecord =
   | { role: "user"; text: string }
   | { role: "assistant"; text: string }
-  | { role: "tool"; name: string; status: string; result?: string }
+  | { role: "tool"; id: string; name: string; status: string; result?: string }
   | { role: "info"; text: string }
   | { role: "error"; text: string };
 
@@ -305,7 +305,7 @@ export class ChatPanel {
   }
 
   addToolCard(id: string, name: string): void {
-    this.history.push({ role: "tool", name, status: "running" });
+    this.history.push({ role: "tool", id, name, status: "running" });
     const card = document.createElement("div");
     card.className = "tool-card";
     card.innerHTML = `
@@ -350,6 +350,16 @@ export class ChatPanel {
     const dot = card.querySelector(".tool-status")!;
     dot.className = `tool-status ${status}`;
 
+    // Sync the export record up front, keyed by id. The team_dispatch branch
+    // below returns early, so doing this here keeps those records from being
+    // frozen at "running"; matching on id (not the rendered name) stops two
+    // same-named tools in a turn from clobbering each other.
+    const rec = this.history.findLast((r) => r.role === "tool" && r.id === id);
+    if (rec && rec.role === "tool") {
+      rec.status = status;
+      if (result) rec.result = result.slice(0, 2000);
+    }
+
     // Specialized branch: team_dispatch details render as a collapsible card.
     if (details && (details as { kind?: string }).kind === TEAM_DISPATCH_KIND) {
       const body = card.querySelector(".tool-card-body")!;
@@ -361,12 +371,6 @@ export class ChatPanel {
     if (result) {
       const body = card.querySelector(".tool-card-body")!;
       body.textContent = result.slice(0, 2000);
-    }
-
-    const rec = this.history.findLast(r => r.role === "tool" && r.name === card.querySelector("span:last-child")?.textContent);
-    if (rec && rec.role === "tool") {
-      rec.status = status;
-      if (result) rec.result = result.slice(0, 2000);
     }
   }
 

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -36,6 +36,10 @@ export class ChatPanel {
   private lastErrorText = "";
   private lastErrorCount = 0;
   private history: MessageRecord[] = [];
+  // Assistant text accumulated since the last export flush (message start or a
+  // tool card). Flushed as its own record so prose keeps its order around tool
+  // cards instead of all collapsing to one block pushed at message end.
+  private pendingSegment = "";
   private copyBtn: HTMLElement;
 
   constructor(container: HTMLElement) {
@@ -175,6 +179,7 @@ export class ChatPanel {
     this.container.innerHTML = "";
     this.currentMessage = null;
     this.currentText = "";
+    this.pendingSegment = "";
     this.pendingBlockBreak = false;
     this.toolCards.clear();
     this.thinkingEl = null;
@@ -259,6 +264,7 @@ export class ChatPanel {
 
   startAssistantMessage(): void {
     this.currentText = "";
+    this.pendingSegment = "";
     this.pendingBlockBreak = false;
     const el = document.createElement("div");
     el.className = "message assistant";
@@ -283,8 +289,10 @@ export class ChatPanel {
     if (this.pendingBlockBreak) {
       this.pendingBlockBreak = false;
       this.currentText = joinTextBlocks(this.currentText, delta);
+      this.pendingSegment = joinTextBlocks(this.pendingSegment, delta);
     } else {
       this.currentText += delta;
+      this.pendingSegment += delta;
     }
     this.renderCurrentMessage();
     this.scrollToBottom();
@@ -296,15 +304,25 @@ export class ChatPanel {
     }
     // Clean up any stray cursors across the whole container
     this.container.querySelectorAll(".cursor-blink").forEach((c) => c.remove());
-    if (this.currentText) {
-      this.history.push({ role: "assistant", text: this.currentText });
-    }
+    this.flushAssistantSegment();
     this.currentMessage = null;
     this.currentText = "";
     this.pendingBlockBreak = false;
   }
 
+  /**
+   * Push the assistant text accumulated since the last flush as one export
+   * record. Called at each tool card and at message end so prose keeps its
+   * position relative to tool cards.
+   */
+  private flushAssistantSegment(): void {
+    const segment = this.pendingSegment.trim();
+    if (segment) this.history.push({ role: "assistant", text: segment });
+    this.pendingSegment = "";
+  }
+
   addToolCard(id: string, name: string): void {
+    this.flushAssistantSegment();
     this.history.push({ role: "tool", id, name, status: "running" });
     const card = document.createElement("div");
     card.className = "tool-card";

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -377,13 +377,16 @@ export class ChatPanel {
   }
 
   addErrorMessage(text: string): void {
-    this.history.push({ role: "error", text });
     if (this.lastErrorEl && this.lastErrorText === text) {
       this.lastErrorCount += 1;
       this.lastErrorEl.textContent = `${text}  (x${this.lastErrorCount})`;
       this.scrollToBottom();
       return;
     }
+    // Record only when a new card is actually rendered -- duplicates collapse
+    // into the card above, so one record per visible card keeps the export in
+    // sync with what the user sees.
+    this.history.push({ role: "error", text });
     const el = document.createElement("div");
     el.className = "message assistant";
     el.style.color = "var(--error)";

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -399,6 +399,8 @@ export class ChatPanel {
   }
 
   addErrorMessage(text: string): void {
+    // Flush any prose streamed before this error so the export keeps order.
+    this.flushAssistantSegment();
     if (this.lastErrorEl && this.lastErrorText === text) {
       this.lastErrorCount += 1;
       this.lastErrorEl.textContent = `${text}  (x${this.lastErrorCount})`;

--- a/tests/chat-panel-history.test.ts
+++ b/tests/chat-panel-history.test.ts
@@ -42,3 +42,34 @@ describe("ChatPanel error history", () => {
     expect(md).toContain("*Error: second*");
   });
 });
+
+describe("ChatPanel tool history", () => {
+  it("correlates updates by id, not by rendered tool name", () => {
+    const panel = makePanel();
+    // Two tools with the SAME name in one turn -- matching on name alone would
+    // land both updates on the last record.
+    panel.addToolCard("a", "team_dispatch");
+    panel.addToolCard("b", "team_dispatch");
+    panel.updateToolCard("a", "done", "result-A");
+    panel.updateToolCard("b", "error", "result-B");
+    const [blockA, blockB] = panel.exportAsMarkdown().split("\n---\n\n");
+    expect(blockA).toContain("✓");
+    expect(blockA).toContain("result-A");
+    expect(blockB).toContain("✗");
+    expect(blockB).toContain("result-B");
+  });
+
+  it("syncs team_dispatch records even though the card render returns early", () => {
+    const panel = makePanel();
+    panel.addToolCard("td", "team_dispatch");
+    panel.updateToolCard("td", "done", "team finished", {
+      kind: TEAM_DISPATCH_KIND,
+      summary: "ran the team",
+    });
+    // Without the fix the team_dispatch branch returns before syncing history,
+    // so the export would stay frozen at the running badge.
+    const md = panel.exportAsMarkdown();
+    expect(md).toContain("Tool call ✓");
+    expect(md).not.toContain("Tool call …");
+  });
+});

--- a/tests/chat-panel-history.test.ts
+++ b/tests/chat-panel-history.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+//
+// Stateful tests for the ChatPanel -> export `history` buffer. These drive a
+// real ChatPanel against a happy-dom container (the pure historyToMarkdown /
+// fragmentToMarkdown helpers are covered separately in chat-panel.test.ts).
+import { beforeEach, describe, expect, it } from "vitest";
+import { ChatPanel } from "../app/src/renderer/chat/chat-panel.js";
+import { TEAM_DISPATCH_KIND } from "../shared/team-dispatch-contract.js";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+function makePanel(): ChatPanel {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  return new ChatPanel(container);
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe("ChatPanel error history", () => {
+  it("records one entry per visible card when duplicate errors collapse", () => {
+    const panel = makePanel();
+    // The UI collapses consecutive identical errors into one card with "(xN)";
+    // the export must mirror that, not emit one block per swallowed duplicate.
+    panel.addErrorMessage("boom");
+    panel.addErrorMessage("boom");
+    panel.addErrorMessage("boom");
+    const md = panel.exportAsMarkdown();
+    expect(countOccurrences(md, "*Error: boom*")).toBe(1);
+  });
+
+  it("records distinct errors separately", () => {
+    const panel = makePanel();
+    panel.addErrorMessage("first");
+    panel.addErrorMessage("second");
+    const md = panel.exportAsMarkdown();
+    expect(md).toContain("*Error: first*");
+    expect(md).toContain("*Error: second*");
+  });
+});

--- a/tests/chat-panel-history.test.ts
+++ b/tests/chat-panel-history.test.ts
@@ -95,4 +95,14 @@ describe("ChatPanel text/tool ordering", () => {
     expect(iBefore).toBeLessThan(iTool);
     expect(iTool).toBeLessThan(iAfter);
   });
+
+  it("flushes pending prose before an error so order is preserved", () => {
+    const panel = makePanel();
+    panel.startAssistantMessage();
+    panel.appendDelta("Trying the thing.");
+    panel.addErrorMessage("it broke");
+    panel.finishAssistantMessage();
+    const md = panel.exportAsMarkdown();
+    expect(md.indexOf("Trying the thing.")).toBeLessThan(md.indexOf("*Error: it broke*"));
+  });
 });

--- a/tests/chat-panel-history.test.ts
+++ b/tests/chat-panel-history.test.ts
@@ -73,3 +73,26 @@ describe("ChatPanel tool history", () => {
     expect(md).not.toContain("Tool call …");
   });
 });
+
+describe("ChatPanel text/tool ordering", () => {
+  it("records assistant prose in order relative to tool cards", () => {
+    const panel = makePanel();
+    panel.startAssistantMessage();
+    panel.appendDelta("Let me run a team.");
+    panel.addToolCard("t1", "team_dispatch");
+    panel.updateToolCard("t1", "done", "team result");
+    panel.separateNextBlock();
+    panel.appendDelta("All done!");
+    panel.finishAssistantMessage();
+
+    const md = panel.exportAsMarkdown();
+    const iBefore = md.indexOf("Let me run a team.");
+    const iTool = md.indexOf("Tool call");
+    const iAfter = md.indexOf("All done!");
+    expect(iBefore).toBeGreaterThanOrEqual(0);
+    expect(iAfter).toBeGreaterThanOrEqual(0);
+    // prose-before-tool must export before the tool card, prose-after must follow it
+    expect(iBefore).toBeLessThan(iTool);
+    expect(iTool).toBeLessThan(iAfter);
+  });
+});

--- a/tests/chat-panel.test.ts
+++ b/tests/chat-panel.test.ts
@@ -24,23 +24,23 @@ describe("historyToMarkdown", () => {
   });
 
   it("formats a tool call with done status and no result", () => {
-    const records: MessageRecord[] = [{ role: "tool", name: "bash", status: "done" }];
+    const records: MessageRecord[] = [{ role: "tool", id: "t1", name: "bash", status: "done" }];
     expect(historyToMarkdown(records)).toBe("*Tool call ✓: `bash`*\n");
   });
 
   it("formats a tool call with error status", () => {
-    const records: MessageRecord[] = [{ role: "tool", name: "bash", status: "error" }];
+    const records: MessageRecord[] = [{ role: "tool", id: "t1", name: "bash", status: "error" }];
     expect(historyToMarkdown(records)).toBe("*Tool call ✗: `bash`*\n");
   });
 
   it("formats a running tool call", () => {
-    const records: MessageRecord[] = [{ role: "tool", name: "bash", status: "running" }];
+    const records: MessageRecord[] = [{ role: "tool", id: "t1", name: "bash", status: "running" }];
     expect(historyToMarkdown(records)).toBe("*Tool call …: `bash`*\n");
   });
 
   it("includes tool result in a code fence when present", () => {
     const records: MessageRecord[] = [
-      { role: "tool", name: "bash", status: "done", result: "hello world" },
+      { role: "tool", id: "t1", name: "bash", status: "done", result: "hello world" },
     ];
     expect(historyToMarkdown(records)).toBe(
       "*Tool call ✓: `bash`*\n\n```\nhello world\n```\n",


### PR DESCRIPTION
Follow-up to #244, which added chat export and copy-to-markdown. While reviewing it I found a handful of bugs in the `history` buffer that backs the export -- all in how records get recorded, none of them regressions in the merged feature. This cleans them up, with tests.

- **Errors double-counted.** `addErrorMessage` recorded a history entry before the dedup check, so three identical errors the UI collapses into one `(x3)` card still wrote three `*Error*` blocks into the export. Now there's one record per visible card.
- **Tool records correlated by name.** `updateToolCard` matched the history record by rendered tool name, so two same-named tools in one turn clobbered each other -- and the `team_dispatch` branch returned before syncing at all, leaving those records frozen at "running" with no result. Records now carry an `id`, the sync keys off it, and runs before the team_dispatch early-return.
- **Text/tool order.** `finishAssistantMessage` pushed the whole message as one record at the end, after every tool card from that turn, so the export showed a tool card before the prose that introduced it. A per-segment buffer flushes at each tool card and at message end, so text/tool/text records keep the order they happened (errors flush pending prose too).

All TDD'd against a happy-dom `ChatPanel` in `tests/chat-panel-history.test.ts`; full suite green, root + app typecheck clean.

Two things I deliberately left alone: the export skips `info` messages (resumed-session markers, `/help` output) -- intentional UI chrome, and the existing test documents it. And it still only includes `team_dispatch` cards, not every Galaxy tool -- that mirrors what the chat pane shows; whether to pull broader tool activity from the Activity stream is a product call, not a bug.
