### PR TITLE
Surface the Galaxy history panel + open-history for env-driven sessions (#290)

### DIFF
--- a/app/src/main/galaxy-status.ts
+++ b/app/src/main/galaxy-status.ts
@@ -8,6 +8,20 @@ export interface GalaxyStatus {
 }
 
 /**
+ * The effective Galaxy server URL with the same precedence the brain's env
+ * uses: the active config profile's URL wins, else an exported `GALAXY_URL`,
+ * else null. Shared by the footer status resolver and the open-history origin
+ * pin so both agree on which server an env-driven session is actually talking
+ * to -- deriving it from the masked config profile alone missed the env-driven
+ * / auto-connect path (#290, follow-up to #284).
+ */
+export function resolveGalaxyServerUrl(cfg: LoomConfig, env: NodeJS.ProcessEnv): string | null {
+  const active = cfg.galaxy?.active;
+  const profileUrl = active ? cfg.galaxy?.profiles?.[active]?.url : undefined;
+  return profileUrl || env.GALAXY_URL || null;
+}
+
+/**
  * Effective Galaxy connection state as the brain actually sees it. The brain
  * treats Galaxy as connected when `GALAXY_URL` and `GALAXY_API_KEY` are both
  * present in its env (extensions/loom/context.ts), and Orbit builds that env
@@ -27,9 +41,42 @@ export function resolveGalaxyStatus(
   env: NodeJS.ProcessEnv,
   resolveKey: (c: LoomConfig) => string | null,
 ): GalaxyStatus {
-  const active = cfg.galaxy?.active;
-  const profileUrl = active ? cfg.galaxy?.profiles?.[active]?.url : undefined;
-  const url = profileUrl || env.GALAXY_URL || null;
+  const url = resolveGalaxyServerUrl(cfg, env);
   const key = resolveKey(cfg) ?? env.GALAXY_API_KEY ?? null;
   return { connected: Boolean(url && key), url };
+}
+
+/**
+ * Decide whether a renderer-requested history URL is safe to open externally,
+ * returning the normalized URL string to open or null to reject. The
+ * destination must be http(s), end in the canonical `/histories/view` path,
+ * and share an origin with the effective Galaxy server (`serverUrl`, resolved
+ * via resolveGalaxyServerUrl so an env-driven session pins correctly -- #290).
+ * The origin pin is the real trust boundary; the path suffix is a sanity check.
+ * `pathname.endsWith` (not ===) keeps subpath deployments
+ * (https://example.org/galaxy/histories/view) acceptable. Pure so the trust
+ * boundary is unit-testable without Electron.
+ */
+export function resolveGalaxyHistoryOpenUrl(
+  requestedUrl: unknown,
+  serverUrl: string | null,
+): string | null {
+  if (typeof requestedUrl !== "string") return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(requestedUrl);
+  } catch {
+    return null;
+  }
+  const httpScheme = parsed.protocol === "https:" || parsed.protocol === "http:";
+  if (!httpScheme || !parsed.pathname.endsWith("/histories/view")) return null;
+  if (!serverUrl) return null;
+  let expectedOrigin: string;
+  try {
+    expectedOrigin = new URL(serverUrl).origin;
+  } catch {
+    return null;
+  }
+  if (parsed.origin !== expectedOrigin) return null;
+  return parsed.toString();
 }

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -11,7 +11,11 @@ import {
   isAvailable as safeStorageAvailable,
   resolveGalaxyApiKey,
 } from "./secure-config.js";
-import { resolveGalaxyStatus } from "./galaxy-status.js";
+import {
+  resolveGalaxyStatus,
+  resolveGalaxyServerUrl,
+  resolveGalaxyHistoryOpenUrl,
+} from "./galaxy-status.js";
 import { getProviders, getModels } from "@earendil-works/pi-ai";
 import { isDeprecatedModelId } from "./model-catalog.js";
 import { checkLatestVersion } from "./version-check.js";
@@ -594,39 +598,16 @@ export function registerIpcHandlers(agent: AgentManager): void {
 
   // Opens the bound Galaxy history in the user's default browser when the user
   // clicks the link in the Activity tab. The renderer never gets a generic
-  // openExternal capability. We pin the destination to the configured Galaxy
-  // server: the URL must be http(s), its origin must match the active Galaxy
-  // profile, and its path must end in the canonical /histories/view view. The
-  // origin pin is the real trust boundary; the path suffix is a sanity check.
-  // pathname.endsWith (not ===) is required so subpath deployments
-  // (https://example.org/galaxy/histories/view) are accepted.
+  // openExternal capability. resolveGalaxyHistoryOpenUrl pins the destination to
+  // the *effective* Galaxy server (active profile URL or exported GALAXY_URL --
+  // an env-driven session has no saved profile, so pinning to the profile alone
+  // left history links dead, #290) and enforces the http(s) + /histories/view
+  // checks. It returns the normalized URL to open, or null to reject.
   ipcMain.handle("galaxy:open-history", async (_e, url: unknown) => {
-    if (typeof url !== "string") return { opened: false };
-    let parsed: URL;
-    try {
-      parsed = new URL(url);
-    } catch {
-      return { opened: false };
-    }
-    const httpScheme = parsed.protocol === "https:" || parsed.protocol === "http:";
-    if (!httpScheme || !parsed.pathname.endsWith("/histories/view")) {
-      return { opened: false };
-    }
-    // Pin the host to the active Galaxy profile so a compromised renderer
-    // cannot point this at an attacker-controlled host that also serves
-    // /histories/view.
-    const cfg = loadConfig();
-    const active = cfg.galaxy?.active;
-    const serverUrl = active ? cfg.galaxy?.profiles?.[active]?.url : undefined;
-    if (!serverUrl) return { opened: false };
-    let expectedOrigin: string;
-    try {
-      expectedOrigin = new URL(serverUrl).origin;
-    } catch {
-      return { opened: false };
-    }
-    if (parsed.origin !== expectedOrigin) return { opened: false };
-    await shell.openExternal(parsed.toString());
+    const serverUrl = resolveGalaxyServerUrl(loadConfig(), process.env);
+    const target = resolveGalaxyHistoryOpenUrl(url, serverUrl);
+    if (!target) return { opened: false };
+    await shell.openExternal(target);
     return { opened: true };
   });
 

--- a/app/src/renderer/galaxy-history.ts
+++ b/app/src/renderer/galaxy-history.ts
@@ -10,12 +10,17 @@
  *    `state.currentHistoryId` — the brain does not persist the live history
  *    anywhere the shell can read, so surfacing it would require a new
  *    brain->shell channel. See the test+fix notes for that follow-up.
- *  - the server origin comes from the *active Galaxy profile* (live config),
- *    not the server recorded in the binding. The binding records the server at
- *    bind time; the active profile is the connection the user is on right now.
- *    Driving off the live profile means the section hides on disconnect and
- *    tracks profile switches, and the opened link always targets the server
- *    Orbit is actually connected to.
+ *  - the server origin comes from the brain's *effective* Galaxy connection
+ *    (window.orbit.getGalaxyStatus -> { connected, url }), not the server
+ *    recorded in the binding. The binding records the server at bind time; the
+ *    effective status is the connection the user is on right now -- a saved
+ *    profile *or* an exported GALAXY_URL/GALAXY_API_KEY. Reading masked config
+ *    alone missed the env-driven / auto-connect path, so the section stayed
+ *    hidden even though the footer dot was green and a history was bound (#290,
+ *    follow-up to #284). Driving off the effective status means the section
+ *    hides on disconnect, tracks profile switches, and matches the footer dot
+ *    exactly, and the opened link always targets the server Orbit is connected
+ *    to.
  *
  * Hidden when Galaxy is not connected, when no binding exists, or when the URL
  * can't be built. Building the web URL is a shell concern — the Loom brain
@@ -87,30 +92,14 @@ export function buildHistoryUrl(serverUrl: string, historyId: string): string | 
 }
 
 /**
- * Read the active Galaxy profile's server URL from masked config, or null when
- * Galaxy is not connected. Mirrors refreshGalaxyStatus()'s connection check so
- * the section appears/hides on the same connect/disconnect/profile-switch
- * signal as the connection indicator.
- */
-function activeGalaxyServerUrl(cfg: Record<string, unknown>): string | null {
-  const galaxy = cfg.galaxy as
-    | { active?: string | null; profiles?: Record<string, { url?: string; hasApiKey?: boolean }> }
-    | undefined;
-  const active = galaxy?.active;
-  const profile = active ? galaxy?.profiles?.[active] : undefined;
-  if (!profile?.url || !profile?.hasApiKey) return null;
-  return profile.url;
-}
-
-/**
  * Render the Galaxy history section. Uses the first binding block (today's MVP
- * is one binding per notebook) for the history id and the active Galaxy profile
- * for the server. Hides the section when Galaxy is not connected, there's no
- * binding, or the URL can't be built.
+ * is one binding per notebook) for the history id and the brain's effective
+ * Galaxy connection for the server. Hides the section when Galaxy is not
+ * connected, there's no binding, or the URL can't be built.
  */
 export async function refreshGalaxyHistory(api: {
   readFile: (p: string) => Promise<{ ok: true; bytes: Uint8Array } | { ok: false }>;
-  getConfig: () => Promise<Record<string, unknown>>;
+  getGalaxyStatus: () => Promise<{ connected: boolean; url: string | null }>;
   openGalaxyHistory: (url: string) => Promise<{ opened: boolean }>;
 }): Promise<void> {
   const section = document.getElementById("activity-galaxy-history-section");
@@ -124,9 +113,12 @@ export async function refreshGalaxyHistory(api: {
 
   let serverUrl: string | null = null;
   try {
-    serverUrl = activeGalaxyServerUrl(await api.getConfig());
+    const status = await api.getGalaxyStatus();
+    // Gate on the same `connected` notion the footer dot uses (which decrypts
+    // the key) rather than URL presence, so the section and the dot agree.
+    if (status.connected) serverUrl = status.url;
   } catch {
-    /* config unavailable — treat as not connected */
+    /* status unavailable — treat as not connected */
   }
   if (!serverUrl) {
     hide();

--- a/tests/galaxy-history.test.ts
+++ b/tests/galaxy-history.test.ts
@@ -1,5 +1,10 @@
+// @vitest-environment happy-dom
 import { describe, it, expect } from "vitest";
-import { buildHistoryUrl, parseGalaxyHistoryBindings } from "../app/src/renderer/galaxy-history";
+import {
+  buildHistoryUrl,
+  parseGalaxyHistoryBindings,
+  refreshGalaxyHistory,
+} from "../app/src/renderer/galaxy-history";
 
 describe("buildHistoryUrl", () => {
   it("builds the canonical view URL for a root-path server", () => {
@@ -93,5 +98,139 @@ describe("parseGalaxyHistoryBindings", () => {
       { historyId: "first" },
       { historyId: "second" },
     ]);
+  });
+});
+
+describe("refreshGalaxyHistory", () => {
+  const NOTEBOOK_WITH_BINDING = [
+    "# Notebook",
+    "",
+    "```loom-galaxy-page",
+    "page_id: page123",
+    "history_id: hist456",
+    "```",
+    "",
+  ].join("\n");
+
+  function setupDom(): { section: HTMLElement; body: HTMLElement } {
+    document.body.innerHTML = `
+      <div id="activity-galaxy-history-section" class="hidden">
+        <div id="galaxy-history-body"></div>
+      </div>
+    `;
+    return {
+      section: document.getElementById("activity-galaxy-history-section")!,
+      body: document.getElementById("galaxy-history-body")!,
+    };
+  }
+
+  function api(opts: {
+    status: { connected: boolean; url: string | null };
+    notebook?: string;
+    onOpen?: (url: string) => void;
+  }): Parameters<typeof refreshGalaxyHistory>[0] {
+    return {
+      getGalaxyStatus: async () => opts.status,
+      readFile: async () =>
+        opts.notebook !== undefined
+          ? { ok: true as const, bytes: new TextEncoder().encode(opts.notebook) }
+          : { ok: false as const },
+      openGalaxyHistory: async (url: string) => {
+        opts.onOpen?.(url);
+        return { opened: true };
+      },
+    };
+  }
+
+  it("shows the section and builds the view URL from the effective env URL when connected (#290)", async () => {
+    // Env-driven session: no saved profile, status reports connected with the
+    // exported GALAXY_URL. Used to hide because it read the (empty) profile.
+    const { section, body } = setupDom();
+    await refreshGalaxyHistory(
+      api({
+        status: { connected: true, url: "https://env.example" },
+        notebook: NOTEBOOK_WITH_BINDING,
+      }),
+    );
+    expect(section.classList.contains("hidden")).toBe(false);
+    const link = body.querySelector<HTMLAnchorElement>("a.galaxy-history-link");
+    expect(link?.getAttribute("href")).toBe("https://env.example/histories/view?id=hist456");
+  });
+
+  it("routes a click through the host-pinned IPC path with the built URL", async () => {
+    const { body } = setupDom();
+    let opened: string | null = null;
+    await refreshGalaxyHistory(
+      api({
+        status: { connected: true, url: "https://env.example" },
+        notebook: NOTEBOOK_WITH_BINDING,
+        onOpen: (url) => {
+          opened = url;
+        },
+      }),
+    );
+    body.querySelector<HTMLAnchorElement>("a.galaxy-history-link")!.click();
+    expect(opened).toBe("https://env.example/histories/view?id=hist456");
+  });
+
+  it("still works for a saved-profile URL (no regression)", async () => {
+    const { section, body } = setupDom();
+    await refreshGalaxyHistory(
+      api({
+        status: { connected: true, url: "https://main.example" },
+        notebook: NOTEBOOK_WITH_BINDING,
+      }),
+    );
+    expect(section.classList.contains("hidden")).toBe(false);
+    expect(
+      body.querySelector<HTMLAnchorElement>("a.galaxy-history-link")?.getAttribute("href"),
+    ).toBe("https://main.example/histories/view?id=hist456");
+  });
+
+  it("hides the section when not connected", async () => {
+    const { section, body } = setupDom();
+    await refreshGalaxyHistory(
+      api({ status: { connected: false, url: null }, notebook: NOTEBOOK_WITH_BINDING }),
+    );
+    expect(section.classList.contains("hidden")).toBe(true);
+    expect(body.children.length).toBe(0);
+  });
+
+  it("hides even if a URL is present but the effective status is disconnected", async () => {
+    // Match the footer dot exactly: gate on `connected`, not URL presence.
+    const { section } = setupDom();
+    await refreshGalaxyHistory(
+      api({
+        status: { connected: false, url: "https://env.example" },
+        notebook: NOTEBOOK_WITH_BINDING,
+      }),
+    );
+    expect(section.classList.contains("hidden")).toBe(true);
+  });
+
+  it("hides when connected but the notebook has no binding", async () => {
+    const { section } = setupDom();
+    await refreshGalaxyHistory(
+      api({
+        status: { connected: true, url: "https://env.example" },
+        notebook: "# Notebook\n\njust prose\n",
+      }),
+    );
+    expect(section.classList.contains("hidden")).toBe(true);
+  });
+
+  it("hides when the status lookup throws", async () => {
+    const { section } = setupDom();
+    await refreshGalaxyHistory({
+      getGalaxyStatus: async () => {
+        throw new Error("ipc down");
+      },
+      readFile: async () => ({
+        ok: true as const,
+        bytes: new TextEncoder().encode(NOTEBOOK_WITH_BINDING),
+      }),
+      openGalaxyHistory: async () => ({ opened: true }),
+    });
+    expect(section.classList.contains("hidden")).toBe(true);
   });
 });

--- a/tests/galaxy-status.test.ts
+++ b/tests/galaxy-status.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveGalaxyStatus } from "../app/src/main/galaxy-status.js";
+import {
+  resolveGalaxyStatus,
+  resolveGalaxyServerUrl,
+  resolveGalaxyHistoryOpenUrl,
+} from "../app/src/main/galaxy-status.js";
 import type { LoomConfig } from "../shared/loom-config.js";
 
 const noConfigKey = () => null;
@@ -61,5 +65,85 @@ describe("resolveGalaxyStatus", () => {
       noConfigKey,
     );
     expect(status.connected).toBe(true);
+  });
+});
+
+describe("resolveGalaxyServerUrl", () => {
+  it("falls back to the exported GALAXY_URL when no profile is saved (#290)", () => {
+    expect(
+      resolveGalaxyServerUrl(
+        {} as LoomConfig,
+        { GALAXY_URL: "https://env.example" } as NodeJS.ProcessEnv,
+      ),
+    ).toBe("https://env.example");
+  });
+
+  it("uses the active profile URL with no env", () => {
+    expect(
+      resolveGalaxyServerUrl(profileConfig("https://main.example"), {} as NodeJS.ProcessEnv),
+    ).toBe("https://main.example");
+  });
+
+  it("prefers the active profile URL over an exported GALAXY_URL", () => {
+    expect(
+      resolveGalaxyServerUrl(profileConfig("https://profile.example"), {
+        GALAXY_URL: "https://env.example",
+      } as NodeJS.ProcessEnv),
+    ).toBe("https://profile.example");
+  });
+
+  it("is null with no profile and no env", () => {
+    expect(resolveGalaxyServerUrl({} as LoomConfig, {} as NodeJS.ProcessEnv)).toBeNull();
+  });
+});
+
+describe("resolveGalaxyHistoryOpenUrl", () => {
+  const HISTORY = "https://env.example/histories/view?id=h1";
+
+  it("accepts a same-origin history URL pinned to the effective env server (#290)", () => {
+    // The env-driven case: no saved profile, server URL comes from GALAXY_URL.
+    const serverUrl = resolveGalaxyServerUrl(
+      {} as LoomConfig,
+      { GALAXY_URL: "https://env.example" } as NodeJS.ProcessEnv,
+    );
+    expect(resolveGalaxyHistoryOpenUrl(HISTORY, serverUrl)).toBe(HISTORY);
+  });
+
+  it("accepts a subpath deployment whose origin matches the server", () => {
+    expect(
+      resolveGalaxyHistoryOpenUrl(
+        "https://example.org/galaxy/histories/view?id=h1",
+        "https://example.org/galaxy",
+      ),
+    ).toBe("https://example.org/galaxy/histories/view?id=h1");
+  });
+
+  it("rejects a cross-origin destination even with a valid path", () => {
+    expect(
+      resolveGalaxyHistoryOpenUrl("https://evil.example/histories/view", "https://env.example"),
+    ).toBeNull();
+  });
+
+  it("rejects when no server URL resolves at all", () => {
+    expect(resolveGalaxyHistoryOpenUrl(HISTORY, null)).toBeNull();
+  });
+
+  it("rejects a non-http(s) scheme", () => {
+    expect(resolveGalaxyHistoryOpenUrl("file:///etc/passwd", "https://env.example")).toBeNull();
+  });
+
+  it("rejects a URL that does not end in /histories/view", () => {
+    expect(
+      resolveGalaxyHistoryOpenUrl("https://env.example/datasets/list", "https://env.example"),
+    ).toBeNull();
+  });
+
+  it("rejects a non-string requested URL", () => {
+    expect(resolveGalaxyHistoryOpenUrl(42, "https://env.example")).toBeNull();
+    expect(resolveGalaxyHistoryOpenUrl(undefined, "https://env.example")).toBeNull();
+  });
+
+  it("rejects an unparseable requested URL", () => {
+    expect(resolveGalaxyHistoryOpenUrl("not a url", "https://env.example")).toBeNull();
   });
 });


### PR DESCRIPTION
Follow-up to #284. That fix made the footer status dot read the *effective* Galaxy connection (a saved profile, or exported `GALAXY_URL`/`GALAXY_API_KEY` with no profile -- the env-driven / auto-connect path). But two other surfaces still derived Galaxy state from the masked config profile only, so they stayed broken in exactly that case:

- The **Galaxy history section** in the Activity tab hid itself, even when the footer dot was green and a history was bound.
- **Clicking a history link** was a dead no-op: `galaxy:open-history` pinned the destination origin to the active profile URL, which is null when there's no saved profile, so it returned `{ opened: false }`.

Both now consume the same effective server URL the footer already uses. I pulled the profile-or-env precedence out of `resolveGalaxyStatus` into a shared `resolveGalaxyServerUrl`, and extracted the `open-history` decision into a pure `resolveGalaxyHistoryOpenUrl` so the trust boundary is unit-testable without Electron. The origin pin, the http(s) check, and the `/histories/view` path suffix are all unchanged -- only the *source* of the server URL broadens from profile to profile-or-env. The renderer's `refreshGalaxyHistory` now reads `getGalaxyStatus()` and gates on its `connected` notion (which decrypts the key) rather than masked-config field presence, so the section and the footer dot agree exactly.

TDD throughout: 19 new tests -- 4 for `resolveGalaxyServerUrl`, 8 for the open-history helper (origin-pin, scheme, and path rejections), and 7 happy-dom cases for `refreshGalaxyHistory` (env-driven shows + builds the URL, click routes through the host-pinned IPC path, saved-profile no-regression, and the various hide cases). Full suite green (861), root + app typecheck clean.

Closes #290.
