### PR TITLE
Document LAN access and security caveats for the web dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The names trace real cosmology. The universe's large-scale structure is the _cos
 
 Future shells — a Galaxy-embedded web UI, a hosted server mode, anything else — talk to the same brain over RPC.
 
+That web shell already has a working seed today: a browser-served build of the Orbit renderer, running the same brain over RPC, reachable from another device on your LAN -- handy for chatting from a phone, and a natural home for Galaxy interactive tools later on. It's an unauthenticated single-user dev tool for now, so keep it on a trusted network; setup and the security caveats are in [`web/README.md`](web/README.md).
+
 ## How it works
 
 1. You open Orbit (or run `loom`) in an analysis directory. A `notebook.md` is created on first launch and committed to git.

--- a/web/README.md
+++ b/web/README.md
@@ -50,6 +50,44 @@ The working directory defaults to `~/.loom/analyses` (override with
 `defaultCwd` in `~/.loom/config.json`). The brain subprocess starts lazily on
 the first browser connection, so the page loads before any agent spins up.
 
+## Using it from another device (phone, tablet)
+
+The server binds to all interfaces, not just loopback, so once it's running you
+can reach it from another device on the same network. The renderer is
+responsive, so a phone browser works fine as a chat client.
+
+1. Start the server on your machine -- `npm run dev` (or `PORT=4000 npm run dev`).
+2. Find your machine's LAN IP -- `ipconfig getifaddr en0` on macOS,
+   `hostname -I` on Linux.
+3. On the other device, on the same Wi-Fi, open `http://<that-ip>:3000`.
+
+Reaching it by IP also sidesteps Vite's dev-server host check, so no extra
+config is needed.
+
+## Security: keep it on a trusted network, never expose it
+
+> [!WARNING]
+> This is an **unauthenticated** dev server. Anyone who can reach the port gets
+> a fully-capable agent running as you -- your LLM API keys, your Galaxy
+> credentials, your shell and filesystem. There is no login, no token, and no
+> per-user isolation. Treat "can reach the port" as "can act as me."
+
+So: keep it behind your home router/firewall on a network you trust, and never
+bind it to a public interface or forward the port in from the internet. The
+stubbed file tree (see below) is a renderer convenience that's missing -- it is
+**not** a capability limit. The underlying brain is the same one Orbit and the
+CLI run, with the same tool execution and Galaxy access.
+
+It also handles **one** browser connection at a time -- a second connection
+displaces the first. It's a single-user dev tool, full stop.
+
+If you genuinely need it from outside your network, put something that adds its
+own authentication in front -- a VPN/mesh like Tailscale, or a tunnel
+(cloudflared/ngrok) gated by access control -- rather than opening the raw port.
+The real multi-user/remote deployment shape (`LOOM_MODE=remote`, tool
+allowlists, path-gating, Docker) is a separate design (spec linked above); this
+dev server is not that and shouldn't be pressed into that role.
+
 ## How it works
 
 ```


### PR DESCRIPTION
The `web/` dev server already binds to all interfaces, so you can reach it from a phone or another device on your LAN -- which is half the appeal -- but the README never said so, and never warned that doing it hands an unauthenticated, fully-capable agent (your LLM keys, Galaxy creds, shell) to anyone who can reach the port.

This adds two sections to `web/README.md`:
- **Using it from another device** -- how to reach it by LAN IP (find your IP, open `http://<ip>:3000`), noting the bind-to-all-interfaces default and that IP access sidesteps Vite's host check.
- **Security: keep it on a trusted network, never expose it** -- a loud warning that it's unauthenticated and single-connection, that the stubbed file tree is a renderer gap and *not* a capability limit, and that anyone needing real remote access should front it with a VPN/mesh or gated tunnel rather than opening the raw port.

Also drops a pointer from the root README's "future shells" note so the browser shell -- and its eventual fit for hosting Galaxy interactive tools -- is discoverable from the top.

Docs only.