### PR TITLE
Close the notebook watcher on session shutdown so --print exits

### DIFF
--- a/extensions/loom/session-lifecycle.ts
+++ b/extensions/loom/session-lifecycle.ts
@@ -1,5 +1,10 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { resetState, initSessionArtifacts, getNotebookPath } from "./state.js";
+import {
+  resetState,
+  initSessionArtifacts,
+  getNotebookPath,
+  stopWatchingNotebook,
+} from "./state.js";
 import { startGalaxyPoller, stopGalaxyPoller } from "./galaxy-poller.js";
 import {
   appendSessionSummaryBlock,
@@ -55,6 +60,12 @@ export function registerSessionLifecycle(pi: ExtensionAPI): void {
 
   pi.on("session_shutdown", async () => {
     stopGalaxyPoller();
+    // Close the notebook FSWatcher before the summary write below. The watcher
+    // otherwise keeps the event loop alive (so --print never exits) and, since
+    // writeSessionSummary() writes to notebook.md, would fire its callback
+    // against a now-stale ctx. Closing first releases the loop and silences
+    // that fire. #271
+    stopWatchingNotebook();
     await writeSessionSummary();
     snapshotNotebook(pi);
   });

--- a/extensions/loom/state.ts
+++ b/extensions/loom/state.ts
@@ -117,7 +117,7 @@ function startWatchingNotebook(filePath: string, autoCommit = false): void {
   }
 }
 
-function stopWatchingNotebook(): void {
+export function stopWatchingNotebook(): void {
   if (currentWatcher) {
     try {
       currentWatcher.close();

--- a/extensions/loom/ui-bridge.ts
+++ b/extensions/loom/ui-bridge.ts
@@ -33,7 +33,23 @@ export function setupUIBridge(pi: ExtensionAPI): void {
     if (getNotebookWidgetMode() === "hidden") return;
     const nbPath = getNotebookPath();
     const header = nbPath ? `> \`${nbPath}\`\n\n` : "";
-    latestCtx.ui.setWidget(LoomWidgetKey.Notebook, encodeMarkdownWidget(header + content));
+    try {
+      latestCtx.ui.setWidget(LoomWidgetKey.Notebook, encodeMarkdownWidget(header + content));
+    } catch (err) {
+      // A notebook write that lands after session teardown fires this callback
+      // with a ctx pi has since invalidated; touching ctx.ui throws "ctx is
+      // stale after session replacement or reload". Drop the captured ctx and
+      // no-op rather than spamming stderr. The deterministic fix closes the
+      // watcher on shutdown; this guards any late-firing callback. #271
+      //
+      // Only the stale-ctx throw is expected here; surface anything else so a
+      // genuine setWidget failure during an active session isn't hidden.
+      if (!(err instanceof Error && /ctx is stale/i.test(err.message))) {
+        console.error("notebook widget update failed:", err);
+      }
+      latestCtx = null;
+      return;
+    }
     setNotebookWidgetMode("open");
   });
 }

--- a/tests/notebook-watcher-teardown.test.ts
+++ b/tests/notebook-watcher-teardown.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mock chokidar so we can assert watcher open/close without real fs-event
+// timing. The bug (#271) is that the notebook FSWatcher is never closed on
+// teardown, so it keeps firing and holds the event loop open (--print hangs).
+const { watchMock, onMock, closeMock } = vi.hoisted(() => {
+  const onMock = vi.fn();
+  const closeMock = vi.fn();
+  const watchMock = vi.fn(() => ({ on: onMock, close: closeMock }));
+  return { watchMock, onMock, closeMock };
+});
+
+vi.mock("chokidar", () => ({ default: { watch: watchMock } }));
+
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { resetState, setNotebookPath, stopWatchingNotebook } from "../extensions/loom/state";
+
+describe("notebook watcher teardown (#271)", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    resetState();
+    watchMock.mockClear();
+    onMock.mockClear();
+    closeMock.mockClear();
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  function freshNotebook(): string {
+    const dir = mkdtempSync(join(tmpdir(), "loom-watcher-"));
+    dirs.push(dir);
+    const nb = join(dir, "notebook.md");
+    writeFileSync(nb, "init", "utf-8");
+    return nb;
+  }
+
+  it("opens a watcher when a notebook path is set", () => {
+    setNotebookPath(freshNotebook());
+    expect(watchMock).toHaveBeenCalledTimes(1);
+    expect(closeMock).not.toHaveBeenCalled();
+  });
+
+  it("closes the watcher on stopWatchingNotebook so it stops firing and releases the loop", () => {
+    setNotebookPath(freshNotebook());
+    stopWatchingNotebook();
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the prior watcher before opening a new one (no leak across re-attach)", () => {
+    setNotebookPath(freshNotebook());
+    setNotebookPath(freshNotebook());
+    expect(watchMock).toHaveBeenCalledTimes(2);
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/session-shutdown-watcher.test.ts
+++ b/tests/session-shutdown-watcher.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #271: session_shutdown must close the notebook FSWatcher (via
+// stopWatchingNotebook) so the dangling watcher stops holding the event loop
+// open and --print can exit. Mock state + poller so we observe the wiring
+// without touching real fs/git/timers.
+vi.mock("../extensions/loom/state.js", () => ({
+  resetState: vi.fn(),
+  initSessionArtifacts: vi.fn(),
+  getNotebookPath: vi.fn(() => null),
+  stopWatchingNotebook: vi.fn(),
+}));
+vi.mock("../extensions/loom/galaxy-poller.js", () => ({
+  startGalaxyPoller: vi.fn(),
+  stopGalaxyPoller: vi.fn(),
+}));
+
+import * as poller from "../extensions/loom/galaxy-poller.js";
+import * as state from "../extensions/loom/state.js";
+import { registerSessionLifecycle } from "../extensions/loom/session-lifecycle";
+
+function fakePi() {
+  const handlers: Record<string, (...args: any[]) => any> = {};
+  const pi = {
+    on: (evt: string, handler: (...args: any[]) => any) => {
+      handlers[evt] = handler;
+    },
+    appendEntry: vi.fn(),
+    sendUserMessage: vi.fn(),
+  } as any;
+  return { pi, handlers };
+}
+
+describe("session_shutdown closes the notebook watcher (#271)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("closes the watcher on shutdown so --print can exit", async () => {
+    const { pi, handlers } = fakePi();
+    registerSessionLifecycle(pi);
+
+    expect(handlers["session_shutdown"]).toBeTypeOf("function");
+
+    await handlers["session_shutdown"]({}, {});
+
+    expect(poller.stopGalaxyPoller).toHaveBeenCalled();
+    expect(state.stopWatchingNotebook).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/ui-bridge-stale-ctx.test.ts
+++ b/tests/ui-bridge-stale-ctx.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// #271: a notebook write that lands after session teardown fires the watcher
+// callback with a captured ctx that pi has since invalidated. Touching
+// ctx.ui throws "ctx is stale after session replacement or reload". The
+// listener must no-op instead of throwing (which otherwise spams stderr and
+// signals the dangling-watcher defect).
+const { captured, setNotebookWidgetMode } = vi.hoisted(() => ({
+  captured: { listener: null as null | ((content: string) => void) },
+  setNotebookWidgetMode: vi.fn(),
+}));
+
+vi.mock("../extensions/loom/state.js", () => ({
+  onNotebookChange: (listener: (content: string) => void) => {
+    captured.listener = listener;
+    return () => {};
+  },
+  getNotebookPath: () => "/work/notebook.md",
+  getNotebookWidgetMode: () => "open",
+  setNotebookWidgetMode,
+}));
+
+import { setupUIBridge } from "../extensions/loom/ui-bridge";
+
+function fakePi() {
+  const handlers: Record<string, (...args: any[]) => any> = {};
+  const pi = {
+    on: (evt: string, handler: (...args: any[]) => any) => {
+      handlers[evt] = handler;
+    },
+  } as any;
+  return { pi, handlers };
+}
+
+function staleCtx() {
+  return {
+    get ui(): never {
+      throw new Error("This extension ctx is stale after session replacement or reload.");
+    },
+  };
+}
+
+describe("ui-bridge notebook widget (#271 stale-ctx guard)", () => {
+  beforeEach(() => {
+    captured.listener = null;
+    setNotebookWidgetMode.mockClear();
+  });
+
+  it("renders the widget on an active ctx", () => {
+    const { pi, handlers } = fakePi();
+    setupUIBridge(pi);
+    const setWidget = vi.fn();
+    handlers["before_agent_start"]({}, { ui: { setWidget } });
+
+    captured.listener!("fresh notebook content");
+
+    expect(setWidget).toHaveBeenCalledTimes(1);
+    expect(setNotebookWidgetMode).toHaveBeenCalledWith("open");
+  });
+
+  it("no-ops instead of throwing when the captured ctx is stale", () => {
+    const { pi, handlers } = fakePi();
+    setupUIBridge(pi);
+    handlers["before_agent_start"]({}, staleCtx());
+
+    expect(() => captured.listener!("content after teardown")).not.toThrow();
+    expect(setNotebookWidgetMode).not.toHaveBeenCalled();
+  });
+
+  it("drops the stale ctx so later notebook changes also no-op", () => {
+    const { pi, handlers } = fakePi();
+    setupUIBridge(pi);
+    handlers["before_agent_start"]({}, staleCtx());
+
+    captured.listener!("first");
+    expect(() => captured.listener!("second")).not.toThrow();
+    expect(setNotebookWidgetMode).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an unexpected setWidget failure instead of silently masking it", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { pi, handlers } = fakePi();
+      setupUIBridge(pi);
+      const setWidget = vi.fn(() => {
+        throw new Error("renderer RPC blew up");
+      });
+      handlers["before_agent_start"]({}, { ui: { setWidget } });
+
+      // Unrelated failure must not throw out of the listener, but unlike the
+      // stale-ctx case it must be logged so a real regression stays visible.
+      expect(() => captured.listener!("content")).not.toThrow();
+      expect(errSpy).toHaveBeenCalledTimes(1);
+      expect(setNotebookWidgetMode).not.toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
Closes #271.

In `--print` mode Loom printed the model response but then hung 30-45s until killed. The notebook `FSWatcher` (chokidar, on `notebook.md`) was never closed when the session tore down, so it kept the Node event loop alive and the process never exited. On top of that, the shutdown summary write to `notebook.md` fired the still-open watcher ~500ms later against a captured ctx that pi had already invalidated -- that's the `ctx is stale after session replacement or reload` error in the report.

The fix is deterministic teardown: `session_shutdown` now closes the watcher before writing the session summary. Closing first both releases the event loop (so `--print` exits) and means the summary write can't fire a stale callback. It runs ahead of the summary/snapshot writes rather than going through `resetState()` so the notebook path stays available for them.

As a belt-and-suspenders guard for any late-firing callback, the ui-bridge notebook listener now drops a stale ctx and no-ops instead of throwing. It still surfaces any *other* `setWidget` failure via `console.error` so a genuine active-session regression doesn't get silently swallowed.

I confirmed the mechanism directly: an open chokidar watcher keeps node alive (the process hangs), and a fire-and-forget `close()` lets it exit with code 0. The Galaxy poller -- the other persistent handle at shutdown -- was already being cleared.

### Tests
- `notebook-watcher-teardown` -- watcher is closed on teardown (chokidar mocked)
- `session-shutdown-watcher` -- `session_shutdown` actually closes it
- `ui-bridge-stale-ctx` -- stale ctx no-ops silently; an unrelated `setWidget` failure is still surfaced

Full root suite green (733), root + app `tsc --noEmit` clean, lint/format clean.

### Notes
- Not live-eyeballed end-to-end against a real provider (no API key handy) -- the exit-0 claim rests on the watcher-close mechanism plus the deterministic teardown wiring.
- The shutdown summary still isn't auto-committed in loom-managed repos, but that's pre-existing and out of scope here: the watcher callback throws in `notifyNotebookChange` before it ever reaches `commitFile`, so the final block was never committed at shutdown anyway. A proper fix would be an explicit commit in `writeSessionSummary()`.
