### PR TITLE
Warn agents about the underscore-vs-pipe repeat-key trap (stopgap for #285)

### DIFF
--- a/docs/agent/gotchas.md
+++ b/docs/agent/gotchas.md
@@ -1,5 +1,12 @@
 # Gotchas and operational notes
 
+> **Stopgap, not a home.** Much of this file encodes _process_ -- behavior the
+> agent should follow -- as prompt-level nudges. That is a pragmatic patch for
+> loom, not where this belongs. Each such entry is a candidate to migrate into a
+> more durable substrate (the galaxy-mcp protocol, a skill, or a deterministic
+> check) and to be deleted here once that substrate enforces it. Prefer fixing
+> the substrate over growing this file.
+
 ## Local-tool environment
 
 When running tools locally, use a per-analysis conda environment rooted
@@ -64,6 +71,17 @@ match it exactly — do not guess input names. The fastest path:
 3. Use flattened keys for nested params: `section|param`,
    `conditional|selector`, `repeat_0|param` (and `repeat_1|...` for more
    repeat instances).
+
+   **Repeat keys use `|`, never `_`, before the child param.** Writing
+   `operations_1_op_name` instead of `operations_1|op_name` is a silent trap:
+   Galaxy _accepts_ the underscore form, ignores the unbound key, and runs the
+   job to `ok` with a wrong (default-filled) value -- a data-correctness failure
+   with no error to catch. The repeat-instance index is `_N`; the separator to
+   its child param is always `|`.
+
+<!-- Remove this underscore-vs-pipe warning once galaxy-mcp surfaces it at
+     submit/enrich time (galaxyproject/galaxy-mcp#52): when the protocol catches
+     the malformed key, this prompt nudge is redundant. -->
 
 If a tool call fails with an opaque or parameter-shaped error — in
 particular `Required parameter(s) kwd not provided in request` — treat it


### PR DESCRIPTION
#285 is a silent data-correctness bug: an agent submitted a repeat-group param as `operations_1_op_name` (underscore) instead of `operations_1|op_name` (pipe). Galaxy accepts the underscore form, silently fails to bind it, and runs the job to `ok` with a default-filled value -- so a Datamash mean came back wrong with no error to catch.

Triaging it, this isn't a loom code bug: loom never builds `run_tool` inputs (the model does), and galaxy-mcp's `run_tool` is a pass-through. The durable fix belongs in galaxy-mcp as a non-blocking advisory hint, which I've proposed on galaxyproject/galaxy-mcp#52. A blocking client-side validator was deliberately rejected there -- since Galaxy *accepts* the malformed key, rejecting it is exactly the false-rejection trap #52 guards against.

So this PR is just the loom-side stopgap: a `gotchas.md` warning that repeat keys use `|`, never `_`, before the child param, with the silent-failure explanation. It carries an HTML-comment trigger to delete it once galaxy-mcp #52 lands.

While here, it also adds a "Stopgap, not a home" note at the top of `gotchas.md`: this file encodes process as prompt-level nudges, which is a patch, not the right substrate. Entries here should migrate into the galaxy-mcp protocol / a skill / a deterministic check and be removed once enforced upstream.

Docs-only; no code or tests touched.
