### PR TITLE
Render relative local images in the File pane markdown preview

### DIFF
--- a/app/src/renderer/files/file-viewer.ts
+++ b/app/src/renderer/files/file-viewer.ts
@@ -6,8 +6,10 @@
  * file being text and dirty.
  */
 
+import type { Marked } from "marked";
 import { renderMarkdown } from "../chat/markdown.js";
 import { extOf, imagePreviewBlob } from "./image-preview.js";
+import { buildPreviewMarked, previewImageBaseDir } from "./markdown-preview.js";
 
 type FileKind = "text" | "image" | "pdf" | "binary";
 
@@ -98,6 +100,9 @@ export class FileViewer {
   private dirty = false;
   private editor: HTMLTextAreaElement | null = null;
   private preview: HTMLDivElement | null = null;
+  // Per-file Marked instance that rewrites relative image srcs against the
+  // markdown file's directory (#283). Undefined → renderMarkdown's default.
+  private previewMarked: Marked | undefined;
   private saveBtn: HTMLButtonElement | null = null;
   private statusEl: HTMLElement | null = null;
   private editBtn: HTMLButtonElement | null = null;
@@ -142,6 +147,7 @@ export class FileViewer {
     this.dirty = false;
     this.editor = null;
     this.preview = null;
+    this.previewMarked = undefined;
     this.saveBtn = null;
     this.statusEl = null;
     this.editBtn = null;
@@ -201,7 +207,7 @@ export class FileViewer {
         this.editor.setSelectionRange(Math.min(selStart, cap), Math.min(selEnd, cap));
         // Re-render markdown preview if it's the currently visible pane.
         if (this.preview && !this.preview.classList.contains("hidden")) {
-          this.preview.innerHTML = renderMarkdown(newText);
+          this.preview.innerHTML = renderMarkdown(newText, this.previewMarked);
         }
       }
     } else if (this.currentKind === "image") {
@@ -236,7 +242,7 @@ export class FileViewer {
         this.statusEl.className = "file-viewer-status saved";
       }
       if (this.preview && !this.preview.classList.contains("hidden")) {
-        this.preview.innerHTML = renderMarkdown(newText);
+        this.preview.innerHTML = renderMarkdown(newText, this.previewMarked);
       }
       banner.remove();
     });
@@ -279,6 +285,7 @@ export class FileViewer {
     this.dirty = false;
     this.editor = null;
     this.preview = null;
+    this.previewMarked = undefined;
     this.saveBtn = null;
     this.statusEl = null;
     this.editBtn = null;
@@ -306,6 +313,12 @@ export class FileViewer {
     const ext = extOf(relPath);
     const isMarkdown = ext === ".md";
     const text = new TextDecoder("utf-8").decode(bytes);
+
+    // Resolve relative image srcs in the preview against the markdown file's
+    // own directory, served over the cwd-jailed orbit-artifact:// scheme (#283).
+    if (isMarkdown) {
+      this.previewMarked = buildPreviewMarked(previewImageBaseDir(relPath));
+    }
 
     // Head-preview path: render read-only with a banner. Skip the
     // editor + Save toolbar + markdown preview toggle entirely — the
@@ -417,7 +430,7 @@ export class FileViewer {
     if (!this.editor || !this.preview) return;
     if (mode === "preview") {
       // Render preview from current (possibly dirty) editor contents.
-      const html = renderMarkdown(this.editor.value);
+      const html = renderMarkdown(this.editor.value, this.previewMarked);
       this.preview.innerHTML = html;
       this.editor.classList.add("hidden");
       this.preview.classList.remove("hidden");

--- a/app/src/renderer/files/markdown-preview.ts
+++ b/app/src/renderer/files/markdown-preview.ts
@@ -1,0 +1,95 @@
+/**
+ * Markdown-preview helpers for the File pane (#283).
+ *
+ * The File pane's Preview renders agent/report-authored markdown that often
+ * embeds local images via relative paths (`![plot](plot.svg)`). Rendered with
+ * the default `marked`, those `<img src="plot.svg">` resolve against the
+ * renderer document's base URL (the app's index.html), not the markdown file's
+ * directory, so valid reports show broken images.
+ *
+ * The notebook pane already solved the same class of problem by rewriting
+ * relative srcs to the cwd-jailed `orbit-artifact://` scheme served by the main
+ * process (see `artifacts/artifact-panel.ts` + the `protocol.handle` in
+ * `main/main.ts`). The File pane reuses that exact scheme — no new file-access
+ * surface — with one difference: a File-pane markdown file can live in a
+ * subdirectory of the cwd, so a relative ref must resolve against the file's
+ * directory, not the cwd root.
+ *
+ * These helpers are kept DOM-free (the `marked` import is pure JS) so they can
+ * be unit-tested in a plain Node/happy-dom environment, mirroring
+ * `image-preview.ts`.
+ */
+
+import { Marked } from "marked";
+
+/** Leading scheme (`https:`, `data:`, `orbit-artifact:`) or protocol-relative `//`. */
+const ABSOLUTE_OR_SCHEME = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+
+/**
+ * POSIX dirname of a cwd-relative path (paths from `files:list` always use
+ * forward slashes). `reports/summary.md` → `reports`; `summary.md` → ``.
+ */
+export function previewImageBaseDir(relPath: string): string {
+  const slash = relPath.lastIndexOf("/");
+  return slash < 0 ? "" : relPath.slice(0, slash);
+}
+
+/** Collapse `.`/`..` segments in a POSIX path, preserving any leading `..`. */
+function normalizePosix(p: string): string {
+  const out: string[] = [];
+  for (const seg of p.split("/")) {
+    if (seg === "" || seg === ".") continue;
+    if (seg === "..") {
+      if (out.length && out[out.length - 1] !== "..") out.pop();
+      else out.push("..");
+    } else {
+      out.push(seg);
+    }
+  }
+  return out.join("/");
+}
+
+/**
+ * Rewrite a relative image href to the cwd-jailed `orbit-artifact://` scheme,
+ * resolved against `baseDir` (the markdown file's directory, relative to cwd).
+ * Absolute URLs, other schemes, and protocol-relative URLs pass through
+ * untouched. A leading-slash href is treated as cwd-root relative (baseDir
+ * ignored), matching the notebook pane's convention.
+ *
+ * The `orbit-artifact` protocol handler re-resolves the path against the live
+ * cwd and refuses anything that escapes it via `..`/symlinks, so this is the
+ * single security boundary — we only produce a best-effort clean path here.
+ */
+export function rewritePreviewImageHref(baseDir: string, href: string): string {
+  if (ABSOLUTE_OR_SCHEME.test(href)) return href;
+  const rooted = href.startsWith("/");
+  const joined = rooted || !baseDir ? href.replace(/^\/+/, "") : `${baseDir}/${href}`;
+  const normalized = normalizePosix(joined);
+  return `orbit-artifact://cwd/${normalized}`;
+}
+
+function escapeAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * A `Marked` instance whose image renderer resolves relative srcs against
+ * `baseDir`. Only images are overridden — links keep marked's default
+ * rendering so click/navigation behavior is unchanged. Pass the result as the
+ * second arg to `renderMarkdown(...)` so the shared sanitizer still runs.
+ */
+export function buildPreviewMarked(baseDir: string): Marked {
+  return new Marked({
+    renderer: {
+      image({ href, title, text }) {
+        const rewritten = rewritePreviewImageHref(baseDir, href ?? "");
+        const titleAttr = title ? ` title="${escapeAttr(title)}"` : "";
+        return `<img src="${escapeAttr(rewritten)}" alt="${escapeAttr(text ?? "")}"${titleAttr}>`;
+      },
+    },
+  });
+}

--- a/app/src/renderer/files/markdown-preview.ts
+++ b/app/src/renderer/files/markdown-preview.ts
@@ -22,7 +22,11 @@
 
 import { Marked } from "marked";
 
-/** Leading scheme (`https:`, `data:`, `orbit-artifact:`) or protocol-relative `//`. */
+// Leading scheme (`https:`, `data:`, `orbit-artifact:`) or protocol-relative
+// `//`. Matches the notebook pane's guard (artifact-panel.ts) on purpose so both
+// panes treat the same hrefs as absolute. Known limitation kept for that
+// consistency: a relative filename that contains a colon (`a:b.png`, legal on
+// POSIX) reads as a scheme and stays unrewritten — author can prefix `./`.
 const ABSOLUTE_OR_SCHEME = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
 
 /**
@@ -57,15 +61,29 @@ function normalizePosix(p: string): string {
  * ignored), matching the notebook pane's convention.
  *
  * The `orbit-artifact` protocol handler re-resolves the path against the live
- * cwd and refuses anything that escapes it via `..`/symlinks, so this is the
- * single security boundary — we only produce a best-effort clean path here.
+ * cwd and refuses (via realpath) anything that escapes it through `..`/symlinks
+ * — that is the security boundary. Here we additionally:
+ *   - leave a ref that climbs above the cwd root unrewritten, so it renders as
+ *     an honest broken image instead of silently folding (via URL `..`
+ *     canonicalization) to a same-named file at the cwd root;
+ *   - percent-encode each path segment, so reserved URL characters (`#`, `?`,
+ *     `%`, space) and pre-encoded traversal (`%2e%2e`) round-trip as literal
+ *     filenames through the handler's `decodeURIComponent` rather than break or
+ *     re-fold into `..`.
  */
 export function rewritePreviewImageHref(baseDir: string, href: string): string {
   if (ABSOLUTE_OR_SCHEME.test(href)) return href;
-  const rooted = href.startsWith("/");
-  const joined = rooted || !baseDir ? href.replace(/^\/+/, "") : `${baseDir}/${href}`;
+  // Windows-authored reports may use backslash separators; the cwd jail and the
+  // orbit-artifact handler speak forward slashes.
+  const ref = href.replace(/\\/g, "/");
+  const rooted = ref.startsWith("/");
+  const joined = rooted || !baseDir ? ref.replace(/^\/+/, "") : `${baseDir}/${ref}`;
   const normalized = normalizePosix(joined);
-  return `orbit-artifact://cwd/${normalized}`;
+  if (normalized === "" || normalized === ".." || normalized.startsWith("../")) {
+    return href;
+  }
+  const encoded = normalized.split("/").map(encodeURIComponent).join("/");
+  return `orbit-artifact://cwd/${encoded}`;
 }
 
 function escapeAttr(s: string): string {

--- a/app/src/renderer/files/markdown-preview.ts
+++ b/app/src/renderer/files/markdown-preview.ts
@@ -63,24 +63,35 @@ function normalizePosix(p: string): string {
  * The `orbit-artifact` protocol handler re-resolves the path against the live
  * cwd and refuses (via realpath) anything that escapes it through `..`/symlinks
  * — that is the security boundary. Here we additionally:
- *   - leave a ref that climbs above the cwd root unrewritten, so it renders as
- *     an honest broken image instead of silently folding (via URL `..`
- *     canonicalization) to a same-named file at the cwd root;
+ *   - fail closed on a ref that climbs above the cwd root: return an empty src
+ *     (the caller then emits no `src`) instead of echoing the raw href, which
+ *     the renderer would otherwise resolve against its own base URL rather than
+ *     the cwd jail;
  *   - percent-encode each path segment, so reserved URL characters (`#`, `?`,
  *     `%`, space) and pre-encoded traversal (`%2e%2e`) round-trip as literal
  *     filenames through the handler's `decodeURIComponent` rather than break or
  *     re-fold into `..`.
+ *
+ * Returns "" for any ref that can't be safely jailed; callers must treat an
+ * empty result as "no usable src" and emit no `src` attribute.
  */
 export function rewritePreviewImageHref(baseDir: string, href: string): string {
   if (ABSOLUTE_OR_SCHEME.test(href)) return href;
+  // A leading `\\` (UNC, e.g. \\server\share) is not a cwd-relative ref. After
+  // backslash normalization below it would masquerade as one and could resolve
+  // to a same-named file under cwd, so fail closed up front.
+  if (/^\\\\/.test(href)) return "";
   // Windows-authored reports may use backslash separators; the cwd jail and the
   // orbit-artifact handler speak forward slashes.
   const ref = href.replace(/\\/g, "/");
   const rooted = ref.startsWith("/");
   const joined = rooted || !baseDir ? ref.replace(/^\/+/, "") : `${baseDir}/${ref}`;
   const normalized = normalizePosix(joined);
+  // Climbs above the cwd root can't be jailed -- fail closed rather than echo
+  // the raw href back into the renderer (where it would resolve against the
+  // app's base URL, not the cwd jail).
   if (normalized === "" || normalized === ".." || normalized.startsWith("../")) {
-    return href;
+    return "";
   }
   const encoded = normalized.split("/").map(encodeURIComponent).join("/");
   return `orbit-artifact://cwd/${encoded}`;
@@ -106,7 +117,10 @@ export function buildPreviewMarked(baseDir: string): Marked {
       image({ href, title, text }) {
         const rewritten = rewritePreviewImageHref(baseDir, href ?? "");
         const titleAttr = title ? ` title="${escapeAttr(title)}"` : "";
-        return `<img src="${escapeAttr(rewritten)}" alt="${escapeAttr(text ?? "")}"${titleAttr}>`;
+        // An empty rewrite means "couldn't be jailed" -- emit no src so the
+        // image fails closed (broken image) rather than carrying a raw href.
+        const srcAttr = rewritten ? ` src="${escapeAttr(rewritten)}"` : "";
+        return `<img${srcAttr} alt="${escapeAttr(text ?? "")}"${titleAttr}>`;
       },
     },
   });

--- a/tests/markdown-preview.test.ts
+++ b/tests/markdown-preview.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from "vitest";
+import {
+  previewImageBaseDir,
+  rewritePreviewImageHref,
+  buildPreviewMarked,
+} from "../app/src/renderer/files/markdown-preview.js";
+import { renderMarkdown } from "../app/src/renderer/chat/markdown.js";
+
+/**
+ * Issue #283: the File pane's markdown Preview renders relative image
+ * references (`![plot](plot.svg)`) with the default `marked` instance, so the
+ * `<img src="plot.svg">` resolves against the renderer document's base URL
+ * (the app's index.html) instead of the markdown file's directory — broken
+ * image. The notebook pane already solved this by rewriting relative srcs to
+ * the cwd-jailed `orbit-artifact://` scheme; the File pane just never adopted
+ * it. The wrinkle the File pane adds: a markdown file can live in a
+ * subdirectory, so refs must resolve against the file's directory, not cwd.
+ */
+
+describe("previewImageBaseDir", () => {
+  it("returns the POSIX dirname of a file in a subdirectory", () => {
+    expect(previewImageBaseDir("reports/summary.md")).toBe("reports");
+  });
+
+  it("handles deeply nested files", () => {
+    expect(previewImageBaseDir("a/b/c/notes.md")).toBe("a/b/c");
+  });
+
+  it("returns empty string for a file at the cwd root", () => {
+    expect(previewImageBaseDir("summary.md")).toBe("");
+  });
+
+  it("returns empty string for an empty path", () => {
+    expect(previewImageBaseDir("")).toBe("");
+  });
+});
+
+describe("rewritePreviewImageHref", () => {
+  it("resolves a relative src against the file's subdirectory", () => {
+    expect(rewritePreviewImageHref("reports", "plot.svg")).toBe(
+      "orbit-artifact://cwd/reports/plot.svg",
+    );
+  });
+
+  it("resolves a relative src against the cwd root when baseDir is empty", () => {
+    expect(rewritePreviewImageHref("", "plot.svg")).toBe("orbit-artifact://cwd/plot.svg");
+  });
+
+  it("normalizes a leading ./", () => {
+    expect(rewritePreviewImageHref("reports", "./plot.svg")).toBe(
+      "orbit-artifact://cwd/reports/plot.svg",
+    );
+  });
+
+  it("resolves ../ against the parent directory", () => {
+    expect(rewritePreviewImageHref("reports/sub", "../plot.svg")).toBe(
+      "orbit-artifact://cwd/reports/plot.svg",
+    );
+  });
+
+  it("treats a leading-slash href as cwd-root relative (ignores baseDir)", () => {
+    expect(rewritePreviewImageHref("reports", "/shared/logo.png")).toBe(
+      "orbit-artifact://cwd/shared/logo.png",
+    );
+  });
+
+  it("leaves absolute http(s) URLs untouched", () => {
+    expect(rewritePreviewImageHref("reports", "https://example.com/x.png")).toBe(
+      "https://example.com/x.png",
+    );
+    expect(rewritePreviewImageHref("reports", "http://example.com/x.png")).toBe(
+      "http://example.com/x.png",
+    );
+  });
+
+  it("leaves data: URLs untouched", () => {
+    expect(rewritePreviewImageHref("reports", "data:image/png;base64,AAAA")).toBe(
+      "data:image/png;base64,AAAA",
+    );
+  });
+
+  it("leaves protocol-relative URLs untouched", () => {
+    expect(rewritePreviewImageHref("reports", "//cdn.example.com/x.png")).toBe(
+      "//cdn.example.com/x.png",
+    );
+  });
+
+  it("leaves an already-rewritten orbit-artifact URL untouched", () => {
+    expect(rewritePreviewImageHref("reports", "orbit-artifact://cwd/x.png")).toBe(
+      "orbit-artifact://cwd/x.png",
+    );
+  });
+});
+
+describe("buildPreviewMarked", () => {
+  it("rewrites a relative image src to the file's directory through renderMarkdown", () => {
+    const html = renderMarkdown("![plot](plot.svg)", buildPreviewMarked("reports"));
+    expect(html).toContain('src="orbit-artifact://cwd/reports/plot.svg"');
+    expect(html).toContain('alt="plot"');
+  });
+
+  it("preserves the image alt/title text", () => {
+    const html = renderMarkdown('![a plot](chart.png "Figure 1")', buildPreviewMarked(""));
+    expect(html).toContain('src="orbit-artifact://cwd/chart.png"');
+    expect(html).toContain('title="Figure 1"');
+  });
+
+  it("does not rewrite absolute image URLs", () => {
+    const html = renderMarkdown("![remote](https://example.com/x.png)", buildPreviewMarked("reports"));
+    expect(html).toContain('src="https://example.com/x.png"');
+    expect(html).not.toContain("orbit-artifact");
+  });
+
+  it("leaves relative links (non-images) to default rendering — only images are rewritten", () => {
+    const html = renderMarkdown("[see data](data.csv)", buildPreviewMarked("reports"));
+    expect(html).not.toContain("orbit-artifact");
+  });
+
+  it("the rewritten src survives DOMPurify sanitization", () => {
+    // orbit-artifact: is allow-listed in markdown.ts's ALLOWED_URI_REGEXP, so
+    // the rewritten src must not be stripped by the sanitizer.
+    const html = renderMarkdown("![plot](fig/plot.svg)", buildPreviewMarked("reports"));
+    expect(html).toContain("orbit-artifact://cwd/reports/fig/plot.svg");
+  });
+});
+
+describe("default marked (regression contrast)", () => {
+  it("does NOT rewrite relative image srcs — this is the #283 bug", () => {
+    const html = renderMarkdown("![plot](plot.svg)");
+    expect(html).toContain('src="plot.svg"');
+    expect(html).not.toContain("orbit-artifact");
+  });
+});

--- a/tests/markdown-preview.test.ts
+++ b/tests/markdown-preview.test.ts
@@ -91,6 +91,38 @@ describe("rewritePreviewImageHref", () => {
       "orbit-artifact://cwd/x.png",
     );
   });
+
+  it("leaves a ref that climbs above the cwd root unrewritten (honest broken image, no silent redirect)", () => {
+    // `../../secret.png` from reports/ would, if rewritten, fold via URL
+    // canonicalization to cwd/secret.png and silently serve the wrong file.
+    expect(rewritePreviewImageHref("reports", "../../secret.png")).toBe("../../secret.png");
+    expect(rewritePreviewImageHref("", "../secret.png")).toBe("../secret.png");
+  });
+
+  it("neutralizes percent-encoded traversal by encoding it as a literal segment", () => {
+    // `%2e%2e` must NOT be folded into `..` by URL parsing — encode it so the
+    // handler sees a literal (non-existent) directory name and 404s.
+    const out = rewritePreviewImageHref("reports", "%2e%2e/secret.png");
+    expect(out).toContain("%252e%252e");
+    expect(out).not.toContain("/../");
+  });
+
+  it("percent-encodes reserved URL characters in filenames so the handler round-trips them", () => {
+    expect(rewritePreviewImageHref("", "my plot.png")).toBe("orbit-artifact://cwd/my%20plot.png");
+    expect(rewritePreviewImageHref("", "a#b.png")).toBe("orbit-artifact://cwd/a%23b.png");
+    expect(rewritePreviewImageHref("", "a?b.png")).toBe("orbit-artifact://cwd/a%3Fb.png");
+    expect(rewritePreviewImageHref("", "a%b.png")).toBe("orbit-artifact://cwd/a%25b.png");
+  });
+
+  it("encodes non-ASCII filenames", () => {
+    expect(rewritePreviewImageHref("", "café.png")).toBe("orbit-artifact://cwd/caf%C3%A9.png");
+  });
+
+  it("treats backslash separators as path separators (Windows-authored reports)", () => {
+    expect(rewritePreviewImageHref("", "figs\\plot.png")).toBe(
+      "orbit-artifact://cwd/figs/plot.png",
+    );
+  });
 });
 
 describe("buildPreviewMarked", () => {
@@ -114,6 +146,11 @@ describe("buildPreviewMarked", () => {
 
   it("leaves relative links (non-images) to default rendering — only images are rewritten", () => {
     const html = renderMarkdown("[see data](data.csv)", buildPreviewMarked("reports"));
+    expect(html).not.toContain("orbit-artifact");
+  });
+
+  it("does not emit an orbit-artifact src for a ref that escapes the cwd root", () => {
+    const html = renderMarkdown("![x](../../secret.png)", buildPreviewMarked("reports"));
     expect(html).not.toContain("orbit-artifact");
   });
 

--- a/tests/markdown-preview.test.ts
+++ b/tests/markdown-preview.test.ts
@@ -92,11 +92,25 @@ describe("rewritePreviewImageHref", () => {
     );
   });
 
-  it("leaves a ref that climbs above the cwd root unrewritten (honest broken image, no silent redirect)", () => {
-    // `../../secret.png` from reports/ would, if rewritten, fold via URL
-    // canonicalization to cwd/secret.png and silently serve the wrong file.
-    expect(rewritePreviewImageHref("reports", "../../secret.png")).toBe("../../secret.png");
-    expect(rewritePreviewImageHref("", "../secret.png")).toBe("../secret.png");
+  it("fails closed (empty src) on a ref that climbs above the cwd root", () => {
+    // `../../secret.png` can't be jailed; returning it raw would let the renderer
+    // resolve it against the app base URL, so it must fail closed to "".
+    expect(rewritePreviewImageHref("reports", "../../secret.png")).toBe("");
+    expect(rewritePreviewImageHref("", "../secret.png")).toBe("");
+  });
+
+  it("fails closed on a rooted ref that climbs above the cwd root", () => {
+    expect(rewritePreviewImageHref("reports", "/../secret.png")).toBe("");
+    expect(rewritePreviewImageHref("", "/../../secret.png")).toBe("");
+  });
+
+  it("fails closed on backslash traversal (Windows-authored reports)", () => {
+    expect(rewritePreviewImageHref("reports", "..\\..\\secret.png")).toBe("");
+    expect(rewritePreviewImageHref("reports", "sub\\..\\..\\..\\secret.png")).toBe("");
+  });
+
+  it("fails closed on a UNC path", () => {
+    expect(rewritePreviewImageHref("reports", "\\\\server\\share\\plot.png")).toBe("");
   });
 
   it("neutralizes percent-encoded traversal by encoding it as a literal segment", () => {
@@ -139,7 +153,10 @@ describe("buildPreviewMarked", () => {
   });
 
   it("does not rewrite absolute image URLs", () => {
-    const html = renderMarkdown("![remote](https://example.com/x.png)", buildPreviewMarked("reports"));
+    const html = renderMarkdown(
+      "![remote](https://example.com/x.png)",
+      buildPreviewMarked("reports"),
+    );
     expect(html).toContain('src="https://example.com/x.png"');
     expect(html).not.toContain("orbit-artifact");
   });
@@ -149,9 +166,13 @@ describe("buildPreviewMarked", () => {
     expect(html).not.toContain("orbit-artifact");
   });
 
-  it("does not emit an orbit-artifact src for a ref that escapes the cwd root", () => {
+  it("emits no usable src for a ref that escapes the cwd root (fails closed)", () => {
     const html = renderMarkdown("![x](../../secret.png)", buildPreviewMarked("reports"));
     expect(html).not.toContain("orbit-artifact");
+    // The raw traversal href must NOT survive into the rendered HTML at all --
+    // no src attribute the renderer could resolve against its own base URL.
+    expect(html).not.toContain("secret.png");
+    expect(html).not.toMatch(/src=/);
   });
 
   it("the rewritten src survives DOMPurify sanitization", () => {


### PR DESCRIPTION
The File pane's markdown Preview didn't render relative image references that
sit next to the markdown file -- `![plot](plot.svg)` showed broken-image/alt
text even though the SVG opens fine on its own. Generated reports and notebooks
routinely embed local plots this way, so valid reports looked broken in Preview.

## Cause
The preview rendered through `renderMarkdown(text)` with the default `marked`
instance, so `![plot](plot.svg)` became `<img src="plot.svg">` and the browser
resolved `plot.svg` against the renderer document's base URL (the bundled
index.html), not the markdown file's directory. This is a different code path
from #188/#196, which fixed the SVG-opened-directly case.

## Fix
Reuse the mechanism the notebook pane already uses: rewrite relative image srcs
to the cwd-jailed `orbit-artifact://` scheme served by the main process, whose
handler realpath-jails to the cwd and refuses anything that escapes via
`..`/symlinks. The one wrinkle the File pane adds is that a markdown file can
live in a subdirectory, so refs resolve against the file's own directory rather
than the cwd root.

A small DOM-free helper (`markdown-preview.ts`) does the rewrite; `file-viewer.ts`
builds a per-file `marked` instance and feeds it to the three preview render
paths (toggle, on-disk reload, stale-file reload). Only images are rewritten --
links keep their default behavior. No new file-access surface: this is the same
cwd jail the notebook pane already ships with, and DOMPurify already allow-lists
the `orbit-artifact:` scheme.

## Edge cases handled
- A ref that climbs above the cwd root (`../../x.png`) is left unrewritten so it
  shows an honest broken image, instead of folding via URL canonicalization to a
  same-named file at the cwd root.
- Path segments are percent-encoded, so filenames with `#`, `?`, `%`, spaces, or
  non-ASCII round-trip through the handler, and a pre-encoded `%2e%2e` can't
  re-fold into `..`.
- Backslash separators from Windows-authored reports are normalized.

## Tests
25 unit tests in `tests/markdown-preview.test.ts` (happy-dom for the full
render + sanitize pipeline) covering subdirectory resolution, scheme/absolute
passthrough, the traversal/encoding/backslash cases, and a regression contrast
against the default `marked`. Full root suite (861) green, app typecheck clean.

Not yet eyeballed live in Orbit -- worth opening a report markdown with a
relative image next to it and switching to Preview before merge.

Addresses #283.