### PR TITLE
Prefer Galaxy server-side fetch-by-URL over local download then re-upload

### DIFF
--- a/docs/agent/galaxy-routing.md
+++ b/docs/agent/galaxy-routing.md
@@ -27,6 +27,27 @@ Before drafting a plan, consult Galaxy resources:
      scripts) — mark it local.
 3. Document each routing decision inline in the markdown plan section.
 
+## Getting remote data into a history
+
+When a history needs a file that lives at a public URL (reference
+genomes, model weights, SRA/ENA accessions, released datasets, anything
+addressable by http/https/ftp), hand Galaxy the URL and let its server
+fetch it directly. Do **not** download the file locally and re-upload it.
+A local download plus a local→Galaxy upload doubles the transfer, spends
+the user's upstream bandwidth, fills local disk, and blocks the turn (a
+2.3 GB local→Galaxy upload took 8+ minutes on a normal connection, where a
+server-side fetch runs at datacenter bandwidth).
+
+- Preferred: the Galaxy MCP fetch-by-URL tool
+  `galaxy_upload_file_from_url({ url, history_id })` (optional `file_name`,
+  `file_type`, `dbkey`).
+- Scripting bioblend instead: use `gi.tools.put_url(url, history_id)` (one
+  URL per line for several), which Galaxy fetches server-side. Don't call
+  `gi.tools.upload_file()` on a path you just downloaded from that URL.
+- Local→upload is the exception, used only when the source is genuinely
+  local: a file the user created, or one that exists only on this machine
+  with no URL Galaxy can reach itself.
+
 ## When Galaxy is not connected
 
 All execution is local. Suggest connecting via `/connect` once if the

--- a/docs/live-validation-checklist.md
+++ b/docs/live-validation-checklist.md
@@ -70,12 +70,15 @@ Inside the same session:
 3. Ask it to run the smallest practical Galaxy action.
 4. After the invocation returns, confirm the agent calls `galaxy_invocation_record`.
 5. Poll with `galaxy_invocation_check_one` or `galaxy_invocation_check_all`.
+6. Ask it to add a file that lives at a public URL (for example a small
+   reference FASTA) to that history.
 
 Expected:
 
 - `notebook.md` contains a fenced `loom-invocation` block with `invocation_id`, `galaxy_server_url`, `notebook_anchor`, `label`, `submitted_at`, `status`, and `summary`
 - polling transitions the block from `in_progress` to `completed` or `failed`
 - the related markdown checklist item is updated after the status transition
+- the URL-backed file is fetched server-side (via `galaxy_upload_file_from_url`, or a bioblend `put_url` call), not downloaded locally and re-uploaded
 
 ## 5. Validate restart and sidecars
 

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -325,8 +325,29 @@ mode setting:
 ### Uploading local data
 
 To upload a file from the user's machine, call \`galaxy_upload_local_file\`
-(resumable; handles large files without timing out). For data already at a
-public URL, use \`galaxy_upload_file_from_url\` (Galaxy fetches it server-side).
+(resumable; handles large files without timing out).
+
+### Getting data into a Galaxy history
+
+When a history needs a file that lives at a **public URL** (reference
+genomes, model weights, SRA/ENA accessions, released datasets, anything
+addressable by http/https/ftp), hand Galaxy the URL and let its server
+fetch it directly. Do **not** download the file to this machine and then
+re-upload it. A local download followed by a local→Galaxy upload doubles
+the transfer, burns the user's upstream bandwidth, fills local disk, and
+blocks the turn: a 2.3 GB local→Galaxy upload took 8+ minutes on a normal
+connection, where a server-side fetch runs at datacenter bandwidth.
+
+- **Preferred:** the Galaxy MCP fetch-by-URL tool
+  \`galaxy_upload_file_from_url({ url, history_id })\` (optional
+  \`file_name\`, \`file_type\`, \`dbkey\`). One hop, no local copy.
+- **Scripting bioblend instead?** Use the URL-fetch path
+  \`gi.tools.put_url(url, history_id)\` (one URL per line for several),
+  which Galaxy fetches server-side. Never call \`gi.tools.upload_file()\`
+  on a path you just downloaded from that same URL.
+- **Local→upload is the exception.** Reach for it only when the source is
+  genuinely local: a file the user created, or one that exists only on
+  this machine with no URL Galaxy can reach itself.
 
 ### Executing a Galaxy step
 


### PR DESCRIPTION
When the agent needs a file in a history that already lives at a public URL -- reference genomes, model weights, SRA/ENA accessions, released datasets -- it's been downloading the file locally and then uploading local->Galaxy. The live trigger was a 2.3 GB ProstT5 weights file pulled down and re-uploaded with bioblend's `upload_file`, which took 8+ minutes over the user's upstream and blocked the whole turn. That's the wrong data path: the file never needed to touch the user's machine.

The fix is almost entirely agent steering. I checked the toolset first, and the URL-fetch path already exists -- the galaxy MCP exposes `upload_file_from_url` (server-side fetch), and bioblend has `gi.tools.put_url(url, history_id)`, which Galaxy fetches server-side. Nothing was missing on the tool side; the brain just wasn't telling the agent to prefer it.

So I added a "Getting data into a Galaxy history" section to the Galaxy-routing guidance in `context.ts` (and mirrored it in the `docs/agent/galaxy-routing.md` topic doc): when a history artifact originates from a URL, hand Galaxy the URL via `galaxy_upload_file_from_url` (or `put_url` when scripting bioblend) and let the server fetch it; fall back to local->upload only when the source is genuinely local. I also added a check to the live-validation checklist.

I left the issue's optional runtime guardrail (intercepting a download-then-upload pattern) out -- it's a bigger code change and the steering already covers all three acceptance criteria.

One follow-up worth flagging: this guidance, and a fair bit of the other inlined Galaxy-routing prose, would be better living in a shared layer -- e.g. a `getting-data-into-galaxy` galaxy-skills skill the brain routes to via `skills_fetch` -- rather than duplicated across the context block and the topic doc. Kept this change small instead.

Closes #282.
