### PR TITLE
Stamp the host date into context so notebooks stop hallucinating one

### DIFF
--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -159,6 +159,42 @@ opaque, non-secret code that rides along on feedback submissions.
 `;
 }
 
+/**
+ * Stamp the host's current date into the system prompt so the agent never has
+ * to guess "today" when it records a date in the durable notebook (issue #268:
+ * a model wrote `Analysis date: 2025-07-14` into notebook.md for a run that
+ * happened 2026-06-09). The date comes from the host clock, not the LLM.
+ *
+ * `now` is injectable so the value is deterministic under test. We read LOCAL
+ * calendar components rather than UTC: the "run date" a human expects is the
+ * host's wall-clock day, and an evening run in a behind-UTC timezone would
+ * otherwise stamp tomorrow. Recomputed fresh on each agent start -- the
+ * before_agent_start hook runs per turn (see the cache note in
+ * setupContextInjection), so a session that crosses midnight picks up the new
+ * date on the next turn rather than going stale.
+ */
+export function buildCurrentDateBlock(now: Date = new Date()): string {
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  const date = `${y}-${m}-${d}`;
+  return `## Current date
+
+Today's date, from the host system clock, is **${date}**.
+
+When you stamp *today's* date -- an "Analysis date" or "Run date" header, a
+progress note you're writing now, a Galaxy page timestamp -- use this exact
+value. **Never guess, infer, or fabricate today's date**: your training data
+doesn't tell you what today is, so a date written from memory will be wrong and
+quietly corrupt the auditable record (issue #268).
+
+This applies only to dates that mean "now." Leave every other date as-is --
+dataset creation dates, publication dates, dates already written in the
+notebook, and dates the user gives you are recorded verbatim, never
+overwritten with today's.
+`;
+}
+
 function buildExecutionModeBlock(): string {
   const cfg = loadConfig();
   if (cfg.executionMode !== "local") return "";
@@ -1043,6 +1079,7 @@ export function setupContextInjection(pi: ExtensionAPI): void {
     const systemPrompt = [
       buildActiveModelBlock(),
       buildTesterIdBlock(),
+      buildCurrentDateBlock(),
       buildOperatingDisciplineBlock(),
       buildVerificationDisciplineBlock(),
       buildPlanConventionBlock({ omitAnchors }),

--- a/tests/current-date-context.test.ts
+++ b/tests/current-date-context.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+// context.ts reads config in several blocks; stub it so the assembled-prompt
+// test is deterministic regardless of the dev machine's ~/.loom/config.json.
+const { loadConfigMock } = vi.hoisted(() => ({ loadConfigMock: vi.fn() }));
+vi.mock("../extensions/loom/config", () => ({ loadConfig: loadConfigMock }));
+
+import { buildCurrentDateBlock, setupContextInjection } from "../extensions/loom/context";
+
+describe("buildCurrentDateBlock", () => {
+  it("stamps the host date from the injected clock, not a model-supplied string", () => {
+    // Constructed from LOCAL components at noon so the calendar date is the same
+    // in every runner timezone (no midnight/DST edge) -- the block must report
+    // 2026-06-09 deterministically.
+    const fixedClock = new Date(2026, 5, 9, 12, 0, 0);
+
+    const block = buildCurrentDateBlock(fixedClock);
+
+    expect(block).toContain("## Current date");
+    expect(block).toContain("2026-06-09");
+    // The bug (#268) was the model inventing a date -- the block must tell it not to.
+    expect(block.toLowerCase()).toContain("never");
+    // Name the field that regressed so the guidance is unambiguous.
+    expect(block).toContain("Analysis date");
+  });
+
+  it("tracks the injected clock rather than a hard-coded constant", () => {
+    const a = buildCurrentDateBlock(new Date(2026, 0, 1, 12, 0, 0));
+    const b = buildCurrentDateBlock(new Date(2030, 11, 31, 12, 0, 0));
+
+    expect(a).toContain("2026-01-01");
+    expect(b).toContain("2030-12-31");
+    expect(a).not.toEqual(b);
+  });
+
+  it("is wired into the assembled system prompt using the live host clock", async () => {
+    loadConfigMock.mockReturnValue({});
+    // Pin the host clock so the default new Date() path inside the assembled
+    // prompt must report this exact local date -- proves the date is
+    // host-derived, not a leftover constant or a model-supplied string.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2027, 2, 5, 12, 0, 0));
+    try {
+      const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>();
+      const pi = {
+        on: (event: string, handler: (event: unknown, ctx: unknown) => Promise<unknown>) => {
+          handlers.set(event, handler);
+        },
+      };
+
+      setupContextInjection(pi as any);
+      const result = (await handlers.get("before_agent_start")!({}, {})) as {
+        systemPrompt: string;
+      };
+
+      expect(result.systemPrompt).toContain("## Current date");
+      expect(result.systemPrompt).toContain("2027-03-05");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Closes #268.

The agent was writing a made-up `Analysis date` into `notebook.md` (`2025-07-14` for a run that actually happened `2026-06-09`) because nothing ever told it what today is, and a model has no reliable sense of the current date. The notebook is plain agent-curated markdown, so there's no template field we stamp at write time -- the date is whatever the model types.

Fix follows the existing context-block pattern (like the active-model and tester-id blocks): a new `buildCurrentDateBlock()` reads the host clock and injects today's date into the system prompt, telling the model to use that exact value for today's-date fields and never fabricate one. I scoped the guidance to dates that mean "now" so it doesn't tell the model to clobber dataset/publication/user-supplied dates -- those stay recorded verbatim.

A couple of deliberate choices:
- Local calendar date, not UTC, so an evening run in a behind-UTC timezone doesn't stamp tomorrow.
- It lives in the (per-turn) system prompt rather than the transient live-notebook context, since that message is wrapped in a "treat as untrusted data" boundary and an authoritative host-clock fact doesn't belong there. The block recomputes each turn, so a session crossing midnight picks up the new date.

One caveat worth naming: this gives the model the real date but still relies on it copying the value -- a strong nudge, not a hard post-write stamp. A fully deterministic stamp would mean intercepting notebook writes and rewriting date fields, which is fragile (which field? what format?) and felt out of scope. This is the "inject the real date into context" direction the issue itself suggested.

Tests: `tests/current-date-context.test.ts` injects a fixed clock and asserts the block uses it (plus a fake-timers check that the wired-up prompt uses the live host clock), so the date is provably host-derived, not model-generated. Full suite green, typecheck/prettier/eslint clean.