### PR TITLE
Galaxy: reconnect on credential change + show the connected user in the status tooltip

### DIFF
--- a/app/src/main/galaxy-url.ts
+++ b/app/src/main/galaxy-url.ts
@@ -1,0 +1,49 @@
+/**
+ * Galaxy URL hygiene for the main process. Mirrors the brain's
+ * extensions/loom/profiles.ts validators: the brain guards the `/connect`
+ * path, this guards Orbit's config:save and the current-user fetch so a
+ * compromised renderer (or a hand-edited config) can't repoint the decrypted
+ * API key at an attacker URL or downgrade it to cleartext http.
+ */
+
+/** Default a scheme-less URL to https:// (users type bare hostnames). */
+export function normalizeGalaxyUrl(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) return trimmed;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)) return trimmed;
+  return `https://${trimmed}`;
+}
+
+/**
+ * A Galaxy URL is safe to send the API key to only over https, or over http
+ * when the host is loopback (local installs). Everything else is rejected so
+ * the key can't be exfiltrated to an attacker host or sent in cleartext.
+ */
+export function validateGalaxyUrl(url: string): { ok: true } | { ok: false; reason: string } {
+  let parsed: URL;
+  try {
+    parsed = new URL(url.trim());
+  } catch {
+    return { ok: false, reason: "Not a valid URL." };
+  }
+  if (parsed.protocol === "http:") {
+    const host = parsed.hostname.toLowerCase();
+    // Match real loopback only. A bare startsWith("127.") would also accept a
+    // resolvable hostname like "127.evil.example" -- a cleartext-exfil hole.
+    // URL.hostname keeps the brackets on an IPv6 literal ("[::1]").
+    const loopback =
+      host === "localhost" ||
+      /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) ||
+      host === "::1" ||
+      host === "[::1]";
+    if (loopback) return { ok: true };
+    return {
+      ok: false,
+      reason: "Galaxy URL must use https:// (the API key is sent on every request).",
+    };
+  }
+  if (parsed.protocol !== "https:") {
+    return { ok: false, reason: `Unsupported URL scheme: ${parsed.protocol}` };
+  }
+  return { ok: true };
+}

--- a/app/src/main/galaxy-user.ts
+++ b/app/src/main/galaxy-user.ts
@@ -1,0 +1,59 @@
+/**
+ * Fetch the current Galaxy user for the configured API key.
+ *
+ * Lives in the main process because that's the only place the plaintext key
+ * exists -- the renderer only ever sees the masked config. The renderer asks
+ * for this via the `galaxy:current-user` IPC and uses it to show *who* the key
+ * authenticates as in the status tooltip (not just the server URL).
+ *
+ * Returns a small discriminated result the tooltip formatter consumes directly:
+ *   - { ok: true, username?, email? }  the key authenticated; identity (if any)
+ *   - { ok: false, authFailed: true }  401/403 -- the key is wrong/expired
+ *   - { ok: false, authFailed: false } offline / timeout / 5xx / no creds
+ */
+import { validateGalaxyUrl } from "./galaxy-url.js";
+
+export type GalaxyUserStatus =
+  | { ok: true; username?: string; email?: string }
+  | { ok: false; authFailed: boolean };
+
+/** A non-empty string, or undefined -- Galaxy returns "" for unset fields. */
+function nonEmptyString(v: unknown): string | undefined {
+  return typeof v === "string" && v ? v : undefined;
+}
+
+export async function fetchGalaxyCurrentUser(
+  url: string,
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+  timeoutMs = 6000,
+): Promise<GalaxyUserStatus> {
+  const base = url.trim().replace(/\/+$/, "");
+  const key = apiKey.trim();
+  if (!base || !key) return { ok: false, authFailed: false };
+  // Never send the key to a non-https/non-loopback host, even if a legacy or
+  // hand-edited config slipped one past config:save validation.
+  if (!validateGalaxyUrl(base).ok) return { ok: false, authFailed: false };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchImpl(`${base}/api/users/current`, {
+      headers: { "x-api-key": key },
+      signal: controller.signal,
+    });
+    // 401/403 is the one failure worth surfacing -- a wrong or expired key.
+    // Everything else (offline, timeout, 5xx) stays silent so a transient blip
+    // doesn't cry "sign-in failed" on a perfectly good key.
+    if (res.status === 401 || res.status === 403) return { ok: false, authFailed: true };
+    if (!res.ok) return { ok: false, authFailed: false };
+    // Body isn't size-capped; the configured Galaxy server is semi-trusted and
+    // the timeout bounds wall time, so a pathological huge body is low risk.
+    const body = (await res.json()) as { username?: unknown; email?: unknown };
+    return { ok: true, username: nonEmptyString(body.username), email: nonEmptyString(body.email) };
+  } catch {
+    return { ok: false, authFailed: false };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -17,6 +17,8 @@ import {
   resolveGalaxyServerUrl,
   resolveGalaxyHistoryOpenUrl,
 } from "./galaxy-status.js";
+import { fetchGalaxyCurrentUser, type GalaxyUserStatus } from "./galaxy-user.js";
+import { normalizeGalaxyUrl, validateGalaxyUrl } from "./galaxy-url.js";
 import { getProviders, getModels } from "@earendil-works/pi-ai";
 import { isDeprecatedModelId } from "./model-catalog.js";
 import { checkLatestVersion } from "./version-check.js";
@@ -149,7 +151,15 @@ function reconcileIncomingConfig(incoming: Record<string, unknown>): LoomConfig 
     for (const [name, p] of Object.entries(incomingGalaxy.profiles || {})) {
       const existing = current.galaxy?.profiles?.[name];
       const rawKey = p.apiKey;
-      const profile: (typeof mergedProfiles)[string] = { url: p.url };
+      // Normalize + validate before the decrypted key is ever sent here -- the
+      // main process is the trust boundary, so a compromised renderer that
+      // reaches config:save still can't repoint the key at an http/attacker URL.
+      const url = p.url ? normalizeGalaxyUrl(p.url) : p.url;
+      if (url) {
+        const v = validateGalaxyUrl(url);
+        if (!v.ok) throw new Error(`Galaxy profile "${name}": ${v.reason}`);
+      }
+      const profile: (typeof mergedProfiles)[string] = { url };
       if (rawKey === UNCHANGED_SECRET || rawKey === undefined) {
         if (existing?.apiKeyEncrypted) profile.apiKeyEncrypted = existing.apiKeyEncrypted;
         if (existing?.apiKey) profile.apiKey = existing.apiKey;
@@ -321,6 +331,21 @@ export function registerIpcHandlers(agent: AgentManager): void {
   // masked config, so env-driven sessions read connected (#284).
   ipc.handle("galaxy:status", () => {
     return resolveGalaxyStatus(loadConfig(), process.env, resolveGalaxyApiKey);
+  });
+
+  // Who does the active Galaxy key authenticate as? The renderer can't ask
+  // Galaxy itself -- it never sees the plaintext key (config:get is masked) --
+  // so main resolves the active profile's url + decrypted key and asks Galaxy.
+  // Used to show the connected account in the status tooltip. Registered via the
+  // idempotent ipc wrapper (#327) so reopen doesn't throw on a duplicate handler.
+  ipc.handle("galaxy:current-user", async (): Promise<GalaxyUserStatus> => {
+    const cfg = loadConfig();
+    const active = cfg.galaxy?.active;
+    const profile = active ? cfg.galaxy?.profiles?.[active] : undefined;
+    const url = profile?.url;
+    const key = resolveGalaxyApiKey(cfg);
+    if (!url || !key) return { ok: false, authFailed: false };
+    return fetchGalaxyCurrentUser(url, key);
   });
 
   ipc.handle(

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -76,6 +76,7 @@ export interface OrbitAPI {
   onFilesChanged(callback: (changedPaths: string[] | null) => void): () => void;
   getConfig(): Promise<Record<string, unknown>>;
   saveConfig(config: Record<string, unknown>): Promise<{ success: boolean; error?: string }>;
+  getGalaxyUser(): Promise<import("../main/galaxy-user.js").GalaxyUserStatus>;
   setBypassPermissions(
     enabled: boolean,
   ): Promise<{ ok: boolean; enabled: boolean; cancelled?: boolean }>;
@@ -180,6 +181,7 @@ const api: OrbitAPI = {
   },
   getConfig: () => ipcRenderer.invoke("config:get"),
   saveConfig: (config) => ipcRenderer.invoke("config:save", config),
+  getGalaxyUser: () => ipcRenderer.invoke("galaxy:current-user"),
   setBypassPermissions: (enabled) => ipcRenderer.invoke("guardian:set-bypass", enabled),
   validateApiKey: (provider, key, baseUrl) =>
     ipcRenderer.invoke("apiKey:validate", provider, key, baseUrl),

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -12,6 +12,7 @@ import { shouldRefreshOpenFile } from "./files/file-change-match.js";
 import { FeedbackConfirmation } from "./feedback-confirmation.js";
 import { refreshGalaxyInvocations } from "./galaxy-invocations.js";
 import { refreshGalaxyHistory } from "./galaxy-history.js";
+import { formatGalaxyTooltip } from "./galaxy-tooltip.js";
 import { PromptQueue, queuedPreview } from "./prompt-queue.js";
 import { FeedbackDraftStore } from "./feedback-draft.js";
 import { caretVisualLineFlags, shouldRecallOnArrow } from "./input-history-nav.js";
@@ -618,32 +619,46 @@ window.orbit.onFilesChanged((changedPaths) => {
 
 const galaxyStatus = document.getElementById("galaxy-status")!;
 
+// Bumped on every refresh so a superseded refresh (profile switch / disconnect)
+// can't clobber the latest tooltip -- captured before the first await, so a
+// late-resolving getConfig also can't overwrite newer state.
+let galaxyStatusSeq = 0;
+
+function setGalaxyTooltip(text: string): void {
+  galaxyStatus.title = text;
+  galaxyStatus.setAttribute("aria-label", `${text}. Click to open Preferences.`);
+}
+
 async function refreshGalaxyStatus(): Promise<void> {
+  const seq = ++galaxyStatusSeq;
   // Reflect the *effective* connection the brain sees -- a usable URL + API key
   // whether they came from a saved profile or exported GALAXY_URL/GALAXY_API_KEY
   // env vars. Deriving "connected" from the masked config alone missed the
   // env-driven / auto-connect path, leaving the dot red even though the URL was
   // known and tool calls worked (#284).
   const { connected, url } = await window.orbit.getGalaxyStatus();
+  // A newer refresh started while we awaited -- let it win.
+  if (seq !== galaxyStatusSeq) return;
 
-  if (connected) {
+  if (connected && url) {
     galaxyStatus.classList.add("status-dot-connected");
     galaxyStatus.classList.remove("status-dot-disconnected");
-    galaxyStatus.title = `Galaxy: ${url}`;
-    // Keep the accessible name in sync -- the issue's "not configured" string
-    // is the aria-label, which previously never tracked connection state.
-    galaxyStatus.setAttribute(
-      "aria-label",
-      `Galaxy connection: ${url}. Click to open Preferences.`,
-    );
+    // Show the server immediately, then upgrade to "(username)" once we've
+    // asked Galaxy who the key authenticates as. The key lives only in main,
+    // so the lookup round-trips through the galaxy:current-user IPC.
+    setGalaxyTooltip(formatGalaxyTooltip(url));
+    void window.orbit
+      .getGalaxyUser()
+      .then((user) => {
+        if (seq === galaxyStatusSeq) setGalaxyTooltip(formatGalaxyTooltip(url, user));
+      })
+      .catch(() => {
+        /* leave the url-only tooltip in place */
+      });
   } else {
     galaxyStatus.classList.add("status-dot-disconnected");
     galaxyStatus.classList.remove("status-dot-connected");
-    galaxyStatus.title = "Galaxy: not configured (open Preferences to add a profile)";
-    galaxyStatus.setAttribute(
-      "aria-label",
-      "Galaxy connection: not configured. Click to open Preferences.",
-    );
+    setGalaxyTooltip("Galaxy: not configured (open Preferences to add a profile)");
   }
 
   // The Galaxy history section is driven off the same connection signal so it

--- a/app/src/renderer/galaxy-tooltip.ts
+++ b/app/src/renderer/galaxy-tooltip.ts
@@ -1,0 +1,23 @@
+import type { GalaxyUserStatus } from "../main/galaxy-user.js";
+
+/**
+ * Build the Galaxy status tooltip. The base is always the server URL; when we
+ * know who the key authenticates as, we append the identity so the connected
+ * Galaxy account is glanceable (not just the server).
+ *
+ *   no user yet  -> "Galaxy: <url>"
+ *   connected    -> "Galaxy: <url> (dannon)"        (username, else email)
+ *   auth failed  -> "Galaxy: <url> (sign-in failed)"
+ *
+ * Type-only import of GalaxyUserStatus -- erased at build, so the renderer never
+ * pulls in any main-process runtime code.
+ */
+export function formatGalaxyTooltip(url: string, user?: GalaxyUserStatus | null): string {
+  const base = `Galaxy: ${url}`;
+  if (!user) return base;
+  if (user.ok) {
+    const identity = user.username || user.email;
+    return identity ? `${base} (${identity})` : base;
+  }
+  return user.authFailed ? `${base} (sign-in failed)` : base;
+}

--- a/extensions/loom/agent-dir.ts
+++ b/extensions/loom/agent-dir.ts
@@ -1,0 +1,11 @@
+import * as path from "path";
+import * as os from "os";
+
+/**
+ * Resolve pi's agent directory -- where mcp.json, sessions, and Loom's own
+ * per-cwd state live. Honors PI_CODING_AGENT_DIR (set in tests and custom
+ * setups), else ~/.pi/agent.
+ */
+export function piAgentDir(): string {
+  return process.env.PI_CODING_AGENT_DIR || path.join(os.homedir(), ".pi", "agent");
+}

--- a/extensions/loom/galaxy-cred-drift.ts
+++ b/extensions/loom/galaxy-cred-drift.ts
@@ -1,0 +1,164 @@
+/**
+ * Galaxy credential-drift reconnect.
+ *
+ * The galaxy MCP connection is established by the model *choosing* to call
+ * `galaxy_connect()`, and the only thing that prompts it is the startup
+ * greeting -- which is suppressed on a `--continue` resume (see
+ * session-lifecycle.ts). So when the user rotates their Galaxy API key (or
+ * switches server/account) in Orbit's Preferences, the brain restarts with the
+ * new credentials in its env, but the resumed model still believes it's
+ * connected as the *old* account from the replayed transcript and never
+ * rebinds. The result: galaxy tools keep acting as the previous key's user.
+ *
+ * This module closes that gap. On session_start we fingerprint the active
+ * credentials and compare against a per-cwd baseline -- the creds the model
+ * last *confirmed* a connection with. On a resume where the fingerprint
+ * changed, we nudge the model to call `galaxy_connect()` so it rebinds. The
+ * baseline only advances on a confirmed connect (recordGalaxyConnected), so an
+ * ignored nudge or a crash before the reconnect lands can't mask the drift.
+ *
+ * The fingerprint is a one-way hash of url+key, so the raw key never lands on
+ * disk -- only an opaque digest used for equality checks.
+ */
+
+import { createHash } from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { activeGalaxyStatus } from "./profiles.js";
+import { piAgentDir } from "./agent-dir.js";
+
+export const GALAXY_RECONNECT_NUDGE =
+  "Your Galaxy credentials changed since this session was last active -- a different " +
+  "server or account is now configured, so the previous connection is no longer valid. " +
+  "Call galaxy_connect() to rebind, then confirm in one short sentence which Galaxy " +
+  "account is now active. Do NOT use other Galaxy tools until reconnected.";
+
+/**
+ * Opaque, stable fingerprint of a (url, key) pair. SHA-256 so the raw key is
+ * never recoverable from the stored value. url and key are fed as separate
+ * hash updates split by a newline, which neither a URL nor an API key can
+ * contain -- so ("ab","c") can't collide with ("a","bc").
+ */
+export function galaxyCredFingerprint(url: string, apiKey: string): string {
+  return createHash("sha256").update(url).update("\n").update(apiKey).digest("hex");
+}
+
+export interface CredDriftInput {
+  /** Fingerprint persisted by a prior session in this cwd (null = first run). */
+  stored: string | null;
+  /** Fingerprint of the credentials active now (null = galaxy not usable). */
+  current: string | null;
+  /** True on a `--continue` resume, where the startup greeting is suppressed. */
+  isResume: boolean;
+}
+
+/**
+ * Decide whether to nudge a reconnect. Pure.
+ *
+ * Only fires on a resume (fresh starts get the greeting, which already prompts
+ * galaxy_connect), only when there are usable creds to reconnect *to*, and only
+ * when a baseline exists to prove the creds actually changed.
+ */
+export function shouldNudgeReconnect({ stored, current, isResume }: CredDriftInput): boolean {
+  if (!isResume) return false;
+  if (!current) return false;
+  if (!stored) return false;
+  return stored !== current;
+}
+
+/** Encode a cwd into a single filesystem-safe path segment. */
+function encodeCwd(cwd: string): string {
+  // A readable slug prefix for debuggability, plus a hash of the *full* cwd for
+  // uniqueness -- the slug substitution alone collides (e.g. `/a-b/c` and
+  // `/a/b-c` both slug to `a-b-c`), so the hash is what keeps distinct cwds in
+  // distinct files. The slug is also capped so the filename can't overrun the
+  // OS limit.
+  const hash = createHash("sha256").update(cwd).digest("hex").slice(0, 12);
+  const slug =
+    cwd
+      .replace(/^[/\\]/, "")
+      .replace(/[/\\:]/g, "-")
+      .slice(0, 64) || "root";
+  return `${slug}-${hash}`;
+}
+
+/**
+ * Per-cwd path where this cwd's credential fingerprint is persisted. Keyed by
+ * cwd (not session id) because credentials are global and the question is "did
+ * this project's creds change since it last connected." Caveat: two windows on
+ * the *same* cwd share one baseline, so the first to restart after a change can
+ * satisfy the second's check -- acceptable since one-window-per-project is the
+ * norm.
+ */
+export function fingerprintPath(cwd: string, agentDir: string = piAgentDir()): string {
+  return path.join(agentDir, "galaxy-cred-fp", `${encodeCwd(cwd)}.txt`);
+}
+
+export function readStoredFingerprint(filePath: string): string | null {
+  try {
+    const v = fs.readFileSync(filePath, "utf-8").trim();
+    return v || null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredFingerprint(filePath: string, fingerprint: string): void {
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    // 0600: a credential digest is low-risk but there's no reason to let other
+    // users on a shared machine read it.
+    fs.writeFileSync(filePath, fingerprint, { mode: 0o600 });
+  } catch (err) {
+    console.error("galaxy cred fingerprint write failed:", err);
+  }
+}
+
+export interface ReconnectOptions {
+  isResume: boolean;
+  cwd?: string;
+}
+
+/** Fingerprint of the credentials active in this process's env, or null when
+ *  Galaxy isn't usable. */
+function currentGalaxyFingerprint(): string | null {
+  const url = process.env.GALAXY_URL;
+  const key = process.env.GALAXY_API_KEY;
+  // The `url && key` guard narrows both to string for the fingerprint call.
+  return activeGalaxyStatus() === "usable" && url && key ? galaxyCredFingerprint(url, key) : null;
+}
+
+/**
+ * Session_start hook: on a resume where the Galaxy account/server changed since
+ * the last *confirmed* connect, nudge the model to reconnect.
+ */
+export function maybeNudgeGalaxyReconnect(pi: ExtensionAPI, opts: ReconnectOptions): void {
+  const cwd = opts.cwd ?? process.cwd();
+  const current = currentGalaxyFingerprint();
+  const fpPath = fingerprintPath(cwd);
+  const stored = readStoredFingerprint(fpPath);
+
+  if (shouldNudgeReconnect({ stored, current, isResume: opts.isResume })) {
+    pi.sendUserMessage(GALAXY_RECONNECT_NUDGE);
+  }
+
+  // Seed an initial baseline the first time usable creds appear, but NEVER
+  // overwrite an existing one here. The baseline only advances on a confirmed
+  // galaxy_connect (recordGalaxyConnected), so an ignored nudge or a crash
+  // before the reconnect lands can't mask the drift -- the next resume
+  // re-nudges until the model actually reconnects.
+  if (current && stored === null) writeStoredFingerprint(fpPath, current);
+}
+
+/**
+ * Record that the model successfully (re)connected to Galaxy with the current
+ * credentials. This advances the drift baseline so a later key/server change
+ * registers as drift on the next resume. Call from the galaxy_connect success
+ * hook -- advancing only on confirmed connect is what keeps an unacted nudge
+ * from permanently suppressing future ones.
+ */
+export function recordGalaxyConnected(cwd: string = process.cwd()): void {
+  const current = currentGalaxyFingerprint();
+  if (current) writeStoredFingerprint(fingerprintPath(cwd), current);
+}

--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -15,6 +15,7 @@ import { registerSyncCommand } from "./sync-command";
 import { setupContextInjection, formatConnectionStatus } from "./context";
 import { setupUIBridge } from "./ui-bridge";
 import { registerSessionLifecycle } from "./session-lifecycle";
+import { recordGalaxyConnected } from "./galaxy-cred-drift";
 import { registerActivityHooks } from "./activity-hooks";
 import { registerExecutionCommands } from "./execution-commands";
 import { registerFeedbackCommand } from "./feedback-command";
@@ -377,6 +378,12 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
     }
 
     if (event.toolName === "galaxy_connect" && !event.isError) {
+      // A non-error galaxy_connect means we're now bound to the current env
+      // creds (galaxy-mcp raises on failure -> isError), so advance the
+      // credential-drift baseline. Keyed off isError, not the loose success
+      // string below, which both false-matches ("unsuccessful") and would miss
+      // a success that omits the literal.
+      recordGalaxyConnected();
       try {
         const resultText =
           typeof event.result === "string" ? event.result : JSON.stringify(event.result);

--- a/extensions/loom/profiles.ts
+++ b/extensions/loom/profiles.ts
@@ -10,8 +10,8 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import * as os from "os";
 import { loadConfig, saveConfig } from "./config";
+import { piAgentDir } from "./agent-dir.js";
 
 export interface GalaxyProfile {
   url: string;
@@ -115,6 +115,15 @@ export function normalizeGalaxyUrl(url: string): string {
   return `https://${trimmed}`;
 }
 
+/**
+ * True for an IPv4 loopback (127.0.0.0/8), localhost, or IPv6 ::1. A bare
+ * `startsWith("127.")` would wrongly accept a resolvable hostname like
+ * `127.evil.example`, which over http would leak the API key in cleartext.
+ */
+function isLoopbackHost(host: string): boolean {
+  return host === "localhost" || /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) || host === "::1";
+}
+
 export function validateGalaxyUrl(url: string): { ok: true } | { ok: false; reason: string } {
   let parsed: URL;
   try {
@@ -124,7 +133,7 @@ export function validateGalaxyUrl(url: string): { ok: true } | { ok: false; reas
   }
   if (parsed.protocol === "http:") {
     const host = parsed.hostname.toLowerCase();
-    if (host === "localhost" || host.startsWith("127.") || host === "::1") {
+    if (isLoopbackHost(host)) {
       // Loopback HTTP is fine for local Galaxy installs.
       return { ok: true };
     }
@@ -153,11 +162,7 @@ export function saveProfile(name: string, url: string, apiKey: string): void {
   if (!v.ok) throw new Error(v.reason);
   const host = new URL(url).hostname.toLowerCase();
   const trusted =
-    host === "localhost" ||
-    host.startsWith("127.") ||
-    host === "::1" ||
-    host === "galaxyproject.org" ||
-    host.endsWith(".galaxyproject.org");
+    isLoopbackHost(host) || host === "galaxyproject.org" || host.endsWith(".galaxyproject.org");
   if (!trusted) {
     console.warn(
       `[galaxy] Profile "${name}" points at ${host} (not a galaxyproject.org subdomain).`,
@@ -286,8 +291,7 @@ export function deleteProfile(name: string): boolean {
  */
 export function syncMcpConfig(url: string): void {
   try {
-    const agentDir = process.env.PI_CODING_AGENT_DIR || path.join(os.homedir(), ".pi", "agent");
-    const mcpPath = path.join(agentDir, "mcp.json");
+    const mcpPath = path.join(piAgentDir(), "mcp.json");
     if (!fs.existsSync(mcpPath)) return;
 
     const config = JSON.parse(fs.readFileSync(mcpPath, "utf-8"));

--- a/extensions/loom/session-lifecycle.ts
+++ b/extensions/loom/session-lifecycle.ts
@@ -14,6 +14,7 @@ import {
   type SessionSummaryYaml,
 } from "./notebook-writer.js";
 import { activeGalaxyStatus, type ActiveGalaxyStatus } from "./profiles.js";
+import { maybeNudgeGalaxyReconnect } from "./galaxy-cred-drift.js";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -54,8 +55,16 @@ export function registerSessionLifecycle(pi: ExtensionAPI): void {
     };
 
     const freshSession = process.env.LOOM_FRESH_SESSION === "1";
+    const isResume = process.argv.includes("--continue");
 
-    if (freshSession || process.argv.includes("--continue")) {
+    // Galaxy credential drift: on a resume the startup greeting -- the only
+    // thing that prompts galaxy_connect() -- is suppressed, so a key/server
+    // change made while this session was idle would leave the model believing
+    // it's still connected as the old account. Refresh the per-cwd credential
+    // baseline and, on a resume where it changed, nudge a reconnect.
+    maybeNudgeGalaxyReconnect(pi, { isResume });
+
+    if (freshSession || isResume) {
       return;
     }
 

--- a/tests/galaxy-cred-drift.test.ts
+++ b/tests/galaxy-cred-drift.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import {
+  galaxyCredFingerprint,
+  shouldNudgeReconnect,
+  fingerprintPath,
+  readStoredFingerprint,
+  writeStoredFingerprint,
+  maybeNudgeGalaxyReconnect,
+  recordGalaxyConnected,
+} from "../extensions/loom/galaxy-cred-drift.js";
+
+describe("galaxyCredFingerprint", () => {
+  it("is stable for the same url+key", () => {
+    const a = galaxyCredFingerprint("https://x.galaxyproject.org", "key-A");
+    const b = galaxyCredFingerprint("https://x.galaxyproject.org", "key-A");
+    expect(a).toBe(b);
+  });
+
+  it("changes when the key changes (same url)", () => {
+    const a = galaxyCredFingerprint("https://x.galaxyproject.org", "key-A");
+    const b = galaxyCredFingerprint("https://x.galaxyproject.org", "key-B");
+    expect(a).not.toBe(b);
+  });
+
+  it("changes when the url changes (same key)", () => {
+    const a = galaxyCredFingerprint("https://a.galaxyproject.org", "key-A");
+    const b = galaxyCredFingerprint("https://b.galaxyproject.org", "key-A");
+    expect(a).not.toBe(b);
+  });
+
+  it("does not embed the raw key (one-way hash)", () => {
+    const fp = galaxyCredFingerprint("https://x.galaxyproject.org", "super-secret-key");
+    expect(fp).not.toContain("super-secret-key");
+  });
+});
+
+describe("shouldNudgeReconnect", () => {
+  const fpA = galaxyCredFingerprint("https://x.galaxyproject.org", "key-A");
+  const fpB = galaxyCredFingerprint("https://x.galaxyproject.org", "key-B");
+
+  it("nudges on a resume when creds changed and a baseline exists", () => {
+    expect(shouldNudgeReconnect({ stored: fpA, current: fpB, isResume: true })).toBe(true);
+  });
+
+  it("stays quiet on a resume when creds are unchanged", () => {
+    expect(shouldNudgeReconnect({ stored: fpA, current: fpA, isResume: true })).toBe(false);
+  });
+
+  it("stays quiet on the first resume (no stored baseline)", () => {
+    expect(shouldNudgeReconnect({ stored: null, current: fpA, isResume: true })).toBe(false);
+  });
+
+  it("stays quiet when galaxy is no longer usable (no current creds)", () => {
+    expect(shouldNudgeReconnect({ stored: fpA, current: null, isResume: true })).toBe(false);
+  });
+
+  it("stays quiet on a fresh start even if creds changed (greeting handles it)", () => {
+    expect(shouldNudgeReconnect({ stored: fpA, current: fpB, isResume: false })).toBe(false);
+  });
+});
+
+describe("fingerprint persistence", () => {
+  let agentDir: string;
+
+  beforeEach(() => {
+    agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "loom-creddrift-fp-"));
+  });
+  afterEach(() => {
+    try {
+      fs.rmSync(agentDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it("round-trips a fingerprint per cwd", () => {
+    const p = fingerprintPath("/Users/me/work/projectA", agentDir);
+    expect(readStoredFingerprint(p)).toBeNull();
+    writeStoredFingerprint(p, "deadbeef");
+    expect(readStoredFingerprint(p)).toBe("deadbeef");
+  });
+
+  it("keeps fingerprints for different cwds separate", () => {
+    const a = fingerprintPath("/Users/me/work/projectA", agentDir);
+    const b = fingerprintPath("/Users/me/work/projectB", agentDir);
+    writeStoredFingerprint(a, "fpA");
+    writeStoredFingerprint(b, "fpB");
+    expect(readStoredFingerprint(a)).toBe("fpA");
+    expect(readStoredFingerprint(b)).toBe("fpB");
+  });
+
+  it("does not collide cwds that slug to the same segment", () => {
+    // Both paths reduce to the slug "tmp-a-b-c" under separator substitution;
+    // the full-cwd hash must keep them in distinct files.
+    expect(fingerprintPath("/tmp/a-b/c", agentDir)).not.toBe(
+      fingerprintPath("/tmp/a/b-c", agentDir),
+    );
+  });
+
+  it("never writes the raw key to disk", () => {
+    const p = fingerprintPath("/Users/me/work/projectA", agentDir);
+    writeStoredFingerprint(p, galaxyCredFingerprint("https://x.galaxyproject.org", "leaky-key"));
+    expect(fs.readFileSync(p, "utf-8")).not.toContain("leaky-key");
+  });
+});
+
+// Integration: maybeNudgeGalaxyReconnect reads the live env (GALAXY_URL/KEY),
+// compares against the per-cwd baseline in the sandboxed agent dir, nudges via
+// a fake pi, and always refreshes the baseline. Mirrors the startup-greeting
+// dispatch tests: sandbox HOME + PI_CODING_AGENT_DIR so nothing leaks to disk.
+describe("maybeNudgeGalaxyReconnect (dispatch)", () => {
+  let prevHome: string | undefined;
+  let prevUserProfile: string | undefined;
+  let sandboxHome: string;
+  let agentDir: string;
+  const cwd = "/Users/me/work/projectA";
+
+  beforeEach(() => {
+    prevHome = process.env.HOME;
+    prevUserProfile = process.env.USERPROFILE;
+    sandboxHome = fs.mkdtempSync(path.join(os.tmpdir(), "loom-creddrift-"));
+    agentDir = path.join(sandboxHome, ".pi", "agent");
+    fs.mkdirSync(agentDir, { recursive: true });
+    process.env.HOME = sandboxHome;
+    process.env.USERPROFILE = sandboxHome;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
+    delete process.env.GALAXY_URL;
+    delete process.env.GALAXY_API_KEY;
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevUserProfile;
+    delete process.env.GALAXY_URL;
+    delete process.env.GALAXY_API_KEY;
+    delete process.env.PI_CODING_AGENT_DIR;
+    try {
+      fs.rmSync(sandboxHome, { recursive: true, force: true });
+    } catch {}
+  });
+
+  function pi() {
+    return { sendUserMessage: vi.fn() } as { sendUserMessage: ReturnType<typeof vi.fn> };
+  }
+
+  it("first resume writes a baseline and does not nudge", () => {
+    process.env.GALAXY_URL = "https://x.galaxyproject.org";
+    process.env.GALAXY_API_KEY = "key-A";
+    const fake = pi();
+    maybeNudgeGalaxyReconnect(fake as never, { isResume: true, cwd });
+    expect(fake.sendUserMessage).not.toHaveBeenCalled();
+    expect(readStoredFingerprint(fingerprintPath(cwd, agentDir))).toBe(
+      galaxyCredFingerprint("https://x.galaxyproject.org", "key-A"),
+    );
+  });
+
+  it("nudges on a resume after the key changed but does NOT advance the baseline", () => {
+    const fpPath = fingerprintPath(cwd, agentDir);
+    writeStoredFingerprint(fpPath, galaxyCredFingerprint("https://x.galaxyproject.org", "key-A"));
+    process.env.GALAXY_URL = "https://x.galaxyproject.org";
+    process.env.GALAXY_API_KEY = "key-B";
+    const fake = pi();
+    maybeNudgeGalaxyReconnect(fake as never, { isResume: true, cwd });
+    expect(fake.sendUserMessage).toHaveBeenCalledTimes(1);
+    expect(fake.sendUserMessage.mock.calls[0][0]).toContain("galaxy_connect");
+    // Baseline stays at key-A until a confirmed connect, so a crash or an
+    // ignored nudge leaves the next resume free to nudge again.
+    expect(readStoredFingerprint(fpPath)).toBe(
+      galaxyCredFingerprint("https://x.galaxyproject.org", "key-A"),
+    );
+  });
+
+  it("does not nudge on a resume when the key is unchanged", () => {
+    writeStoredFingerprint(
+      fingerprintPath(cwd, agentDir),
+      galaxyCredFingerprint("https://x.galaxyproject.org", "key-A"),
+    );
+    process.env.GALAXY_URL = "https://x.galaxyproject.org";
+    process.env.GALAXY_API_KEY = "key-A";
+    const fake = pi();
+    maybeNudgeGalaxyReconnect(fake as never, { isResume: true, cwd });
+    expect(fake.sendUserMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not nudge on a non-resume start even when the key changed", () => {
+    writeStoredFingerprint(
+      fingerprintPath(cwd, agentDir),
+      galaxyCredFingerprint("https://x.galaxyproject.org", "key-A"),
+    );
+    process.env.GALAXY_URL = "https://x.galaxyproject.org";
+    process.env.GALAXY_API_KEY = "key-B";
+    const fake = pi();
+    maybeNudgeGalaxyReconnect(fake as never, { isResume: false, cwd });
+    expect(fake.sendUserMessage).not.toHaveBeenCalled();
+    // session_start never overwrites an existing baseline; only a confirmed
+    // connect does. So it stays at key-A here.
+    expect(readStoredFingerprint(fingerprintPath(cwd, agentDir))).toBe(
+      galaxyCredFingerprint("https://x.galaxyproject.org", "key-A"),
+    );
+  });
+
+  it("does not nudge when galaxy is not configured (no env creds)", () => {
+    const fake = pi();
+    maybeNudgeGalaxyReconnect(fake as never, { isResume: true, cwd });
+    expect(fake.sendUserMessage).not.toHaveBeenCalled();
+  });
+
+  it("recordGalaxyConnected advances the baseline to the current env creds", () => {
+    writeStoredFingerprint(
+      fingerprintPath(cwd, agentDir),
+      galaxyCredFingerprint("https://x.galaxyproject.org", "key-A"),
+    );
+    process.env.GALAXY_URL = "https://x.galaxyproject.org";
+    process.env.GALAXY_API_KEY = "key-B";
+    recordGalaxyConnected(cwd);
+    expect(readStoredFingerprint(fingerprintPath(cwd, agentDir))).toBe(
+      galaxyCredFingerprint("https://x.galaxyproject.org", "key-B"),
+    );
+  });
+
+  it("recordGalaxyConnected is a no-op when galaxy creds are absent", () => {
+    recordGalaxyConnected(cwd);
+    expect(readStoredFingerprint(fingerprintPath(cwd, agentDir))).toBeNull();
+  });
+});

--- a/tests/galaxy-url-validation.test.ts
+++ b/tests/galaxy-url-validation.test.ts
@@ -18,6 +18,11 @@ describe("validateGalaxyUrl", () => {
     if (!r.ok) expect(r.reason).toMatch(/https/);
   });
 
+  it("rejects a resolvable hostname masquerading as loopback (127.x must be numeric)", () => {
+    expect(validateGalaxyUrl("http://127.evil.example").ok).toBe(false);
+    expect(validateGalaxyUrl("http://127.0.0.1.evil.example").ok).toBe(false);
+  });
+
   it("rejects malformed URLs", () => {
     expect(validateGalaxyUrl("not a url").ok).toBe(false);
     expect(validateGalaxyUrl("").ok).toBe(false);

--- a/tests/galaxy-url.test.ts
+++ b/tests/galaxy-url.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { normalizeGalaxyUrl, validateGalaxyUrl } from "../app/src/main/galaxy-url.js";
+
+describe("normalizeGalaxyUrl", () => {
+  it("adds https:// to a scheme-less host", () => {
+    expect(normalizeGalaxyUrl("test.galaxyproject.org")).toBe("https://test.galaxyproject.org");
+  });
+
+  it("preserves an explicit scheme", () => {
+    expect(normalizeGalaxyUrl("https://x.org")).toBe("https://x.org");
+    expect(normalizeGalaxyUrl("http://localhost:8080")).toBe("http://localhost:8080");
+  });
+
+  it("leaves an empty string empty", () => {
+    expect(normalizeGalaxyUrl("  ")).toBe("");
+  });
+});
+
+describe("validateGalaxyUrl", () => {
+  it("accepts https to any host", () => {
+    expect(validateGalaxyUrl("https://usegalaxy.org").ok).toBe(true);
+    expect(validateGalaxyUrl("https://my-institution.example").ok).toBe(true);
+  });
+
+  it("accepts http only for loopback", () => {
+    expect(validateGalaxyUrl("http://localhost:8080").ok).toBe(true);
+    expect(validateGalaxyUrl("http://127.0.0.1:9000").ok).toBe(true);
+    expect(validateGalaxyUrl("http://[::1]:8080").ok).toBe(true);
+  });
+
+  it("rejects cleartext http to a non-loopback host (the exfil/downgrade case)", () => {
+    const r = validateGalaxyUrl("http://evil.example/api");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/https/i);
+  });
+
+  it("rejects a resolvable hostname masquerading as loopback (127.x must be a numeric IP)", () => {
+    expect(validateGalaxyUrl("http://127.evil.example").ok).toBe(false);
+    expect(validateGalaxyUrl("http://127.0.0.1.evil.example").ok).toBe(false);
+  });
+
+  it("rejects non-http(s) schemes", () => {
+    expect(validateGalaxyUrl("ftp://host/x").ok).toBe(false);
+    expect(validateGalaxyUrl("file:///etc/passwd").ok).toBe(false);
+  });
+
+  it("rejects an unparseable URL", () => {
+    expect(validateGalaxyUrl("not a url").ok).toBe(false);
+  });
+});

--- a/tests/galaxy-user.test.ts
+++ b/tests/galaxy-user.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from "vitest";
+import { fetchGalaxyCurrentUser } from "../app/src/main/galaxy-user.js";
+import { formatGalaxyTooltip } from "../app/src/renderer/galaxy-tooltip.js";
+
+describe("formatGalaxyTooltip", () => {
+  const U = "https://test.galaxyproject.org";
+
+  it("shows the url alone when there's no user info yet", () => {
+    expect(formatGalaxyTooltip(U)).toBe(`Galaxy: ${U}`);
+    expect(formatGalaxyTooltip(U, null)).toBe(`Galaxy: ${U}`);
+  });
+
+  it("appends the username when connected", () => {
+    expect(formatGalaxyTooltip(U, { ok: true, username: "dannon" })).toBe(`Galaxy: ${U} (dannon)`);
+  });
+
+  it("falls back to email when there's no username", () => {
+    expect(formatGalaxyTooltip(U, { ok: true, email: "dannon@lab.org" })).toBe(
+      `Galaxy: ${U} (dannon@lab.org)`,
+    );
+  });
+
+  it("prefers username over email when both are present", () => {
+    expect(formatGalaxyTooltip(U, { ok: true, username: "dannon", email: "dannon@lab.org" })).toBe(
+      `Galaxy: ${U} (dannon)`,
+    );
+  });
+
+  it("shows url alone when connected but the account has no public identity", () => {
+    expect(formatGalaxyTooltip(U, { ok: true })).toBe(`Galaxy: ${U}`);
+  });
+
+  it("flags an auth failure", () => {
+    expect(formatGalaxyTooltip(U, { ok: false, authFailed: true })).toBe(
+      `Galaxy: ${U} (sign-in failed)`,
+    );
+  });
+
+  it("stays silent (url only) on a non-auth failure", () => {
+    expect(formatGalaxyTooltip(U, { ok: false, authFailed: false })).toBe(`Galaxy: ${U}`);
+  });
+});
+
+describe("fetchGalaxyCurrentUser", () => {
+  const U = "https://test.galaxyproject.org";
+  const KEY = "secret-key";
+
+  function jsonResponse(status: number, body: unknown): Response {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    } as Response;
+  }
+
+  it("returns username + email from /api/users/current with the x-api-key header", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(200, { username: "dannon", email: "dannon@lab.org", id: "abc" }),
+    );
+    const result = await fetchGalaxyCurrentUser(U, KEY, fetchImpl as unknown as typeof fetch);
+    expect(result).toEqual({ ok: true, username: "dannon", email: "dannon@lab.org" });
+    const [calledUrl, init] = fetchImpl.mock.calls[0];
+    expect(calledUrl).toBe(`${U}/api/users/current`);
+    expect((init as RequestInit).headers).toMatchObject({ "x-api-key": KEY });
+  });
+
+  it("strips a trailing slash from the base url", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, { username: "dannon" }));
+    await fetchGalaxyCurrentUser(`${U}/`, KEY, fetchImpl as unknown as typeof fetch);
+    expect(fetchImpl.mock.calls[0][0]).toBe(`${U}/api/users/current`);
+  });
+
+  it("treats an empty username as no public identity", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, { username: "", email: "" }));
+    const result = await fetchGalaxyCurrentUser(U, KEY, fetchImpl as unknown as typeof fetch);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("reports an auth failure on 401", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(401, {}));
+    expect(await fetchGalaxyCurrentUser(U, KEY, fetchImpl as unknown as typeof fetch)).toEqual({
+      ok: false,
+      authFailed: true,
+    });
+  });
+
+  it("reports an auth failure on 403", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(403, {}));
+    expect(await fetchGalaxyCurrentUser(U, KEY, fetchImpl as unknown as typeof fetch)).toEqual({
+      ok: false,
+      authFailed: true,
+    });
+  });
+
+  it("stays silent on a non-auth HTTP error (5xx)", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(503, {}));
+    expect(await fetchGalaxyCurrentUser(U, KEY, fetchImpl as unknown as typeof fetch)).toEqual({
+      ok: false,
+      authFailed: false,
+    });
+  });
+
+  it("stays silent on a network/timeout error", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    expect(await fetchGalaxyCurrentUser(U, KEY, fetchImpl as unknown as typeof fetch)).toEqual({
+      ok: false,
+      authFailed: false,
+    });
+  });
+
+  it("does not send the key to a non-https/non-loopback url", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, { username: "x" }));
+    expect(
+      await fetchGalaxyCurrentUser(
+        "http://evil.example",
+        KEY,
+        fetchImpl as unknown as typeof fetch,
+      ),
+    ).toEqual({ ok: false, authFailed: false });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("does not call the network when url or key is missing", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, {}));
+    expect(await fetchGalaxyCurrentUser("", KEY, fetchImpl as unknown as typeof fetch)).toEqual({
+      ok: false,
+      authFailed: false,
+    });
+    expect(await fetchGalaxyCurrentUser(U, "", fetchImpl as unknown as typeof fetch)).toEqual({
+      ok: false,
+      authFailed: false,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Two related Galaxy-credential fixes for Orbit, both stemming from the same gap: changing your Galaxy API key didn't reset the live connection, and there was no way to see which account you were actually connected as.

## Reconnect after a credential change on resume

After rotating the Galaxy API key (or switching servers) in Preferences, the brain restarts with the new credentials but the `--continue` resume suppresses the startup greeting -- the only thing that prompts the model to call `galaxy_connect()`. So the resumed model keeps believing it's connected as the old account and Galaxy tools keep acting as the previous key's user.

Now `session_start` fingerprints the active credentials (one-way hash, so the key never lands on disk) against a per-cwd baseline -- the creds the model last *confirmed* a connection with. On a resume where they changed, it nudges the model to reconnect and confirm the now-active account. The baseline only advances on a confirmed `galaxy_connect`, not at `session_start`, so an ignored nudge or a crash before the reconnect lands can't permanently mask the drift -- the next resume re-nudges. Fresh starts are unaffected; the greeting already handles those.

## Show the connected user in the status tooltip

The status badge only showed the server URL, so you couldn't tell which account the key authenticates as -- easy to miss after a key rotation. Main now resolves the active profile's decrypted key and asks Galaxy's `/api/users/current`, and the tooltip reads `Galaxy: <url> (username)` (falling back to the email when there's no public name, and `(sign-in failed)` on a 401/403; other failures stay silent on the URL so a transient blip doesn't smear a good key). It refreshes on the existing triggers, so it updates right after a key change. The key never leaves the main process -- the renderer only gets the username back over a new `galaxy:current-user` IPC.

## Hardening

This area went through an adversarial security pass, which surfaced a credential-exfil concern worth fixing centrally: the decrypted key was sent to whatever URL was in the config without validation. `config:save` now normalizes and validates Galaxy profile URLs -- https, or http only for a numeric loopback IP -- before the key is ever used, so a compromised renderer that reaches `config:save` can't repoint the key at an attacker host (the loopback check is a real IPv4 match, not a `127.` prefix that a hostname like `127.evil.example` would slip through). The current-user fetch refuses any non-https/non-loopback URL as a backstop.

## Testing

810 unit tests pass (≈70 new across the drift logic, the URL validator, the tooltip formatter, and the current-user fetch), root + app typechecks clean, lint/prettier clean.

Not yet eyeballed in a running Orbit against a live Galaxy server. A few low-severity edges are intentionally left as documented limitations: two windows on the same cwd share one drift baseline, dev-mode (safeStorage off) can fingerprint a stale exported key, and the current-user response body isn't size-capped.
