### PR TITLE
Treat .tabular and the fastq/interval datatypes as previewable text

### DIFF
--- a/app/src/main/files-handler.ts
+++ b/app/src/main/files-handler.ts
@@ -80,6 +80,7 @@ const TEXT_PREVIEW_EXTS = new Set([
   ".csv",
   ".tsv",
   ".tab",
+  ".tabular",
   ".fa",
   ".fasta",
   ".fna",
@@ -87,8 +88,13 @@ const TEXT_PREVIEW_EXTS = new Set([
   ".ffn",
   ".fastq",
   ".fq",
+  ".fastqsanger",
+  ".fastqillumina",
+  ".fastqsolexa",
+  ".fastqcssanger",
   ".vcf",
   ".bed",
+  ".interval",
   ".bedgraph",
   ".wig",
   ".gff",
@@ -104,7 +110,7 @@ const TEXT_PREVIEW_EXTS = new Set([
   ".phylip",
 ]);
 
-function isTextLikeForPreview(name: string): boolean {
+export function isTextLikeForPreview(name: string): boolean {
   const dot = name.lastIndexOf(".");
   // No extension -- the renderer treats these as text (READMEs, configs).
   if (dot <= 0) return true;

--- a/app/src/renderer/files/file-viewer.ts
+++ b/app/src/renderer/files/file-viewer.ts
@@ -45,6 +45,7 @@ const TEXT_EXTS = new Set([
   ".csv",
   ".tsv",
   ".tab",
+  ".tabular",
   // bioinformatics text formats
   ".fa",
   ".fasta",
@@ -53,8 +54,13 @@ const TEXT_EXTS = new Set([
   ".ffn",
   ".fastq",
   ".fq",
+  ".fastqsanger",
+  ".fastqillumina",
+  ".fastqsolexa",
+  ".fastqcssanger",
   ".vcf",
   ".bed",
+  ".interval",
   ".bedgraph",
   ".wig",
   ".gff",
@@ -74,7 +80,7 @@ const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"]);
 
 const PDF_EXTS = new Set([".pdf"]);
 
-function kindOf(path: string): FileKind {
+export function kindOf(path: string): FileKind {
   const ext = extOf(path);
   if (!ext) return "text"; // no extension → treat as text
   if (TEXT_EXTS.has(ext)) return "text";

--- a/tests/file-preview-classification.test.ts
+++ b/tests/file-preview-classification.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi } from "vitest";
+
+// files-handler.ts imports { ipcMain, BrowserWindow } from "electron" at module
+// top-level. In a clean checkout app/node_modules/electron isn't installed, so
+// vitest needs the named exports stubbed -- the functions under test never call
+// into them.
+vi.mock("electron", () => ({ ipcMain: {}, BrowserWindow: {} }));
+
+import { kindOf } from "../app/src/renderer/files/file-viewer.js";
+import { isTextLikeForPreview } from "../app/src/main/files-handler.js";
+
+// Regression coverage for #269: Galaxy downloads tabular datasets as *.tabular,
+// but the file viewer's text-extension allowlist only knew .tsv/.csv/.tab, so
+// .tabular fell through to "Cannot preview -- binary file". These extensions are
+// all plain text and Galaxy-common; both the renderer classifier (kindOf, which
+// drives the binary placeholder) and the main-process head-preview gate
+// (isTextLikeForPreview) must treat them as text.
+const GALAXY_TEXT_EXTS = [
+  ".tabular",
+  ".interval",
+  ".fastqsanger",
+  ".fastqillumina",
+  ".fastqsolexa",
+  ".fastqcssanger",
+];
+
+describe("kindOf (renderer file viewer)", () => {
+  it.each(GALAXY_TEXT_EXTS)("classifies %s as text", (ext) => {
+    expect(kindOf(`data${ext}`)).toBe("text");
+  });
+
+  it("is case-insensitive about the extension", () => {
+    expect(kindOf("DATA.TABULAR")).toBe("text");
+  });
+
+  it("still classifies the pre-existing tabular extensions as text", () => {
+    expect(kindOf("a.tsv")).toBe("text");
+    expect(kindOf("a.csv")).toBe("text");
+    expect(kindOf("a.tab")).toBe("text");
+  });
+
+  it("keeps real binaries out of the text path", () => {
+    expect(kindOf("reads.bam")).toBe("binary");
+    expect(kindOf("index.bai")).toBe("binary");
+    expect(kindOf("archive.gz")).toBe("binary");
+    expect(kindOf("photo.png")).toBe("image");
+    expect(kindOf("doc.pdf")).toBe("pdf");
+  });
+
+  it("keeps the gzipped Galaxy variant binary -- only the last extension counts", () => {
+    // .fastqsanger is text now, but the compressed datatype is a distinct
+    // (.gz) extension and must stay binary.
+    expect(kindOf("reads.fastqsanger.gz")).toBe("binary");
+  });
+});
+
+describe("isTextLikeForPreview (main-process head-preview gate)", () => {
+  it.each(GALAXY_TEXT_EXTS)("treats %s as text-like", (ext) => {
+    expect(isTextLikeForPreview(`data${ext}`)).toBe(true);
+  });
+
+  it("is case-insensitive about the extension", () => {
+    expect(isTextLikeForPreview("DATA.TABULAR")).toBe(true);
+  });
+
+  it("keeps real binaries out of the head-preview path", () => {
+    expect(isTextLikeForPreview("reads.bam")).toBe(false);
+    expect(isTextLikeForPreview("archive.gz")).toBe(false);
+    expect(isTextLikeForPreview("photo.png")).toBe(false);
+  });
+
+  it("keeps the gzipped Galaxy variant binary -- only the last extension counts", () => {
+    expect(isTextLikeForPreview("reads.fastqsanger.gz")).toBe(false);
+  });
+});


### PR DESCRIPTION
Galaxy downloads tabular datasets as `*.tabular`, but the file viewer's text-extension allowlist only knew `.tsv`/`.csv`/`.tab`, so a `.tabular` file fell through to the "Cannot preview -- binary file" placeholder. Same gap for `.interval` and the fastq datatype variants (`.fastqsanger`, `.fastqillumina`, `.fastqsolexa`, `.fastqcssanger`) -- all plain text, all Galaxy-common.

There are two parallel allowlists -- the renderer classifier (`kindOf`, which drives the binary placeholder) and the main-process head-preview gate (`isTextLikeForPreview`) -- so I added the extensions to both and exported the two functions to test them directly. Tests cover the new extensions, case-insensitivity, and that compressed variants like `reads.fastqsanger.gz` stay binary (only the last extension counts).

Closes #269.
