### PR TITLE
Match the stated Node version to the engine requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Orbit ships as a native installer that bundles its own Node runtime, `uv`, and L
 
 ### Loom CLI from npm
 
-Run the brain on the command line without Orbit. Requires Node 22+ and (for Galaxy MCP) [uv](https://docs.astral.sh/uv/).
+Run the brain on the command line without Orbit. Requires Node 22.19+ and (for Galaxy MCP) [uv](https://docs.astral.sh/uv/).
 
 ```bash
 npm install -g @galaxyproject/loom
@@ -279,7 +279,7 @@ node bin/loom.js                       # from repo root
 For a browser-based dev loop with hot reload (the Orbit renderer served over
 the web, against the same brain), see [`web/README.md`](web/README.md).
 
-The developer install needs Node 22+ and `uv` on `PATH`. Per-OS bootstrap below.
+The developer install needs Node 22.19+ (matching [`.nvmrc`](.nvmrc)) and `uv` on `PATH`. Per-OS bootstrap below.
 
 #### Linux (Ubuntu/Debian)
 

--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -78,7 +78,7 @@ function resolveLoomBin(): string {
   return path.resolve(__dirname, "../../../bin/loom.js");
 }
 
-// Resolve the Node binary the brain runs under. Dev assumes Node 20+ on PATH.
+// Resolve the Node binary the brain runs under. Dev assumes Node 22.19+ on PATH.
 // Packaged Orbit ships its own Node next to Loom (Resources/node/) so users
 // don't need to have Node installed; this also keeps native module ABI in sync
 // with whatever Node ran `npm ci` during prePackage staging.

--- a/install.sh
+++ b/install.sh
@@ -26,14 +26,15 @@ echo -e "${GREEN}║     Galaxy Co-Scientist for Bioinformatics ║${NC}"
 echo -e "${GREEN}╚════════════════════════════════════════════╝${NC}"
 echo ""
 
-# Check Node.js
+# Check Node.js (>=22.19, matching package.json engines.node / .nvmrc)
 if ! command -v node &> /dev/null; then
-    error "Node.js is required but not installed. Please install Node.js 18+ from https://nodejs.org/"
+    error "Node.js is required but not installed. Please install Node.js 22.19+ from https://nodejs.org/"
 fi
 
-NODE_VERSION=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
-if [ "$NODE_VERSION" -lt 18 ]; then
-    error "Node.js 18+ is required. You have $(node -v). Please upgrade."
+NODE_MAJOR=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
+NODE_MINOR=$(node -v | cut -d'.' -f2)
+if [ "$NODE_MAJOR" -lt 22 ] || { [ "$NODE_MAJOR" -eq 22 ] && [ "$NODE_MINOR" -lt 19 ]; }; then
+    error "Node.js 22.19+ is required. You have $(node -v). Please upgrade."
 fi
 success "Node.js $(node -v) found"
 

--- a/web/README.md
+++ b/web/README.md
@@ -19,7 +19,7 @@ lives in `docs/superpowers/specs/2026-05-09-orbit-web-remote-only-design.md`.
 
 Same as the developer install in the root [`README.md`](../README.md):
 
-- Node 20+ and `uv` on `PATH` (uv is needed by galaxy-mcp, same as the CLI).
+- Node 22.19+ and `uv` on `PATH` (uv is needed by galaxy-mcp, same as the CLI).
 - A configured `~/.loom/config.json` with at least an LLM API key. The web
   server reads the exact same config as Orbit and the CLI, so if either of
   those already works, you're set. Otherwise you can fill it in from the


### PR DESCRIPTION
Fixes #270.

`package.json` `engines.node` and `.nvmrc` both require Node 22.19, but the docs and installer were advertising looser floors:

- README "Loom CLI from npm" said Node 22+
- README developer install said Node 22+
- `web/README.md` still said Node 20+
- `install.sh` told users "18+" and only enforced a major-version `>=18` check

So anyone on a 20.x or 22.0-22.18 shell passed every prompt/check and then tripped npm's engine error. This bumps all the stated requirements to 22.19+, points the developer-install line at `.nvmrc` as the source of truth, and tightens `install.sh` to actually enforce `>=22.19` with a major.minor compare (checked the boundary: 22.18 rejected, 22.19 accepted, 23.x/24.x accepted). Also corrects a stale "Node 20+" comment in `agent.ts`.

Docs- and script-only -- the only behavior change is the installer's version gate now matching the declared engine.

Left out of scope on purpose: the CI workflows pin `node-version: 22` (bare), which resolves to a 22.x that already satisfies the floor. Switching those to `node-version-file: .nvmrc` would be a nice consistency follow-up but isn't needed to close this issue.