### PR TITLE
Follow-up to #281: guard the completion toast + fix the local-jobs guidance

### DIFF
--- a/extensions/loom/execution-commands.ts
+++ b/extensions/loom/execution-commands.ts
@@ -45,7 +45,7 @@ export function registerExecutionCommands(pi: ExtensionAPI): void {
         `Do NOT sit in this turn polling the invocation to completion — a background poller advances its status ` +
         `automatically and the user is notified when it finishes. Leave the step's checkbox \`- [ ]\`. ` +
         `Only wait in-turn if the user explicitly asked you to.\n` +
-        `3. For local steps: run via bash; capture results into the notebook (long local jobs use the launch-record-return background pattern; quick ones run synchronously).\n` +
+        `3. For local steps: run via bash synchronously; capture results into the notebook.\n` +
         `4. **Verify before claiming done — but only for work that has actually finished.** A *local* result: verify now ` +
         `(read/parse/lint/smoke-test; use the step's \`Verification:\` sub-bullet). A *Galaxy* run: verification happens ` +
         `LATER, on demand — when the user asks (or after the completion notification), call galaxy_invocation_check_all, ` +

--- a/extensions/loom/session-lifecycle.ts
+++ b/extensions/loom/session-lifecycle.ts
@@ -36,7 +36,17 @@ export function registerSessionLifecycle(pi: ExtensionAPI): void {
     // Idempotent — start() stops any prior timer first. Pass the shell
     // notifier so a backgrounded invocation toasts the user on completion
     // (async-by-default execution: submit, hand back, notify-on-finish).
-    startGalaxyPoller((text, level) => ctx.ui.notify(text, level));
+    // The poller fires this from a 15s timer, so the captured session_start
+    // ctx may be headless (rpc/--print/web) or stale after a session swap —
+    // ctx.ui/hasUI assert an active context and can throw. Guard like the
+    // compaction notifier (see registerCommand("compact") in index.ts).
+    startGalaxyPoller((text, level) => {
+      try {
+        if (ctx.hasUI) ctx.ui.notify(text, level);
+      } catch {
+        /* stale/headless context — a dropped completion toast is fine */
+      }
+    });
 
     sessionStart = {
       id: ctx.sessionManager?.getSessionId?.() ?? `session-${Date.now()}`,

--- a/tests/galaxy-poller.test.ts
+++ b/tests/galaxy-poller.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The background poller fires a completion toast when checkInvocations reports
+// an invocation that JUST reached a terminal state (autoAction completed/failed).
+// Mock the poller's four dependencies so we can drive a single tick (kicked off
+// synchronously by startGalaxyPoller) and observe exactly what it notifies.
+vi.mock("../extensions/loom/state.js", () => ({
+  getNotebookPath: vi.fn(() => "/fake/notebook.md"),
+}));
+vi.mock("../extensions/loom/notebook-writer.js", () => ({
+  readNotebook: vi.fn(async () => "notebook contents"),
+  // Always report one in-flight block so tick() proceeds to checkInvocations.
+  findInvocationBlocks: vi.fn(() => [{ status: "in_progress", invocationId: "inv1" }]),
+}));
+vi.mock("../extensions/loom/tools.js", () => ({
+  checkInvocations: vi.fn(),
+}));
+vi.mock("../extensions/loom/galaxy-api.js", () => ({
+  getGalaxyConfig: vi.fn(() => ({ url: "https://galaxy.test", apiKey: "k" })),
+}));
+
+import { startGalaxyPoller, stopGalaxyPoller } from "../extensions/loom/galaxy-poller";
+import { checkInvocations } from "../extensions/loom/tools.js";
+
+const mockCheck = vi.mocked(checkInvocations);
+
+/** A checkInvocations return whose details carry per-invocation results. */
+function resultWith(results: unknown[]) {
+  return {
+    content: [{ type: "text" as const, text: "{}" }],
+    details: { checked: results.length, results },
+  };
+}
+
+describe("galaxy-poller completion notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Clear the 15s interval the poller installs so it doesn't leak between tests.
+    stopGalaxyPoller();
+  });
+
+  it("fires a completed toast once when an invocation reaches a terminal ok state", async () => {
+    mockCheck.mockResolvedValue(
+      resultWith([
+        { invocationId: "inv1", label: "RNA-seq run", jobSummary: { ok: 3 }, autoAction: "completed" },
+      ]),
+    );
+    const notify = vi.fn();
+
+    startGalaxyPoller(notify);
+
+    await vi.waitFor(() => expect(notify).toHaveBeenCalledTimes(1));
+    expect(notify).toHaveBeenCalledWith(
+      '✅ Galaxy: "RNA-seq run" finished (3 jobs ok) — ask me to verify the outputs.',
+      "info",
+    );
+  });
+
+  it("fires a failed toast at warning level with the error count", async () => {
+    mockCheck.mockResolvedValue(
+      resultWith([
+        { invocationId: "inv1", label: "Variant call", jobSummary: { ok: 1, error: 2 }, autoAction: "failed" },
+      ]),
+    );
+    const notify = vi.fn();
+
+    startGalaxyPoller(notify);
+
+    await vi.waitFor(() => expect(notify).toHaveBeenCalledTimes(1));
+    expect(notify).toHaveBeenCalledWith(
+      '❌ Galaxy: "Variant call" failed (2 job error(s)) — ask me to investigate.',
+      "warning",
+    );
+  });
+
+  it("falls back to notebookAnchor then invocationId when no label is present", async () => {
+    mockCheck.mockResolvedValue(
+      resultWith([
+        { invocationId: "inv-xyz", notebookAnchor: "plan-1-step-3", jobSummary: { ok: 1 }, autoAction: "completed" },
+      ]),
+    );
+    const notify = vi.fn();
+
+    startGalaxyPoller(notify);
+
+    await vi.waitFor(() => expect(notify).toHaveBeenCalledTimes(1));
+    expect(notify.mock.calls[0][0]).toContain('"plan-1-step-3"');
+  });
+
+  it("does not notify for invocations that are still in progress (no autoAction)", async () => {
+    mockCheck.mockResolvedValue(
+      resultWith([{ invocationId: "inv1", label: "Still running", jobSummary: { ok: 1 }, autoAction: undefined }]),
+    );
+    const notify = vi.fn();
+
+    startGalaxyPoller(notify);
+
+    await vi.waitFor(() => expect(mockCheck).toHaveBeenCalled());
+    await Promise.resolve();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("does not throw or notify when the result omits a results array", async () => {
+    // Mirrors the checkInvocations early-return shape: details has no `results`.
+    mockCheck.mockResolvedValue({
+      content: [{ type: "text" as const, text: "{}" }],
+      details: { checked: 0 },
+    });
+    const notify = vi.fn();
+
+    startGalaxyPoller(notify);
+
+    await vi.waitFor(() => expect(mockCheck).toHaveBeenCalled());
+    await Promise.resolve();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it("swallows a throwing notifier so the poll loop's catch keeps the timer alive", async () => {
+    mockCheck.mockResolvedValue(
+      resultWith([{ invocationId: "inv1", label: "x", jobSummary: { ok: 1 }, autoAction: "completed" }]),
+    );
+    const notify = vi.fn(() => {
+      throw new Error("UI is gone");
+    });
+
+    // Must not reject/throw out of the fire-and-forget tick.
+    expect(() => startGalaxyPoller(notify)).not.toThrow();
+    await vi.waitFor(() => expect(notify).toHaveBeenCalledTimes(1));
+  });
+});


### PR DESCRIPTION
Follow-up to #281, which made backgrounded Galaxy jobs the default and added a completion toast. Two cleanups that came out of review:

**Guard the completion toast against a dead context.** The poller fires its notification from a 15s timer, so the `ctx` it captures at `session_start` can be headless (rpc/`--print`/web) or stale after a session swap -- and `ctx.ui`/`hasUI` throw in exactly that case. The compaction command already wraps its notify in `if (ctx.hasUI)` + try/catch for this reason; the poller now does the same. Before this, a finished invocation in those situations showed up as a `[galaxy-poller] tick failed` log line with the toast silently dropped.

**Drop a phantom local-job pattern from `/execute`.** The guidance told the model that "long local jobs use the launch-record-return background pattern," but that pattern only exists for Galaxy (`galaxy_invocation_record` + the poller) -- there's no local equivalent. Local steps run synchronously, so the prompt now says that.

Also backfills the poller-notification tests #281 didn't have: completed fires once at info, failed fires once at warning, label falls back to anchor/id, no toast when nothing transitioned or `results` is absent, and a throwing notifier doesn't take the tick down.

Root `tsc --noEmit` clean; 842 tests pass (836 + 6 new).