### PR TITLE
Make /cost render locally instead of billing the model

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -1,4 +1,6 @@
 import { ChatPanel } from "./chat/chat-panel.js";
+import { renderMarkdown } from "./chat/markdown.js";
+import { runCostCommand, type Usage } from "./cost-table.js";
 import { detectCompactIntent } from "./chat/compact-intent.js";
 import { humanizeAgentError } from "./chat/error-humanizer.js";
 import { detectStopIntent } from "./chat/stop-intent.js";
@@ -157,13 +159,6 @@ let CONTEXT_WINDOWS: Record<string, Record<string, number>> = {
     "gemini-2.5-flash": 1_048_576,
   },
 };
-
-interface Usage {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-}
 
 const sessionUsage: Usage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
 const turnUsage: Usage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
@@ -1557,7 +1552,10 @@ const SLASH_COMMANDS: SlashCommand[] = [
     usage: "/summarize [N [M]]",
     description: "summarize prompts N–M into the notebook",
   },
-  { name: "cost", description: "append session token/cost breakdown to the notebook" },
+  {
+    name: "cost",
+    description: "show session token/cost breakdown (with opt-in append to notebook)",
+  },
   { name: "decisions", description: "show decision log" },
   { name: "connect", description: "open Galaxy connection settings" },
   { name: "help", description: "show this help" },
@@ -1747,73 +1745,48 @@ function handleSummarize(raw: string, argStr: string): void {
 }
 
 /**
- * /cost — snapshot session token usage per model, price it against the renderer's
- * pricing table, and ask the agent to append the breakdown to notebook.md.
- * The renderer is the authoritative source for usage numbers; the agent just
- * writes them out.
+ * /cost — render the session token/cost breakdown directly in chat from the
+ * renderer's own per-model usage counters, with zero model calls (issue #263).
+ *
+ * The breakdown is a snapshot of the counters at the moment /cost runs. Because
+ * the default path makes no model call, running /cost adds nothing to the
+ * session total — so this snapshot stays consistent with the footer. An opt-in
+ * "Append to notebook" button persists the same table via the agent (the only
+ * path that costs a model call).
  */
 function handleCost(raw: string): void {
-  if (perModelUsage.size === 0) {
-    chat.addUserMessage(raw);
-    chat.addErrorMessage("No billable assistant turns recorded yet in this renderer session.");
-    return;
-  }
-
-  const rows: string[] = [];
-  let totalCostKnown = true;
-  let grandCost = 0;
-  const totals: Usage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
-
-  for (const [model, u] of perModelUsage) {
-    totals.input += u.input;
-    totals.output += u.output;
-    totals.cacheRead += u.cacheRead;
-    totals.cacheWrite += u.cacheWrite;
-    const cost = computeCost(u, model);
-    const costStr = cost === null ? "unknown (no pricing entry)" : `$${cost.toFixed(4)}`;
-    if (cost === null) totalCostKnown = false;
-    else grandCost += cost;
-    rows.push(
-      `| \`${model}\` | ${u.input.toLocaleString()} | ${u.output.toLocaleString()} | ` +
-        `${u.cacheRead.toLocaleString()} | ${u.cacheWrite.toLocaleString()} | ${costStr} |`,
-    );
-  }
-
-  const totalCostStr = totalCostKnown
-    ? `$${grandCost.toFixed(4)}`
-    : `≥$${grandCost.toFixed(4)} (some models unpriced)`;
-  rows.push(
-    `| **Total** | **${totals.input.toLocaleString()}** | **${totals.output.toLocaleString()}** | ` +
-      `**${totals.cacheRead.toLocaleString()}** | **${totals.cacheWrite.toLocaleString()}** | **${totalCostStr}** |`,
-  );
-
-  const table =
-    `| Model | Input tokens | Output tokens | Cache read | Cache write | Cost (USD) |\n` +
-    `|-------|-------------:|--------------:|-----------:|------------:|-----------:|\n` +
-    rows.join("\n");
-
-  const heading = "## Session cost";
-  const prompt =
-    `Append the following session cost breakdown verbatim to the notebook file ` +
-    `(notebook.md) in the current working directory. Use Edit or Write to append — ` +
-    `do NOT regenerate, reformat, or wrap the table. The numbers below are authoritative ` +
-    `(captured from the renderer's usage counters, same source as the masthead), so ` +
-    `use them as-is.\n\n` +
-    `Use exactly this heading (H2, verbatim) on its own line, followed by a blank line, ` +
-    `then the table:\n` +
-    `    ${heading}\n\n` +
-    `--- Cost table ---\n` +
-    table +
-    `\n--- end table ---`;
-
-  chat.addUserMessage(raw);
-  chat.addInfoMessage(
-    `<i>Asking the agent to append the session cost breakdown to ` +
-      `<code>notebook.md</code>…</i>`,
-  );
-  chat.showThinking();
-  setStatusBadge("thinking", "thinking...");
-  promptAgent(prompt);
+  runCostCommand(raw, perModelUsage, computeCost, {
+    addUserMessage: (text) => chat.addUserMessage(text),
+    addErrorMessage: (text) => chat.addErrorMessage(text),
+    renderBreakdown: (table, onAppend) => {
+      const el = chat.addInfoMessage(
+        `<div class="cost-breakdown">` +
+          `<h3>Session cost</h3>` +
+          renderMarkdown(table) +
+          `<button type="button" class="cost-append-btn" data-cost-append>Append to notebook</button>` +
+          `</div>`,
+      );
+      const btn = el.querySelector<HTMLButtonElement>("[data-cost-append]");
+      btn?.addEventListener(
+        "click",
+        () => {
+          btn.disabled = true;
+          btn.textContent = "Appending to notebook…";
+          onAppend();
+        },
+        { once: true },
+      );
+    },
+    beginNotebookAppend: () => {
+      chat.addInfoMessage(
+        `<i>Asking the agent to append the session cost breakdown to ` +
+          `<code>notebook.md</code>…</i>`,
+      );
+      chat.showThinking();
+      setStatusBadge("thinking", "thinking...");
+    },
+    promptAgent: (message) => promptAgent(message),
+  });
 }
 
 /**

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -437,12 +437,13 @@ export class ChatPanel {
   }
 
   /** Add a system/info message with neutral styling and HTML support. */
-  addInfoMessage(html: string): void {
+  addInfoMessage(html: string): HTMLElement {
     const el = document.createElement("div");
     el.className = "message assistant system-info";
     el.innerHTML = html;
     this.container.appendChild(el);
     this.scrollToBottom();
+    return el;
   }
 
   /** Export the current conversation as a Markdown string. */

--- a/app/src/renderer/cost-table.ts
+++ b/app/src/renderer/cost-table.ts
@@ -1,0 +1,163 @@
+/**
+ * `/cost` table construction (issue #263).
+ *
+ * `/cost` used to inject a prompt asking the agent to append the cost table to
+ * notebook.md, so it made 2-3 full-context model round-trips just to display a
+ * table the renderer had already computed from its own usage counters. These
+ * pure helpers move the table construction out of the agent's hands: the
+ * default `/cost` builds the markdown locally (zero model calls), and only the
+ * opt-in "append to notebook" action uses the model.
+ *
+ * Kept DOM-free so the table construction is unit-testable on its own.
+ */
+
+export interface Usage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+/** Resolve a model's cost from its usage, or null when the model is unpriced. */
+export type ComputeCost = (u: Usage, model: string) => number | null;
+
+export interface CostBreakdown {
+  /** Markdown table: one row per model plus a totals row. */
+  table: string;
+  /** Sum of the known per-model costs (excludes unpriced models). */
+  grandCost: number;
+  /** False when at least one model had no pricing entry. */
+  totalCostKnown: boolean;
+}
+
+/**
+ * Build the session cost breakdown purely from the renderer's per-model usage
+ * counters. `computeCost` is injected so this stays independent of the
+ * renderer's PRICING map (and trivially testable).
+ */
+export function buildCostBreakdown(
+  perModelUsage: Iterable<[string, Usage]>,
+  computeCost: ComputeCost,
+): CostBreakdown {
+  const rows: string[] = [];
+  let totalCostKnown = true;
+  let grandCost = 0;
+  const totals: Usage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+  for (const [model, u] of perModelUsage) {
+    totals.input += u.input;
+    totals.output += u.output;
+    totals.cacheRead += u.cacheRead;
+    totals.cacheWrite += u.cacheWrite;
+    const cost = computeCost(u, model);
+    const costStr = cost === null ? "unknown (no pricing entry)" : `$${cost.toFixed(4)}`;
+    if (cost === null) totalCostKnown = false;
+    else grandCost += cost;
+    rows.push(
+      `| \`${model}\` | ${u.input.toLocaleString()} | ${u.output.toLocaleString()} | ` +
+        `${u.cacheRead.toLocaleString()} | ${u.cacheWrite.toLocaleString()} | ${costStr} |`,
+    );
+  }
+
+  const totalCostStr = totalCostKnown
+    ? `$${grandCost.toFixed(4)}`
+    : `≥$${grandCost.toFixed(4)} (some models unpriced)`;
+  rows.push(
+    `| **Total** | **${totals.input.toLocaleString()}** | **${totals.output.toLocaleString()}** | ` +
+      `**${totals.cacheRead.toLocaleString()}** | **${totals.cacheWrite.toLocaleString()}** | **${totalCostStr}** |`,
+  );
+
+  const table =
+    `| Model | Input tokens | Output tokens | Cache read | Cache write | Cost (USD) |\n` +
+    `|-------|-------------:|--------------:|-----------:|------------:|-----------:|\n` +
+    rows.join("\n");
+
+  return { table, grandCost, totalCostKnown };
+}
+
+export type CostCommandAction = { kind: "empty" } | ({ kind: "table" } & CostBreakdown);
+
+/**
+ * Resolve the `/cost` command to a local-render action. Returns `empty` when no
+ * billable turns have been recorded, otherwise a `table` action carrying the
+ * breakdown. This never makes a model call — the only collaborator is the
+ * injected `computeCost`.
+ */
+export function resolveCostCommand(
+  perModelUsage: Map<string, Usage>,
+  computeCost: ComputeCost,
+): CostCommandAction {
+  if (perModelUsage.size === 0) return { kind: "empty" };
+  return { kind: "table", ...buildCostBreakdown(perModelUsage, computeCost) };
+}
+
+/** Heading the cost table is filed under in the notebook. */
+export const COST_HEADING = "## Session cost";
+
+/** Shown when `/cost` runs before any billable assistant turn. */
+export const NO_USAGE_MESSAGE =
+  "No billable assistant turns recorded yet in this renderer session.";
+
+/**
+ * The renderer surface `runCostCommand` drives. Kept abstract so the command
+ * orchestration is testable without a DOM — the test asserts the default path
+ * never reaches `promptAgent`, which is the regression #263 is about.
+ */
+export interface CostCommandView {
+  /** Echo the `/cost` command into the chat log. */
+  addUserMessage(text: string): void;
+  /** Report that there's nothing to show yet. */
+  addErrorMessage(text: string): void;
+  /** Render the breakdown locally and wire `onAppend` to the opt-in button. */
+  renderBreakdown(table: string, onAppend: () => void): void;
+  /** Surface the "asking the agent…" notice + thinking state for the append. */
+  beginNotebookAppend(): void;
+  /** Send a prompt to the agent — the only model-call path in `/cost`. */
+  promptAgent(message: string): void;
+}
+
+/**
+ * Orchestrate `/cost`: echo the command, then either report "no usage" or
+ * render the breakdown locally. The only `promptAgent` call is behind the
+ * opt-in append action, so the default path provably makes no model call.
+ */
+export function runCostCommand(
+  raw: string,
+  perModelUsage: Map<string, Usage>,
+  computeCost: ComputeCost,
+  view: CostCommandView,
+): void {
+  view.addUserMessage(raw);
+
+  const action = resolveCostCommand(perModelUsage, computeCost);
+  if (action.kind === "empty") {
+    view.addErrorMessage(NO_USAGE_MESSAGE);
+    return;
+  }
+
+  view.renderBreakdown(action.table, () => {
+    view.beginNotebookAppend();
+    view.promptAgent(buildCostAppendPrompt(action.table));
+  });
+}
+
+/**
+ * Prompt for the opt-in "append to notebook" action: hand the agent the table
+ * that was already rendered in chat and ask it to append verbatim. This is the
+ * only `/cost` path that costs a model call, and the user opts into it.
+ */
+export function buildCostAppendPrompt(table: string): string {
+  return (
+    `Append the following session cost breakdown verbatim to the notebook file ` +
+    `(notebook.md) in the current working directory. Use Edit or Write to append — ` +
+    `do NOT regenerate, reformat, or wrap the table. The numbers below are authoritative ` +
+    `(captured from the renderer's usage counters, same source as the masthead), so ` +
+    `use them as-is.\n\n` +
+    `Use exactly this heading (H2, verbatim) on its own line, followed by a blank line, ` +
+    `then the table:\n` +
+    `    ${COST_HEADING}\n\n` +
+    `--- Cost table ---\n` +
+    table +
+    `\n--- end table ---`
+  );
+}

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -467,8 +467,10 @@ body.files-collapsed #files-divider {
   border: 1px solid var(--border-strong);
   border-radius: var(--radius);
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.4);
-  transition: background 0.1s, color 0.1s;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  transition:
+    background 0.1s,
+    color 0.1s;
   white-space: nowrap;
 }
 .chat-copy-btn:hover {
@@ -1249,6 +1251,72 @@ body.platform-darwin #files-title {
   line-height: 1.5;
   color: var(--text);
   font-style: italic;
+}
+
+/* /cost breakdown rendered locally in chat (issue #263). The shared markdown
+   table rules are scoped to :not(.system-info), so re-style the table here. */
+.message.system-info .cost-breakdown table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 6px 0 10px;
+  font-family: var(--font);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  display: block;
+  overflow-x: auto;
+}
+
+.message.system-info .cost-breakdown table th,
+.message.system-info .cost-breakdown table td {
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.message.system-info .cost-breakdown table th {
+  background: var(--bg-deep);
+  color: var(--text-dim);
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  white-space: nowrap;
+}
+
+.message.system-info .cost-breakdown table tbody tr:nth-child(even) td {
+  background: var(--bg-stripe);
+}
+
+.message.system-info .cost-breakdown table code {
+  font-family: var(--font);
+  font-size: 11.5px;
+  padding: 0 3px;
+  background: var(--bg-deep);
+  border-radius: 3px;
+  color: var(--accent);
+}
+
+.cost-append-btn {
+  margin-top: 4px;
+  padding: 5px 12px;
+  font-family: var(--font);
+  font-size: 12px;
+  color: var(--text);
+  background: var(--bg-deep);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.cost-append-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  border-color: var(--accent);
+}
+
+.cost-append-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
 }
 
 /* ── Thinking Indicator ────────────────────────────────────────────────────── */

--- a/tests/cost-table.test.ts
+++ b/tests/cost-table.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildCostBreakdown,
+  resolveCostCommand,
+  buildCostAppendPrompt,
+  runCostCommand,
+  type CostCommandView,
+  type Usage,
+} from "../app/src/renderer/cost-table.js";
+
+// A tiny pricing table + computeCost stand-in. The point of the unit is that it
+// builds the table purely from counters via an injected cost function, so the
+// test never touches the renderer's real PRICING map.
+const PRICE: Record<string, { in: number; out: number; cacheRead: number; cacheWrite: number }> = {
+  "claude-haiku-4-5": { in: 1, out: 5, cacheRead: 0.1, cacheWrite: 1.25 },
+};
+
+function computeCost(u: Usage, model: string): number | null {
+  const p = PRICE[model];
+  if (!p) return null;
+  return (
+    (u.input * p.in) / 1_000_000 +
+    (u.output * p.out) / 1_000_000 +
+    (u.cacheRead * p.cacheRead) / 1_000_000 +
+    (u.cacheWrite * p.cacheWrite) / 1_000_000
+  );
+}
+
+describe("buildCostBreakdown", () => {
+  it("builds the markdown table directly from the per-model usage counters", () => {
+    const usage = new Map<string, Usage>([
+      ["claude-haiku-4-5", { input: 1000, output: 500, cacheRead: 2000, cacheWrite: 100 }],
+    ]);
+
+    const { table, grandCost, totalCostKnown } = buildCostBreakdown(usage, computeCost);
+
+    expect(table).toContain("`claude-haiku-4-5`");
+    expect(table).toContain("1,000"); // input, toLocaleString
+    expect(table).toContain("500"); // output
+    expect(table).toContain("2,000"); // cache read
+    expect(table).toContain("**Total**");
+    expect(totalCostKnown).toBe(true);
+    // 1000*1 + 500*5 + 2000*0.1 + 100*1.25 = 1000 + 2500 + 200 + 125 = 3825 / 1e6
+    expect(grandCost).toBeCloseTo(0.003825, 6);
+    expect(table).toContain("$0.0038");
+  });
+
+  it("flags models with no pricing entry as unknown and the total as a lower bound", () => {
+    const usage = new Map<string, Usage>([
+      ["mystery-model", { input: 10, output: 10, cacheRead: 0, cacheWrite: 0 }],
+    ]);
+
+    const { table, totalCostKnown } = buildCostBreakdown(usage, computeCost);
+
+    expect(totalCostKnown).toBe(false);
+    expect(table).toContain("unknown (no pricing entry)");
+    expect(table).toContain("some models unpriced");
+  });
+
+  it("sums tokens across every model into the total row", () => {
+    const usage = new Map<string, Usage>([
+      ["claude-haiku-4-5", { input: 100, output: 10, cacheRead: 5, cacheWrite: 1 }],
+      ["mystery-model", { input: 200, output: 20, cacheRead: 5, cacheWrite: 1 }],
+    ]);
+
+    const { table } = buildCostBreakdown(usage, computeCost);
+
+    // 100 + 200 = 300 input, 10 + 20 = 30 output across both models.
+    expect(table).toMatch(/\*\*Total\*\*[^\n]*\*\*300\*\*[^\n]*\*\*30\*\*/);
+  });
+});
+
+describe("resolveCostCommand", () => {
+  it("returns an empty action when no billable turns have been recorded", () => {
+    const action = resolveCostCommand(new Map(), computeCost);
+    expect(action.kind).toBe("empty");
+  });
+
+  // The default /cost path must be a pure local render: resolveCostCommand's only
+  // collaborator is the injected cost function — it has no access to any agent /
+  // prompt mechanism, so by construction it cannot issue a model call.
+  it("returns a local-render table action built from counters, with no model call", () => {
+    const usage = new Map<string, Usage>([
+      ["claude-haiku-4-5", { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0 }],
+    ]);
+
+    const action = resolveCostCommand(usage, computeCost);
+
+    expect(action.kind).toBe("table");
+    if (action.kind === "table") {
+      expect(action.table).toContain("`claude-haiku-4-5`");
+      expect(action.table).toContain("1,000");
+    }
+  });
+});
+
+describe("buildCostAppendPrompt", () => {
+  it("embeds the already-rendered table verbatim under the Session cost heading", () => {
+    const table = "| Model | Cost |\n|---|---|\n| `x` | $0 |";
+    const prompt = buildCostAppendPrompt(table);
+
+    expect(prompt).toContain(table);
+    expect(prompt).toContain("## Session cost");
+    expect(prompt).toMatch(/append/i);
+  });
+});
+
+describe("runCostCommand", () => {
+  function makeView() {
+    const calls = {
+      addUserMessage: [] as string[],
+      addErrorMessage: [] as string[],
+      renderBreakdown: [] as string[],
+      beginNotebookAppend: 0,
+      promptAgent: [] as string[],
+    };
+    let captured: (() => void) | null = null;
+    const view: CostCommandView = {
+      addUserMessage: (t) => void calls.addUserMessage.push(t),
+      addErrorMessage: (t) => void calls.addErrorMessage.push(t),
+      renderBreakdown: (table, onAppend) => {
+        calls.renderBreakdown.push(table);
+        captured = onAppend;
+      },
+      beginNotebookAppend: () => void (calls.beginNotebookAppend += 1),
+      promptAgent: (m) => void calls.promptAgent.push(m),
+    };
+    return { view, calls, clickAppend: () => captured?.() };
+  }
+
+  const usage = () =>
+    new Map<string, Usage>([
+      ["claude-haiku-4-5", { input: 1000, output: 500, cacheRead: 0, cacheWrite: 0 }],
+    ]);
+
+  it("renders the breakdown locally and makes NO model call on the default path", () => {
+    const { view, calls } = makeView();
+
+    runCostCommand("/cost", usage(), computeCost, view);
+
+    expect(calls.addUserMessage).toEqual(["/cost"]);
+    expect(calls.renderBreakdown).toHaveLength(1);
+    expect(calls.renderBreakdown[0]).toContain("`claude-haiku-4-5`");
+    // The whole point of #263: the default /cost path must not bill the model.
+    expect(calls.promptAgent).toEqual([]);
+    expect(calls.beginNotebookAppend).toBe(0);
+  });
+
+  it("calls the agent only when the opt-in append action fires", () => {
+    const { view, calls, clickAppend } = makeView();
+
+    runCostCommand("/cost", usage(), computeCost, view);
+    expect(calls.promptAgent).toEqual([]);
+
+    clickAppend();
+
+    expect(calls.beginNotebookAppend).toBe(1);
+    expect(calls.promptAgent).toHaveLength(1);
+    expect(calls.promptAgent[0]).toContain("## Session cost");
+    expect(calls.promptAgent[0]).toContain("`claude-haiku-4-5`");
+  });
+
+  it("shows an error and makes no model call when no usage is recorded", () => {
+    const { view, calls } = makeView();
+
+    runCostCommand("/cost", new Map(), computeCost, view);
+
+    expect(calls.addUserMessage).toEqual(["/cost"]);
+    expect(calls.addErrorMessage).toHaveLength(1);
+    expect(calls.renderBreakdown).toEqual([]);
+    expect(calls.promptAgent).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #263.

`/cost` wasn't a local readout -- it injected a prompt asking the agent to append
the cost table to `notebook.md` and let the model handle it as a normal turn. So
every `/cost` made 2-3 full-context round-trips just to display numbers the
renderer had already computed from its own per-model usage counters. On a large
session that worked out to roughly 10% of the total spend, all to show a table.
And because the table was snapshotted before its own append landed, it could
never include the cost of running `/cost`, which is part of why the footer total
and the `/cost` table disagreed.

This makes the default `/cost` build the breakdown straight from the per-model
counters and render it into chat with **zero model calls**. There's an opt-in,
clearly-labeled "Append to notebook" button for anyone who still wants it
persisted -- that's now the only path that costs a model call, and you click for
it. Since the default path no longer appends anything, the snapshot it shows
can't drift from the footer the way the old before-its-own-append snapshot did.

The table construction and command orchestration moved into a DOM-free
`cost-table.ts` behind a small view seam, so the "default path makes no model
call" behavior is actually unit-tested rather than just implied: one test asserts
the default render never reaches `promptAgent`, another that only the append
action does.

Out of scope: the cost *accuracy* bug (#273, cache pricing) -- this PR doesn't
touch the pricing math, only what `/cost` does with it.

### Testing
- root + app typecheck clean
- `npm test` -- 734 passing (9 new in `tests/cost-table.test.ts`)
- lint clean (0 errors), prettier clean on changed files
- Not yet eyeballed live in a running Orbit -- the table/button styling is
  unconfirmed visually, though the logic and tests are solid.