### PR TITLE
feat(loom): backgrounded Galaxy jobs by default + notify on completion

### DIFF
--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -308,17 +308,27 @@ mode setting:
 
 ### Executing a Galaxy step
 
+**Galaxy invocations run in the background by default — submit and hand
+control back to the user.** Do NOT block the turn polling a Galaxy job to
+completion; the user wants to keep working with you while it runs.
+
 After invoking via Galaxy MCP and getting an \`invocationId\` back:
 1. Call \`galaxy_invocation_record({ invocationId, notebookAnchor, label })\`.
    The \`notebookAnchor\` is a stable id like \`plan-1-step-3\` that
    matches an anchor you wrote in the markdown plan section.
-2. Periodically call \`galaxy_invocation_check_all\` to advance in-flight
-   invocations. The tool auto-transitions YAML status (all-jobs-ok →
-   completed, any-error → failed) and writes results back to the
-   notebook. After a successful transition, inspect the output datasets,
-   record verification evidence in the notebook, then edit the markdown
-   checkbox for the step from \`- [ ]\` to \`- [x]\`. On failure, record
-   the error evidence and use \`- [!]\`.
+2. **Return to the user now.** Tell them it's submitted and running in the
+   background (the Activity tab shows live progress), and stop. Leave the
+   step's checkbox \`- [ ]\`. A background poller advances the invocation's
+   YAML status automatically (all-jobs-ok → completed, any-error → failed)
+   and the user is notified when it reaches a terminal state — you do not
+   need to sit here calling \`galaxy_invocation_check_all\` in a loop. Only
+   wait in-turn if the user explicitly asked you to.
+3. **Verify later, on demand.** When the user asks (or after the completion
+   notification), call \`galaxy_invocation_check_all\`, inspect the output
+   datasets, record verification evidence in the notebook, then edit the
+   markdown checkbox from \`- [ ]\` to \`- [x]\`. On failure, record the error
+   evidence and use \`- [!]\`. Do not verify or check off a Galaxy step in the
+   submit turn — it isn't done yet.
 `;
 }
 
@@ -565,10 +575,12 @@ or telling the user the work is done.
 
 Match the verification check to the artifact or action being completed:
 
-- **Galaxy workflow or tool run** — poll the invocation/job to a terminal
-  state with \`galaxy_invocation_check_all\` or the relevant Galaxy MCP
+- **Galaxy workflow or tool run** — verification is on demand, once the run
+  has reached a terminal state (the background poller gets it there). Confirm
+  terminal state with \`galaxy_invocation_check_all\` or the relevant Galaxy MCP
   inspection call, then inspect resulting datasets/collections enough to
-  confirm they exist and look plausible for the request.
+  confirm they exist and look plausible for the request. Don't block a turn
+  waiting for an in-progress invocation just to verify it.
 - **Authored Galaxy workflow** (\`.ga\` or workflow JSON) —
   upload/import it to Galaxy, invoke it on a small
   appropriate test input, poll to completion, and inspect outputs.

--- a/extensions/loom/execution-commands.ts
+++ b/extensions/loom/execution-commands.ts
@@ -39,18 +39,21 @@ export function registerExecutionCommands(pi: ExtensionAPI): void {
         `recent plan section that has unchecked steps (\`- [ ]\`), and execute ` +
         `the next pending step. For each step:\n` +
         `1. Decide local vs Galaxy per the plan's routing tag (see [local|hybrid|remote] in the section header).\n` +
-        `2. For Galaxy steps: invoke via Galaxy MCP, then call galaxy_invocation_record(...).\n` +
-        `3. For local steps: run via bash; capture results into the notebook.\n` +
-        `4. Verify the result using the step's \`Verification:\` sub-bullet when present, ` +
-        `or infer the appropriate check from the artifact just produced. ` +
-        `For Galaxy work, poll to a terminal state and inspect output datasets; ` +
-        `for generated workflows, upload/import and invoke on a small test input; ` +
-        `for local artifacts, read/parse/lint/smoke-test them.\n` +
+        `2. **Galaxy steps run in the BACKGROUND — this is the default.** Invoke via Galaxy MCP, call ` +
+        `galaxy_invocation_record({ invocationId, notebookAnchor, label }), then **hand control back to the user**: ` +
+        `say it's submitted and running in the background (the Activity tab shows live progress), and STOP. ` +
+        `Do NOT sit in this turn polling the invocation to completion — a background poller advances its status ` +
+        `automatically and the user is notified when it finishes. Leave the step's checkbox \`- [ ]\`. ` +
+        `Only wait in-turn if the user explicitly asked you to.\n` +
+        `3. For local steps: run via bash; capture results into the notebook (long local jobs use the launch-record-return background pattern; quick ones run synchronously).\n` +
+        `4. **Verify before claiming done — but only for work that has actually finished.** A *local* result: verify now ` +
+        `(read/parse/lint/smoke-test; use the step's \`Verification:\` sub-bullet). A *Galaxy* run: verification happens ` +
+        `LATER, on demand — when the user asks (or after the completion notification), call galaxy_invocation_check_all, ` +
+        `inspect the output datasets, record evidence, then flip the checkbox. Do not verify a Galaxy step in the submit turn; it isn't done yet.\n` +
         `5. Write the verification evidence into the notebook before changing status.\n` +
         `6. Only after verification succeeds, edit the markdown checkbox to \`- [x]\` (or \`- [!]\` on failure). ` +
         `If verification is blocked or inconclusive, leave the step pending, record the blocker, say "created but not verified" for created artifacts, ask for the missing input or approval to change scope, and stop.\n` +
-        `7. Periodically call galaxy_invocation_check_all to advance in-flight Galaxy work.\n` +
-        `Do NOT narrate progress in chat — the Notebook tab shows it. ` +
+        `Do NOT narrate progress in chat — the Notebook/Activity tabs show it. ` +
         `Do NOT claim the artifact or step is done in chat unless verification evidence is recorded. ` +
         `Stop on failure; do not auto-advance past errors or unverified results.`,
     );

--- a/extensions/loom/galaxy-poller.ts
+++ b/extensions/loom/galaxy-poller.ts
@@ -41,6 +41,19 @@ const POLL_INTERVAL_MS = 15_000;
 let timer: ReturnType<typeof setInterval> | null = null;
 let inFlight = false;
 
+/** Surface a toast to the shell when a background invocation finishes. */
+type PollerNotify = (text: string, level: "info" | "warning" | "error") => void;
+let notify: PollerNotify | null = null;
+
+/** Subset of a checkInvocations result entry the poller needs for notifications. */
+interface PollResultEntry {
+  invocationId: string;
+  notebookAnchor?: string;
+  label?: string;
+  jobSummary?: { ok?: number; error?: number };
+  autoAction?: string;
+}
+
 async function hasInProgressInvocations(): Promise<boolean> {
   const nbPath = getNotebookPath();
   if (!nbPath) return false;
@@ -64,7 +77,28 @@ async function tick(): Promise<void> {
       // this tick; if creds come back the next tick picks up.
       return;
     }
-    await checkInvocations(undefined);
+    const result = await checkInvocations(undefined);
+    // Fire a completion toast for any invocation that JUST reached a terminal
+    // state this tick. The poller only checks blocks that were in_progress, so
+    // an autoAction of completed/failed is a fresh transition that won't recur
+    // (the block is terminal next tick and no longer checked) — notify once.
+    const results = (result.details as { results?: PollResultEntry[] } | undefined)?.results;
+    if (notify && Array.isArray(results)) {
+      for (const r of results) {
+        const label = r.label || r.notebookAnchor || r.invocationId;
+        if (r.autoAction === "completed") {
+          notify(
+            `✅ Galaxy: "${label}" finished (${r.jobSummary?.ok ?? 0} jobs ok) — ask me to verify the outputs.`,
+            "info",
+          );
+        } else if (r.autoAction === "failed") {
+          notify(
+            `❌ Galaxy: "${label}" failed (${r.jobSummary?.error ?? 0} job error(s)) — ask me to investigate.`,
+            "warning",
+          );
+        }
+      }
+    }
   } catch (err) {
     // Don't kill the timer on a single bad poll — Galaxy may be
     // briefly unreachable. Log and try again on the next tick.
@@ -74,7 +108,10 @@ async function tick(): Promise<void> {
   }
 }
 
-export function startGalaxyPoller(): void {
+export function startGalaxyPoller(notifyFn?: PollerNotify): void {
+  // Capture the shell notifier (from the session_start ctx) so a completed
+  // background invocation can toast the user. Refreshed each session_start.
+  notify = notifyFn ?? null;
   // Idempotent: a brain restart triggers a new session_start without
   // session_shutdown firing first in some failure modes. Stop any
   // pre-existing timer so we don't double-poll.

--- a/extensions/loom/session-lifecycle.ts
+++ b/extensions/loom/session-lifecycle.ts
@@ -33,8 +33,10 @@ export function registerSessionLifecycle(pi: ExtensionAPI): void {
     initSessionArtifacts(process.cwd());
 
     // Background poller for in-flight Galaxy invocations (#67 part 2).
-    // Idempotent — start() stops any prior timer first.
-    startGalaxyPoller();
+    // Idempotent — start() stops any prior timer first. Pass the shell
+    // notifier so a backgrounded invocation toasts the user on completion
+    // (async-by-default execution: submit, hand back, notify-on-finish).
+    startGalaxyPoller((text, level) => ctx.ui.notify(text, level));
 
     sessionStart = {
       id: ctx.sessionManager?.getSessionId?.() ?? `session-${Date.now()}`,

--- a/extensions/loom/tools.ts
+++ b/extensions/loom/tools.ts
@@ -810,6 +810,10 @@ export async function checkInvocations(
         text: JSON.stringify({ success: true, checked: results.length, results }, null, 2),
       },
     ],
-    details: { checked: results.length } as Record<string, unknown>,
+    // Expose the per-invocation results so the background poller can fire a
+    // completion notification for any invocation that just reached a terminal
+    // state (autoAction "completed"/"failed"). The agent-facing summary already
+    // travels in `content`; this is for the headless poller path.
+    details: { checked: results.length, results } as Record<string, unknown>,
   };
 }

--- a/tests/execution-commands.test.ts
+++ b/tests/execution-commands.test.ts
@@ -54,8 +54,13 @@ describe("registerExecutionCommands", () => {
     await commands.get("execute")!.handler(undefined, { ui: { notify: vi.fn() } });
 
     const prompt = sendUserMessage.mock.calls[0][0] as string;
-    expect(prompt).toContain("Verify the result using the step's `Verification:` sub-bullet");
-    expect(prompt).toContain("or infer the appropriate check from the artifact just produced");
+    // Async-dominant: Galaxy steps submit and hand control back — no in-turn polling.
+    expect(prompt).toContain("Galaxy steps run in the BACKGROUND");
+    expect(prompt).toContain("hand control back to the user");
+    expect(prompt).toContain("Do NOT sit in this turn polling the invocation to completion");
+    // Verify-before-complete still enforced (local now; Galaxy on demand, later).
+    expect(prompt).toContain("use the step's `Verification:` sub-bullet");
+    expect(prompt).toContain("verification happens");
     expect(prompt).toContain("Write the verification evidence into the notebook");
     expect(prompt).toContain("Only after verification succeeds");
     expect(prompt).toContain("created but not verified");


### PR DESCRIPTION
## Why

When the agent runs a Galaxy job it currently **blocks the turn polling to completion**, so you can't keep working with it while the job runs. This makes async submission the **dominant** behavior: submit, hand control back, and surface a notification when the job finishes.

Design (chosen with the user): **notify on completion, verify on demand** — no surprise agent turns.

## What

**Behavior flip** (`execution-commands.ts` `/execute` + `context.ts` Galaxy guidance):
- Galaxy step → `invoke` → `galaxy_invocation_record(...)` → **return to the user** ("submitted, running in background; the Activity tab shows progress"), leave the step `- [ ]`. **No in-turn poll-to-completion.** Only waits in-turn if the user explicitly asks.
- The existing 15 s background poller (`galaxy-poller.ts`) keeps status + Activity-tab progress fresh (unchanged).
- Verification (inspect outputs → flip the checkbox) **moves to on-demand**, after the run finishes — not in the submit turn. Local steps unchanged (verify immediately).

**Completion notification** (`galaxy-poller.ts` + `tools.ts` + `session-lifecycle.ts`):
- On a background tick, when `checkInvocations` transitions an invocation to a terminal state (`autoAction` completed/failed), fire a shell toast: *"✅ Galaxy: \<label\> finished (N jobs ok) — ask me to verify"* / *"❌ … failed — ask me to investigate."*
- Fires exactly once per transition (the poller only checks in-progress blocks). `checkInvocations` now exposes its per-invocation `results` in `details` for the headless poller path; `session_start`'s ctx supplies the notifier.

## Validation

- Root `tsc --noEmit` clean.
- `npm test` — **836 passed**. `tests/execution-commands.test.ts` updated to assert the new async-dominant guarantees (submit/hand-back, no in-turn polling) while keeping the verify-before-complete checks.

## Notes / follow-ups

- Brain-behavior change — warrants a manual smoke once in a build (submit a real Galaxy job; confirm the agent hands back and the toast fires on completion).
- The completion toast uses the `session_start` ctx notifier for the session lifetime; if preferred, switching to an always-latest captured ctx (like the UI bridge) is a trivial follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)