### PR TITLE
Stop the text-selection Copy button getting stranded mid-chat

### DIFF
--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -531,6 +531,7 @@ export class ChatPanel {
       }
       const range = sel.getRangeAt(0);
       const rect = range.getBoundingClientRect();
+      const crect = this.container.getBoundingClientRect();
       const placement = computeCopyButtonPlacement({
         isCollapsed: sel.isCollapsed,
         rangeCount: sel.rangeCount,
@@ -542,6 +543,7 @@ export class ChatPanel {
           width: rect.width,
           height: rect.height,
         },
+        container: { top: crect.top, bottom: crect.bottom },
         viewport: { width: window.innerWidth, height: window.innerHeight },
       });
       if (placement.hidden) {

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -1,5 +1,6 @@
 import { renderMarkdown } from "./markdown.js";
 import { joinTextBlocks } from "./block-spacing.js";
+import { computeCopyButtonPlacement } from "./copy-button.js";
 import {
   TEAM_DISPATCH_KIND,
   type TeamDispatchDetails,
@@ -468,13 +469,18 @@ export class ChatPanel {
     document.addEventListener("mousedown", (e) => {
       // contains() so clicking the button's inner <svg> (a child) still counts
       // as the button -- otherwise the icon hit hides it before the copy fires.
-      if (!btn.contains(e.target as Node)) { btn.hidden = true; mouseIsDown = true; }
+      if (!btn.contains(e.target as Node)) {
+        btn.hidden = true;
+        mouseIsDown = true;
+      }
     });
     document.addEventListener("mouseup", () => {
       mouseIsDown = false;
       updateBtn();
     });
-    window.addEventListener("blur", () => { btn.hidden = true; });
+    window.addEventListener("blur", () => {
+      btn.hidden = true;
+    });
 
     btn.addEventListener("click", () => {
       const sel = window.getSelection();
@@ -500,19 +506,51 @@ export class ChatPanel {
       updateBtn();
     });
 
+    // The button is position:fixed at the selection's viewport coords, but the
+    // chat re-renders and autoscrolls during streaming. Without re-validating on
+    // scroll the button stays frozen where the selection used to be, stranded in
+    // the middle of the pane (#299). Re-running updateBtn repositions it to track
+    // the selection, or hides it once the selection scrolls away / is gone.
+    this.container.addEventListener("scroll", () => updateBtn());
+
+    // A guaranteed dismiss: Escape clears the selection and hides the button.
+    // Scoped to when the button is showing so it never disturbs selections
+    // elsewhere (e.g. in an input).
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && !btn.hidden) {
+        btn.hidden = true;
+        window.getSelection()?.removeAllRanges();
+      }
+    });
+
     const updateBtn = () => {
       const sel = window.getSelection();
-      if (!sel || sel.isCollapsed || sel.rangeCount === 0) { btn.hidden = true; return; }
+      if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
+        btn.hidden = true;
+        return;
+      }
       const range = sel.getRangeAt(0);
-      if (!this.container.contains(range.commonAncestorContainer)) { btn.hidden = true; return; }
       const rect = range.getBoundingClientRect();
-      if (!rect.width && !rect.height) { btn.hidden = true; return; }
+      const placement = computeCopyButtonPlacement({
+        isCollapsed: sel.isCollapsed,
+        rangeCount: sel.rangeCount,
+        inContainer: this.container.contains(range.commonAncestorContainer),
+        rect: {
+          top: rect.top,
+          bottom: rect.bottom,
+          right: rect.right,
+          width: rect.width,
+          height: rect.height,
+        },
+        viewport: { width: window.innerWidth, height: window.innerHeight },
+      });
+      if (placement.hidden) {
+        btn.hidden = true;
+        return;
+      }
       btn.hidden = false;
-      const bh = 28, bw = 80;
-      const top = rect.bottom + 6 + bh > window.innerHeight ? rect.top - bh - 4 : rect.bottom + 4;
-      const left = Math.max(4, Math.min(rect.right - bw, window.innerWidth - bw - 4));
-      btn.style.top = `${top}px`;
-      btn.style.left = `${left}px`;
+      btn.style.top = `${placement.top}px`;
+      btn.style.left = `${placement.left}px`;
     };
 
     return btn;
@@ -558,7 +596,9 @@ export function historyToMarkdown(records: MessageRecord[]): string {
       lines.push(`**Assistant**\n\n${rec.text}\n`);
     } else if (rec.role === "tool") {
       const badge = rec.status === "done" ? "✓" : rec.status === "error" ? "✗" : "…";
-      lines.push(`*Tool call ${badge}: \`${rec.name}\`*${rec.result ? `\n\n\`\`\`\n${rec.result}\n\`\`\`` : ""}\n`);
+      lines.push(
+        `*Tool call ${badge}: \`${rec.name}\`*${rec.result ? `\n\n\`\`\`\n${rec.result}\n\`\`\`` : ""}\n`,
+      );
     } else if (rec.role === "error") {
       lines.push(`*Error: ${rec.text}*\n`);
     }
@@ -578,9 +618,15 @@ function nodeToMd(node: Node): string {
   const inner = () => Array.from(el.childNodes).map(nodeToMd).join("");
 
   switch (tag) {
-    case "strong": case "b": return `**${inner()}**`;
-    case "em": case "i": return `*${inner()}*`;
-    case "del": case "s": return `~~${inner()}~~`;
+    case "strong":
+    case "b":
+      return `**${inner()}**`;
+    case "em":
+    case "i":
+      return `*${inner()}*`;
+    case "del":
+    case "s":
+      return `~~${inner()}~~`;
     case "code":
       if (el.closest("pre")) return el.textContent ?? "";
       return `\`${el.textContent ?? ""}\``;
@@ -589,21 +635,47 @@ function nodeToMd(node: Node): string {
       const lang = (code?.className ?? "").match(/language-(\w+)/)?.[1] ?? "";
       return `\`\`\`${lang}\n${(code ?? el).textContent ?? ""}\n\`\`\``;
     }
-    case "h1": return `# ${inner()}\n`;
-    case "h2": return `## ${inner()}\n`;
-    case "h3": return `### ${inner()}\n`;
-    case "h4": return `#### ${inner()}\n`;
-    case "h5": return `##### ${inner()}\n`;
-    case "h6": return `###### ${inner()}\n`;
-    case "p": return `${inner()}\n\n`;
-    case "br": return "\n";
-    case "ul": return Array.from(el.children).map(li => `- ${nodeToMd(li)}`).join("\n") + "\n";
-    case "ol": return Array.from(el.children).map((li, i) => `${i + 1}. ${nodeToMd(li)}`).join("\n") + "\n";
-    case "li": return inner();
-    case "a": return `[${inner()}](${el.getAttribute("href") ?? ""})`;
-    case "blockquote": return inner().split("\n").map(l => `> ${l}`).join("\n");
-    case "hr": return "---\n";
-    default: return inner();
+    case "h1":
+      return `# ${inner()}\n`;
+    case "h2":
+      return `## ${inner()}\n`;
+    case "h3":
+      return `### ${inner()}\n`;
+    case "h4":
+      return `#### ${inner()}\n`;
+    case "h5":
+      return `##### ${inner()}\n`;
+    case "h6":
+      return `###### ${inner()}\n`;
+    case "p":
+      return `${inner()}\n\n`;
+    case "br":
+      return "\n";
+    case "ul":
+      return (
+        Array.from(el.children)
+          .map((li) => `- ${nodeToMd(li)}`)
+          .join("\n") + "\n"
+      );
+    case "ol":
+      return (
+        Array.from(el.children)
+          .map((li, i) => `${i + 1}. ${nodeToMd(li)}`)
+          .join("\n") + "\n"
+      );
+    case "li":
+      return inner();
+    case "a":
+      return `[${inner()}](${el.getAttribute("href") ?? ""})`;
+    case "blockquote":
+      return inner()
+        .split("\n")
+        .map((l) => `> ${l}`)
+        .join("\n");
+    case "hr":
+      return "---\n";
+    default:
+      return inner();
   }
 }
 

--- a/app/src/renderer/chat/copy-button.ts
+++ b/app/src/renderer/chat/copy-button.ts
@@ -17,6 +17,14 @@ export interface CopyButtonInput {
   inContainer: boolean;
   /** The selection's viewport-relative bounding rect. */
   rect: CopyButtonRect;
+  /**
+   * The chat scrollport's viewport-relative top/bottom. The chat container is
+   * the scroller, so a selection can stay in the DOM but scroll out of view
+   * (autoscroll during streaming). When the selection's rect is entirely above
+   * or below this band the button is hidden, instead of being stranded at a
+   * stale position over the rest of the pane.
+   */
+  container: { top: number; bottom: number };
   viewport: { width: number; height: number };
 }
 
@@ -26,13 +34,18 @@ const BUTTON_HEIGHT = 28;
 const BUTTON_WIDTH = 80;
 
 export function computeCopyButtonPlacement(input: CopyButtonInput): CopyButtonPlacement {
-  const { isCollapsed, rangeCount, inContainer, rect, viewport } = input;
+  const { isCollapsed, rangeCount, inContainer, rect, container, viewport } = input;
 
   if (isCollapsed || rangeCount === 0) return { hidden: true };
   if (!inContainer) return { hidden: true };
   // A detached/empty selection (e.g. its nodes were re-rendered out from under
   // it during streaming) collapses to a zero-area rect -- treat it as gone.
   if (!rect.width && !rect.height) return { hidden: true };
+  // The selection has scrolled entirely out of the chat scrollport (above or
+  // below it). The fixed button would otherwise sit at a stale position over
+  // the rest of the pane -- the #299 "stranded in the middle" symptom -- so
+  // hide it. A partially-visible selection straddling an edge stays shown.
+  if (rect.bottom < container.top || rect.top > container.bottom) return { hidden: true };
 
   const top =
     rect.bottom + 6 + BUTTON_HEIGHT > viewport.height

--- a/app/src/renderer/chat/copy-button.ts
+++ b/app/src/renderer/chat/copy-button.ts
@@ -1,0 +1,44 @@
+// Pure placement logic for the floating text-selection "Copy" button.
+// Kept DOM-free so the visibility/position decision is unit-testable; the
+// chat panel feeds it live selection geometry and applies the result.
+
+export interface CopyButtonRect {
+  top: number;
+  bottom: number;
+  right: number;
+  width: number;
+  height: number;
+}
+
+export interface CopyButtonInput {
+  isCollapsed: boolean;
+  rangeCount: number;
+  /** Whether the selection range lives inside the chat container. */
+  inContainer: boolean;
+  /** The selection's viewport-relative bounding rect. */
+  rect: CopyButtonRect;
+  viewport: { width: number; height: number };
+}
+
+export type CopyButtonPlacement = { hidden: true } | { hidden: false; top: number; left: number };
+
+const BUTTON_HEIGHT = 28;
+const BUTTON_WIDTH = 80;
+
+export function computeCopyButtonPlacement(input: CopyButtonInput): CopyButtonPlacement {
+  const { isCollapsed, rangeCount, inContainer, rect, viewport } = input;
+
+  if (isCollapsed || rangeCount === 0) return { hidden: true };
+  if (!inContainer) return { hidden: true };
+  // A detached/empty selection (e.g. its nodes were re-rendered out from under
+  // it during streaming) collapses to a zero-area rect -- treat it as gone.
+  if (!rect.width && !rect.height) return { hidden: true };
+
+  const top =
+    rect.bottom + 6 + BUTTON_HEIGHT > viewport.height
+      ? rect.top - BUTTON_HEIGHT - 4
+      : rect.bottom + 4;
+  const left = Math.max(4, Math.min(rect.right - BUTTON_WIDTH, viewport.width - BUTTON_WIDTH - 4));
+
+  return { hidden: false, top, left };
+}

--- a/tests/copy-button.test.ts
+++ b/tests/copy-button.test.ts
@@ -12,6 +12,7 @@ function input(overrides: Partial<CopyButtonInput> = {}): CopyButtonInput {
     rangeCount: 1,
     inContainer: true,
     rect: { top: 100, bottom: 120, right: 300, width: 200, height: 20 },
+    container: { top: 0, bottom: 800 },
     viewport: VIEWPORT,
     ...overrides,
   };
@@ -85,5 +86,26 @@ describe("computeCopyButtonPlacement", () => {
     );
     expect(before).toEqual({ hidden: false, top: 404, left: 220 });
     expect(after).toEqual({ hidden: false, top: 204, left: 220 });
+  });
+
+  // #299: the chat container is the scroller, so a live selection can scroll
+  // out of the visible scrollport. The button must hide rather than strand at a
+  // stale position over the rest of the pane.
+  it("hides when the selection has scrolled above the chat scrollport", () => {
+    const container = { top: 100, bottom: 700 };
+    const rect = { top: 30, bottom: 50, right: 300, width: 200, height: 20 };
+    expect(computeCopyButtonPlacement(input({ container, rect }))).toEqual({ hidden: true });
+  });
+
+  it("hides when the selection has scrolled below the chat scrollport", () => {
+    const container = { top: 100, bottom: 700 };
+    const rect = { top: 740, bottom: 760, right: 300, width: 200, height: 20 };
+    expect(computeCopyButtonPlacement(input({ container, rect }))).toEqual({ hidden: true });
+  });
+
+  it("stays shown when the selection straddles the scrollport's top edge (still partly visible)", () => {
+    const container = { top: 100, bottom: 700 };
+    const rect = { top: 80, bottom: 140, right: 300, width: 200, height: 60 };
+    expect(computeCopyButtonPlacement(input({ container, rect }))).toMatchObject({ hidden: false });
   });
 });

--- a/tests/copy-button.test.ts
+++ b/tests/copy-button.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeCopyButtonPlacement,
+  type CopyButtonInput,
+} from "../app/src/renderer/chat/copy-button.js";
+
+const VIEWPORT = { width: 1000, height: 800 };
+
+function input(overrides: Partial<CopyButtonInput> = {}): CopyButtonInput {
+  return {
+    isCollapsed: false,
+    rangeCount: 1,
+    inContainer: true,
+    rect: { top: 100, bottom: 120, right: 300, width: 200, height: 20 },
+    viewport: VIEWPORT,
+    ...overrides,
+  };
+}
+
+describe("computeCopyButtonPlacement", () => {
+  it("shows the button below a normal selection", () => {
+    const p = computeCopyButtonPlacement(input());
+    expect(p).toEqual({ hidden: false, top: 124, left: 220 });
+  });
+
+  it("hides when the selection is collapsed", () => {
+    expect(computeCopyButtonPlacement(input({ isCollapsed: true }))).toEqual({
+      hidden: true,
+    });
+  });
+
+  it("hides when there is no range", () => {
+    expect(computeCopyButtonPlacement(input({ rangeCount: 0 }))).toEqual({
+      hidden: true,
+    });
+  });
+
+  it("hides when the selection is outside the chat container", () => {
+    expect(computeCopyButtonPlacement(input({ inContainer: false }))).toEqual({
+      hidden: true,
+    });
+  });
+
+  it("hides when the selection's client rect has zero area", () => {
+    const rect = { top: 0, bottom: 0, right: 0, width: 0, height: 0 };
+    expect(computeCopyButtonPlacement(input({ rect }))).toEqual({
+      hidden: true,
+    });
+  });
+
+  it("flips the button above the selection when it would overflow the bottom", () => {
+    const rect = { top: 760, bottom: 780, right: 300, width: 200, height: 20 };
+    expect(computeCopyButtonPlacement(input({ rect }))).toEqual({
+      hidden: false,
+      top: 728,
+      left: 220,
+    });
+  });
+
+  it("clamps the left edge so the button stays on-screen at the far left", () => {
+    const rect = { top: 100, bottom: 120, right: 40, width: 30, height: 20 };
+    expect(computeCopyButtonPlacement(input({ rect }))).toMatchObject({
+      hidden: false,
+      left: 4,
+    });
+  });
+
+  it("clamps the left edge so the button stays on-screen at the far right", () => {
+    const rect = { top: 100, bottom: 120, right: 1000, width: 200, height: 20 };
+    expect(computeCopyButtonPlacement(input({ rect }))).toMatchObject({
+      hidden: false,
+      left: 916,
+    });
+  });
+
+  // The bug: position is viewport-relative, so the same selection at a
+  // scrolled-up rect must yield a different top. This is what makes
+  // recomputing on scroll meaningful instead of leaving a stranded button.
+  it("follows the selection when it scrolls (different rect -> different top)", () => {
+    const before = computeCopyButtonPlacement(
+      input({ rect: { top: 380, bottom: 400, right: 300, width: 200, height: 20 } }),
+    );
+    const after = computeCopyButtonPlacement(
+      input({ rect: { top: 180, bottom: 200, right: 300, width: 200, height: 20 } }),
+    );
+    expect(before).toEqual({ hidden: false, top: 404, left: 220 });
+    expect(after).toEqual({ hidden: false, top: 204, left: 220 });
+  });
+});


### PR DESCRIPTION
Closes #299.

The floating "Copy" button that appears next to a chat text selection is `position: fixed` at the selection's viewport coords, but `updateBtn()` only recomputed on `mouseup` and `selectionchange`. The chat container is the scroller, and streaming autoscrolls it (via `scrollToBottom()`) without firing either event -- so once the selected text scrolls away, the button just freezes wherever it last sat, stranded in the middle of the pane. That's the "stuck in the middle, no way to dismiss" the tester saw.

The decision logic in `updateBtn()` was already fine -- it hides on a collapsed selection, no range, an out-of-container range, or a zero-area rect. The gap was purely *what re-triggers it*, plus there was no keyboard dismiss. So this:

- re-validates the button on container `scroll`, which repositions it to follow the selection or hides it once that scrolls off / collapses -- the actual fix for the stranding;
- adds Escape-to-dismiss, scoped to when the button is showing so it never clears a selection elsewhere (like a text input);
- pulls the visibility + position math into a small DOM-free `computeCopyButtonPlacement()` helper so it's unit-testable in the node test env (the app has no jsdom unit harness), matching the existing pure-helper pattern.

Tests: new `tests/copy-button.test.ts`, 9 cases -- normal show, the four hide guards, flip-above-when-near-the-bottom, left-edge clamping both sides, and a scroll-follow case that's the whole point. Full root suite green (851), `app` typecheck clean. Not live-eyeballed yet; it's renderer code covered by the helper unit tests.