### PR TITLE
Reflect the live Galaxy connection in the footer status (#284)

### DIFF
--- a/app/src/main/galaxy-status.ts
+++ b/app/src/main/galaxy-status.ts
@@ -1,0 +1,35 @@
+import type { LoomConfig } from "./config.js";
+
+export interface GalaxyStatus {
+  /** True when the brain has a usable Galaxy connection (a URL *and* a key). */
+  connected: boolean;
+  /** The effective server URL, or null when none is resolvable. */
+  url: string | null;
+}
+
+/**
+ * Effective Galaxy connection state as the brain actually sees it. The brain
+ * treats Galaxy as connected when `GALAXY_URL` and `GALAXY_API_KEY` are both
+ * present in its env (extensions/loom/context.ts), and Orbit builds that env
+ * with the same precedence used here: the active config profile wins, else a
+ * value exported into Orbit's own environment (agent.ts `buildSecretEnv`).
+ *
+ * The footer status dot reads this instead of the masked config alone, so an
+ * env-driven / auto-connect session that never saved a profile still reads
+ * connected -- previously the dot stayed "not configured" even though the URL
+ * was known and tool calls worked (#284).
+ *
+ * `resolveKey` is injected (the caller passes the safeStorage-backed
+ * `resolveGalaxyApiKey`) so this stays a pure, Electron-free unit.
+ */
+export function resolveGalaxyStatus(
+  cfg: LoomConfig,
+  env: NodeJS.ProcessEnv,
+  resolveKey: (c: LoomConfig) => string | null,
+): GalaxyStatus {
+  const active = cfg.galaxy?.active;
+  const profileUrl = active ? cfg.galaxy?.profiles?.[active]?.url : undefined;
+  const url = profileUrl || env.GALAXY_URL || null;
+  const key = resolveKey(cfg) ?? env.GALAXY_API_KEY ?? null;
+  return { connected: Boolean(url && key), url };
+}

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -6,7 +6,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { execSync } from "node:child_process";
 import { loadConfig, saveConfig, type LoomConfig } from "./config.js";
-import { encryptSecret, isAvailable as safeStorageAvailable } from "./secure-config.js";
+import {
+  encryptSecret,
+  isAvailable as safeStorageAvailable,
+  resolveGalaxyApiKey,
+} from "./secure-config.js";
+import { resolveGalaxyStatus } from "./galaxy-status.js";
 import { getProviders, getModels } from "@earendil-works/pi-ai";
 import { isDeprecatedModelId } from "./model-catalog.js";
 import { checkLatestVersion } from "./version-check.js";
@@ -295,6 +300,13 @@ export function registerIpcHandlers(agent: AgentManager): void {
 
   ipcMain.handle("config:get", () => {
     return maskConfig(loadConfig());
+  });
+
+  // Effective Galaxy connection for the footer dot -- reflects the brain's own
+  // GALAXY_URL/GALAXY_API_KEY view (profile or exported env), not just the
+  // masked config, so env-driven sessions read connected (#284).
+  ipcMain.handle("galaxy:status", () => {
+    return resolveGalaxyStatus(loadConfig(), process.env, resolveGalaxyApiKey);
   });
 
   ipcMain.handle(

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -154,6 +154,7 @@ export interface OrbitAPI {
   getVersion(): Promise<{ version: string; isPackaged: boolean }>;
   openReleasePage(url?: string): Promise<{ opened: boolean }>;
   openGalaxyHistory(url: string): Promise<{ opened: boolean }>;
+  getGalaxyStatus(): Promise<{ connected: boolean; url: string | null }>;
   restartToUpdate(): Promise<{ restarting: boolean }>;
   onUpdateDownloaded(cb: (info: { version: string }) => void): void;
   onUpdateError(cb: (info: { message: string }) => void): void;
@@ -262,6 +263,7 @@ const api: OrbitAPI = {
   getVersion: () => ipcRenderer.invoke("version:current"),
   openReleasePage: (url) => ipcRenderer.invoke("version:open-release", url),
   openGalaxyHistory: (url) => ipcRenderer.invoke("galaxy:open-history", url),
+  getGalaxyStatus: () => ipcRenderer.invoke("galaxy:status"),
   restartToUpdate: () => ipcRenderer.invoke("update:restart"),
   onUpdateDownloaded: (cb) => {
     ipcRenderer.on("update:downloaded", (_e, info) => cb(info));

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -607,26 +607,31 @@ window.orbit.onFilesChanged(() => {
 const galaxyStatus = document.getElementById("galaxy-status")!;
 
 async function refreshGalaxyStatus(): Promise<void> {
-  const cfg = (await window.orbit.getConfig()) as Record<string, unknown>;
-  // getConfig returns the *masked* config — Galaxy profiles carry
-  // `hasApiKey: boolean`, never the plaintext apiKey. Checking
-  // `profile.apiKey` here used to make the dot stay red even when a key
-  // was set, because the field is undefined in the masked shape.
-  const galaxy = cfg.galaxy as
-    | { active?: string; profiles?: Record<string, { url?: string; hasApiKey?: boolean }> }
-    | undefined;
-  const active = galaxy?.active;
-  const profile = active ? galaxy?.profiles?.[active] : undefined;
-  const connected = !!(profile?.url && profile?.hasApiKey);
+  // Reflect the *effective* connection the brain sees -- a usable URL + API key
+  // whether they came from a saved profile or exported GALAXY_URL/GALAXY_API_KEY
+  // env vars. Deriving "connected" from the masked config alone missed the
+  // env-driven / auto-connect path, leaving the dot red even though the URL was
+  // known and tool calls worked (#284).
+  const { connected, url } = await window.orbit.getGalaxyStatus();
 
   if (connected) {
     galaxyStatus.classList.add("status-dot-connected");
     galaxyStatus.classList.remove("status-dot-disconnected");
-    galaxyStatus.title = `Galaxy: ${profile.url}`;
+    galaxyStatus.title = `Galaxy: ${url}`;
+    // Keep the accessible name in sync -- the issue's "not configured" string
+    // is the aria-label, which previously never tracked connection state.
+    galaxyStatus.setAttribute(
+      "aria-label",
+      `Galaxy connection: ${url}. Click to open Preferences.`,
+    );
   } else {
     galaxyStatus.classList.add("status-dot-disconnected");
     galaxyStatus.classList.remove("status-dot-connected");
     galaxyStatus.title = "Galaxy: not configured (open Preferences to add a profile)";
+    galaxyStatus.setAttribute(
+      "aria-label",
+      "Galaxy connection: not configured. Click to open Preferences.",
+    );
   }
 
   // The Galaxy history section is driven off the same connection signal so it

--- a/tests/galaxy-status.test.ts
+++ b/tests/galaxy-status.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { resolveGalaxyStatus } from "../app/src/main/galaxy-status.js";
+import type { LoomConfig } from "../shared/loom-config.js";
+
+const noConfigKey = () => null;
+
+function profileConfig(url: string): LoomConfig {
+  return {
+    galaxy: { active: "main", profiles: { main: { url } } },
+  } as unknown as LoomConfig;
+}
+
+describe("resolveGalaxyStatus", () => {
+  it("reports connected from exported env vars when no profile is saved (#284)", () => {
+    // The env-driven / auto-connect path: tool calls work but the footer used
+    // to read the (empty) config profile and show "not configured".
+    const status = resolveGalaxyStatus(
+      {} as LoomConfig,
+      { GALAXY_URL: "https://usegalaxy.org", GALAXY_API_KEY: "k" } as NodeJS.ProcessEnv,
+      noConfigKey,
+    );
+    expect(status).toEqual({ connected: true, url: "https://usegalaxy.org" });
+  });
+
+  it("reports connected from a saved profile with no env vars", () => {
+    const status = resolveGalaxyStatus(
+      profileConfig("https://main.example"),
+      {} as NodeJS.ProcessEnv,
+      () => "decrypted-key",
+    );
+    expect(status).toEqual({ connected: true, url: "https://main.example" });
+  });
+
+  it("is disconnected when a profile URL exists but no key resolves anywhere", () => {
+    const status = resolveGalaxyStatus(
+      profileConfig("https://main.example"),
+      {} as NodeJS.ProcessEnv,
+      noConfigKey,
+    );
+    expect(status).toEqual({ connected: false, url: "https://main.example" });
+  });
+
+  it("is disconnected with no profile and no env", () => {
+    const status = resolveGalaxyStatus({} as LoomConfig, {} as NodeJS.ProcessEnv, noConfigKey);
+    expect(status).toEqual({ connected: false, url: null });
+  });
+
+  it("prefers the active profile URL over an exported GALAXY_URL", () => {
+    const status = resolveGalaxyStatus(
+      profileConfig("https://profile.example"),
+      { GALAXY_URL: "https://env.example", GALAXY_API_KEY: "k" } as NodeJS.ProcessEnv,
+      () => "ck",
+    );
+    expect(status.url).toBe("https://profile.example");
+  });
+
+  it("falls back to the exported GALAXY_API_KEY when config has no resolvable key", () => {
+    const status = resolveGalaxyStatus(
+      profileConfig("https://main.example"),
+      { GALAXY_API_KEY: "env-key" } as NodeJS.ProcessEnv,
+      noConfigKey,
+    );
+    expect(status.connected).toBe(true);
+  });
+});


### PR DESCRIPTION
The footer Galaxy dot decided "connected" purely from the saved config profile (`url` + `hasApiKey`), so a session that connected via exported `GALAXY_URL`/`GALAXY_API_KEY` -- no saved profile -- showed "not configured" even though the URL was right there and Galaxy tool calls worked. That's the env-driven / auto-connect path: `buildSecretEnv` already falls back to the exported key when it builds the brain env, but only the masked config ever reached the renderer, so the footer never saw it.

This adds a small `galaxy:status` IPC backed by a pure `resolveGalaxyStatus` that computes the connection the brain actually sees -- active profile wins, else the exported `GALAXY_URL`/`GALAXY_API_KEY` -- and points `refreshGalaxyStatus` at it instead of the masked config. The button's `aria-label` (the literal "not configured" string in the report) now tracks state too; before, only the title did.

Saved-profile sessions are unaffected -- the masked config already reported `hasApiKey` for both plaintext and encrypted keys, so those were already green.

Tests: new `tests/galaxy-status.test.ts` (6 cases) for the env-driven, saved-profile, precedence, and disconnected paths. Full suite green (842), root + app typecheck clean.

Not yet eyeballed in a running Orbit. Follow-up #290 covers two sibling surfaces -- the Galaxy history panel and `galaxy:open-history` -- that share the same masked-config-only assumption.

Fixes #284.
