### PR TITLE
Steer Galaxy page content to Galaxy-Flavored Markdown (no ```txt fences)

### DIFF
--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -16,6 +16,7 @@ import { loadConfig } from "./config";
 import { listEnabledSkillRepos } from "./skills";
 import { findGalaxyPageBlocks } from "./galaxy-page-binding";
 import { isLocalShellDisabled } from "./local-exec.js";
+import { GALAXY_PAGE_MARKDOWN_GUIDANCE } from "./galaxy-page-markdown-guidance";
 
 const NOTEBOOK_HEAD_MAX_CHARS = 2000;
 const NOTEBOOK_TAIL_MAX_CHARS = 4000;
@@ -108,6 +109,8 @@ Use \`notebook_push_to_galaxy\` to share progress with the user (creates a new
 revision of the Galaxy page). Use \`notebook_pull_from_galaxy\` to fetch
 updates the user made on the Galaxy side -- only when the user explicitly
 asks for it, since pull discards local edits since the last sync.
+
+${GALAXY_PAGE_MARKDOWN_GUIDANCE}
 `;
 }
 

--- a/extensions/loom/galaxy-page-markdown-guidance.ts
+++ b/extensions/loom/galaxy-page-markdown-guidance.ts
@@ -1,0 +1,19 @@
+/**
+ * How to author content destined for a Galaxy page.
+ *
+ * A Galaxy page renders as "Galaxy Flavored Markdown": ordinary Markdown plus a
+ * fixed set of ```galaxy directive blocks (history_dataset_display,
+ * invocation_outputs, ...). Galaxy does NOT reject other code fences -- a ```txt
+ * block validates fine -- but it renders as a raw monospace <pre> block, not as
+ * formatted content or a live directive, which is almost never what was meant.
+ * The push adapter (galaxy-markdown-adapter.ts) only rewrites ```loom-invocation
+ * fences; everything else in notebook.md is sent to the page verbatim, so a
+ * ```txt fence the model writes lands on the page unchanged. The reliable place
+ * to prevent that is here -- steer the author -- not a lossy after-the-fact
+ * rewrite that can't recover the table or prose the content should have been.
+ *
+ * Shared by the notebook_push_to_galaxy tool description (covers the first push,
+ * before any binding block exists) and the live page-binding context block
+ * (reinforces during iterative page updates).
+ */
+export const GALAXY_PAGE_MARKDOWN_GUIDANCE = `Galaxy pages render as Galaxy Flavored Markdown. Write plain Markdown -- headings, lists, tables, links, emphasis, blockquotes -- and embed Galaxy results only with \`\`\`galaxy directive blocks (e.g. \`history_dataset_display\`, \`history_dataset_as_image\`, \`history_dataset_as_table\`, \`invocation_outputs\`, \`workflow_display\`). Do NOT wrap content in \`\`\`txt, \`\`\`text, or any other code fence: Galaxy renders those as raw monospace text, not formatted content. Present data as Markdown tables or prose; the only meaningful fenced block on a Galaxy page is \`\`\`galaxy.`;

--- a/extensions/loom/tools-sync.ts
+++ b/extensions/loom/tools-sync.ts
@@ -16,6 +16,17 @@ import {
   resumeGalaxyPage,
 } from "./galaxy-pages-sync";
 import { listRecentPages } from "./galaxy-pages-api";
+import { GALAXY_PAGE_MARKDOWN_GUIDANCE } from "./galaxy-page-markdown-guidance";
+
+export const NOTEBOOK_PUSH_TO_GALAXY_DESCRIPTION = `Push the local notebook.md to a Galaxy page. If the notebook already
+has a loom-galaxy-page binding block, updates that page in place (creates a
+new revision). If there's no binding yet, pass history_id (and optionally title,
+slug, annotation) to create a new page attached to that history and bind it.
+Strips loom-galaxy-page blocks from the body sent to Galaxy, but keeps
+loom-invocation blocks (they're analysis content). Unconditional local-wins:
+any concurrent Galaxy-UI edits since the last sync are overwritten.
+
+${GALAXY_PAGE_MARKDOWN_GUIDANCE}`;
 
 function errorContent(e: unknown) {
   return {
@@ -79,13 +90,7 @@ notebook_resume_from_galaxy with its page_id.`,
   pi.registerTool({
     name: "notebook_push_to_galaxy",
     label: "Push notebook to Galaxy page",
-    description: `Push the local notebook.md to a Galaxy page. If the notebook already
-has a loom-galaxy-page binding block, updates that page in place (creates a
-new revision). If there's no binding yet, pass history_id (and optionally title,
-slug, annotation) to create a new page attached to that history and bind it.
-Strips loom-galaxy-page blocks from the body sent to Galaxy, but keeps
-loom-invocation blocks (they're analysis content). Unconditional local-wins:
-any concurrent Galaxy-UI edits since the last sync are overwritten.`,
+    description: NOTEBOOK_PUSH_TO_GALAXY_DESCRIPTION,
     parameters: Type.Object({
       history_id: Type.Optional(
         Type.String({

--- a/tests/galaxy-page-markdown-guidance.test.ts
+++ b/tests/galaxy-page-markdown-guidance.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fs from "fs";
+import * as state from "../extensions/loom/state";
+import { GALAXY_PAGE_MARKDOWN_GUIDANCE } from "../extensions/loom/galaxy-page-markdown-guidance";
+import { NOTEBOOK_PUSH_TO_GALAXY_DESCRIPTION } from "../extensions/loom/tools-sync";
+import { buildGalaxyPageBindingBlock } from "../extensions/loom/context";
+
+vi.mock("../extensions/loom/state");
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof fs>();
+  return { ...actual, readFileSync: vi.fn() };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GALAXY_PAGE_MARKDOWN_GUIDANCE", () => {
+  it("steers toward plain Markdown plus ```galaxy directive blocks", () => {
+    expect(GALAXY_PAGE_MARKDOWN_GUIDANCE).toContain("```galaxy");
+    expect(GALAXY_PAGE_MARKDOWN_GUIDANCE.toLowerCase()).toContain("plain markdown");
+  });
+
+  it("names a real Galaxy directive so the model uses recognized blocks", () => {
+    expect(GALAXY_PAGE_MARKDOWN_GUIDANCE).toContain("history_dataset_display");
+  });
+
+  it("warns against ```txt and other arbitrary code fences", () => {
+    expect(GALAXY_PAGE_MARKDOWN_GUIDANCE).toContain("```txt");
+  });
+});
+
+describe("notebook_push_to_galaxy tool description", () => {
+  // The reported bug is the FIRST push (create), when no binding block exists
+  // yet -- so the always-present tool description is where the guidance has to
+  // live to take effect at create time.
+  it("carries the Galaxy-Flavored-Markdown authoring guidance", () => {
+    expect(NOTEBOOK_PUSH_TO_GALAXY_DESCRIPTION).toContain(GALAXY_PAGE_MARKDOWN_GUIDANCE);
+  });
+});
+
+describe("Galaxy page binding context block", () => {
+  // Reinforces the guidance per turn during the update flow, once a binding exists.
+  it("surfaces the Galaxy-Flavored-Markdown authoring guidance", () => {
+    vi.mocked(state.getNotebookPath).mockReturnValue("/work/notebook.md");
+    const nb = [
+      "```loom-galaxy-page",
+      "page_id: p1",
+      'page_slug: "my-analysis"',
+      'galaxy_server_url: "https://galaxy.example"',
+      "history_id: h1",
+      "last_synced_revision: r3",
+      'bound_at: "2026-05-20T10:00:00Z"',
+      "```",
+      "",
+    ].join("\n");
+    vi.mocked(fs.readFileSync).mockReturnValue(nb as never);
+    expect(buildGalaxyPageBindingBlock()).toContain(GALAXY_PAGE_MARKDOWN_GUIDANCE);
+  });
+});


### PR DESCRIPTION
## What

When the model writes content headed for a Galaxy page, it sometimes wraps data or previews in a ```txt code fence. The push adapter (`galaxy-markdown-adapter.ts`) only rewrites ```loom-invocation fences -- everything else in `notebook.md` is sent to the page verbatim -- so that fence lands on the page as-is. Galaxy doesn't reject it (it validates fine), but it renders as a raw monospace `<pre>` block instead of formatted content or a live directive, which is almost never what was meant. Nothing was telling the model what's safe to author for a page.

## Fix

A single source-of-truth blurb, `GALAXY_PAGE_MARKDOWN_GUIDANCE`, that steers the author toward Galaxy-Flavored Markdown: plain Markdown (headings, lists, tables, links, emphasis) plus ```galaxy directive blocks (`history_dataset_display`, `invocation_outputs`, ...), and explicitly *not* ```txt / ```text / other code fences. It's wired into the two places the model decides what to write:

- **`notebook_push_to_galaxy` tool description** -- this is the one that matters for the reported case. The first push creates the page *before* any binding block exists, so the always-present, cached tool description is the only spot that takes effect at create time.
- **the per-turn page-binding context block** (`buildGalaxyPageBindingBlock`) -- reinforces the same rule during the iterative update flow once a binding exists.

I went with steering rather than a sanitizer in the adapter on purpose: stripping the fence after the fact can make the page *valid* but can't recover the table or prose the content should have been, and aggressive rewriting risks surprising transforms. The reliable lever is the author.

## Tests

New `tests/galaxy-page-markdown-guidance.test.ts` (TDD, watched fail first) covers all three surfaces -- the guidance constant, the push tool description, and the binding context block. Full root suite green (769), `tsc --noEmit` clean, eslint clean.
