### PR TITLE
Declare bash-sandbox runtime deps as deb recommends + name them on init failure

### DIFF
--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -350,6 +350,13 @@ const config: ForgeConfig = {
           // unioned with the defaults, so this only adds the missing lib.
           // libasound2t64 on newer Ubuntu satisfies libasound2 via Provides.
           depends: ["libasound2"],
+          // Runtime prerequisites for the opt-in bash sandbox (ASRT shells out to
+          // these on Linux): ripgrep -> rg, socat -> socat, bubblewrap -> bwrap.
+          // recommends (not depends) because the sandbox is off by default -- apt
+          // pulls them on a normal install, but a vanilla box that never enables
+          // the toggle isn't forced to. recommends is unioned with the defaults
+          // like depends. See #305.
+          recommends: ["ripgrep", "socat", "bubblewrap"],
         },
       },
     },

--- a/extensions/loom/sandbox/index.ts
+++ b/extensions/loom/sandbox/index.ts
@@ -6,6 +6,7 @@ import { loadGuardianConfig, resolveSandbox } from "../exec-guard/guardian-confi
 import { isSandboxActive, setSandboxActive } from "../exec-guard/runtime-state";
 import { buildSandboxConfig } from "./sandbox-config";
 import { createSandboxedBashOps } from "./sandbox-bash";
+import { describeSandboxInitFailure } from "./sandbox-init-message";
 
 /**
  * Bash OS sandbox (opt-in). When enabled (`--sandbox` / LOOM_SANDBOX=1 /
@@ -78,7 +79,10 @@ export function registerSandbox(pi: ExtensionAPI): void {
     } catch (err) {
       setSandboxActive(false);
       ctx.ui.notify(
-        `Bash sandbox init failed (${err instanceof Error ? err.message : String(err)}); bash stays gated per action.`,
+        describeSandboxInitFailure(
+          process.platform,
+          err instanceof Error ? err.message : String(err),
+        ),
         "error",
       );
     }

--- a/extensions/loom/sandbox/sandbox-init-message.ts
+++ b/extensions/loom/sandbox/sandbox-init-message.ts
@@ -1,0 +1,28 @@
+/**
+ * apt package names that provide the Linux sandbox runtime binaries ASRT shells
+ * out to: `ripgrep` -> rg, `socat` -> socat, `bubblewrap` -> bwrap. These ship as
+ * deb `recommends` (see app/forge.config.ts), so a `--no-install-recommends`
+ * install -- or a distro/derivative that strips Recommends -- can still be missing
+ * them and trip the init failure in issue #305. (#305 only named rg + socat, but
+ * ASRT requires bwrap on Linux too.)
+ */
+export const LINUX_SANDBOX_APT_PACKAGES = ["ripgrep", "socat", "bubblewrap"];
+
+/**
+ * User-facing message for a failed bash-sandbox init. On Linux, when ASRT reports
+ * its runtime prerequisites are missing, append the exact apt install line so the
+ * user can fix it in one step instead of decoding "ripgrep (rg) not found". Pure:
+ * takes the platform and the underlying error message, does no IO.
+ */
+export function describeSandboxInitFailure(
+  platform: NodeJS.Platform,
+  errorMessage: string,
+): string {
+  const base = `Bash sandbox init failed (${errorMessage}); bash stays gated per action.`;
+  // ASRT's initialize() throws "Sandbox dependencies not available: ..." only when
+  // the Linux binary checks fail; anchor on that so unrelated failures stay terse.
+  if (platform === "linux" && /dependencies not available/i.test(errorMessage)) {
+    return `${base} On Debian/Ubuntu, install the prerequisites with: sudo apt install ${LINUX_SANDBOX_APT_PACKAGES.join(" ")}`;
+  }
+  return base;
+}

--- a/tests/sandbox-init-message.test.ts
+++ b/tests/sandbox-init-message.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import {
+  describeSandboxInitFailure,
+  LINUX_SANDBOX_APT_PACKAGES,
+} from "../extensions/loom/sandbox/sandbox-init-message";
+
+// ASRT's SandboxManager.initialize() throws this on Linux when the runtime
+// binaries it shells out to (rg/socat/bwrap) aren't on PATH. See issue #305.
+const ASRT_DEPS_ERROR =
+  "Sandbox dependencies not available: ripgrep (rg) not found, bubblewrap (bwrap) not installed, socat not installed";
+
+describe("describeSandboxInitFailure", () => {
+  it("keeps the base shape: names the failure and that bash stays gated", () => {
+    const msg = describeSandboxInitFailure("linux", ASRT_DEPS_ERROR);
+    expect(msg).toContain("Bash sandbox init failed");
+    expect(msg).toContain(ASRT_DEPS_ERROR);
+    expect(msg).toContain("bash stays gated per action");
+  });
+
+  it("on Linux, names the exact apt packages when ASRT reports missing deps", () => {
+    const msg = describeSandboxInitFailure("linux", ASRT_DEPS_ERROR);
+    expect(msg).toContain(`sudo apt install ${LINUX_SANDBOX_APT_PACKAGES.join(" ")}`);
+    // the three binaries ASRT actually requires on Linux (#305 only named two)
+    expect(LINUX_SANDBOX_APT_PACKAGES).toEqual(["ripgrep", "socat", "bubblewrap"]);
+  });
+
+  it("does not add an apt hint on non-Linux platforms", () => {
+    const msg = describeSandboxInitFailure("darwin", ASRT_DEPS_ERROR);
+    expect(msg).not.toContain("apt install");
+    expect(msg).toContain("Bash sandbox init failed");
+  });
+
+  it("does not add an apt hint for unrelated Linux init failures", () => {
+    const other = "network.tlsTerminate and network.mitmProxy are mutually exclusive";
+    const msg = describeSandboxInitFailure("linux", other);
+    expect(msg).not.toContain("apt install");
+    expect(msg).toContain(other);
+  });
+});


### PR DESCRIPTION
Closes #305.

On a fresh `.deb` install you could flip on "sandbox Bash execution" and immediately hit "Bash sandbox init failed" because `rg`/`socat` weren't there.

Triaging it, the missing-binary requirement isn't actually ours -- it's the upstream `@anthropic-ai/sandbox-runtime`. Its `SandboxManager.initialize()` runs a dependency check that, on Linux, requires three binaries and throws `Sandbox dependencies not available: ...` if any are missing: `ripgrep` (`rg`, used to expand glob deny-patterns for bwrap), `bubblewrap` (`bwrap`, the sandbox itself), and `socat` (the network bridge). macOS seatbelt needs none of them. The issue only named rg + socat, but bwrap is required too, so all three are covered here.

Fix is two parts:

1. **maker-deb `recommends: ["ripgrep", "socat", "bubblewrap"]`.** `recommends`, not `depends`, because the sandbox is off by default -- apt still pulls these on a normal install, but a box that never touches the toggle isn't forced to carry them. This is deliberately different from the libasound2 `depends` in #223: Electron hard-links libasound.so.2 so the app won't launch without it, whereas these are only needed for an opt-in feature.

2. **A clearer init-failure message.** When ASRT reports its deps are missing on Linux, the notification now names the exact packages (`sudo apt install ripgrep socat bubblewrap`). That covers the cases a packaging change can't -- `--no-install-recommends`, or non-deb distros.

Pulled the message logic into a small pure helper (`describeSandboxInitFailure`) with unit tests. Full suite green, typecheck/lint clean.

Left maker-rpm alone since the issue and the #223 precedent are both deb-only -- easy follow-up if we want symmetry. Not yet live-verified on a real `.deb`/WSL2 box.