### PR TITLE
Document WSLg GUI session gotcha for WSL2 installs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -161,7 +161,36 @@ sudo apt-get install -f
 orbit
 ```
 
-The Orbit window opens on your Windows desktop via WSLg -- no further configuration needed.
+On most setups the Orbit window opens on your Windows desktop via WSLg with no
+further configuration. On a fresh or minimal WSL2 distro it may not appear the
+first time -- see [If the window doesn't appear](#if-the-window-doesnt-appear)
+below.
+
+### If the window doesn't appear
+
+On a fresh or minimal WSL2 distro, WSLg's GUI session sometimes fails to come
+up on the first launch: `orbit` starts with no error in the terminal, but no
+window appears and the taskbar entry shows a `[WARN COPY MODE] ...` title. A
+full WSL restart is what reliably clears it. Here's the recovery, in order:
+
+1. Make sure the common GUI client libraries are present. Installing any GTK
+   app pulls them in, and `gedit` is a convenient one:
+
+   ```bash
+   sudo apt-get update && sudo apt-get install -y gedit
+   ```
+
+2. From **PowerShell** on Windows, fully restart WSL so WSLg re-initializes:
+
+   ```powershell
+   wsl --shutdown
+   ```
+
+   This stops **all** running WSL2 distros and the WSL VM, so save work in any
+   other WSL sessions first.
+
+3. Reopen your WSL2 terminal and run `orbit` again -- the window should now
+   appear. (Launching `gedit` is a quick way to confirm WSLg itself is back.)
 
 ### Notes
 


### PR DESCRIPTION
Closes #306.

On a fresh/minimal WSL2 distro, WSLg's GUI session can fail to come up the first time you launch Orbit -- the app starts with no error in the terminal but no window appears, and the taskbar title shows `[WARN COPY MODE] ...`.

This adds an "If the window doesn't appear" troubleshooting note to the WSL2 install section in `INSTALL.md` with the recovery a tester verified: make sure the GUI client libraries are present (installing a GTK app like `gedit` pulls them in), then `wsl --shutdown` from PowerShell and restart so WSLg re-initializes. The full restart is the part that reliably clears it.

Docs-only. I went with documenting the verified restart recovery rather than naming a package list on purpose -- the `.deb` already declares the Electron/GTK deps and `apt-get install -f` resolves them, yet the symptom persisted until the WSL restart, so a "install these N packages" note would have been misleading about the actual fix.

Caveat: I haven't reproduced this on real WSL2 hardware myself -- it's based on the reproduced recovery in #306.
