### PR TITLE
Grade open models on decision correctness, not just plan shape

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -34,15 +34,64 @@ PROXY_API_KEY=<your-key>
 (Variable names match `~/work/tacc-inference/.env` so symlinking that file
 straight in works: `ln -s ~/work/tacc-inference/.env evals/.env`.)
 
-## Tier today
+## Dimensions and the leaderboard
 
-Phase 2: matrix runner + TACC-only Tier 2 (Llama-3.3-70B, Llama-4-Maverick,
-Qwen3-32B). One smoke-test scenario verifies the matrix wiring end-to-end.
+Tier 2 scenarios are graded on up to four decision-correctness dimensions.
+Every assertion failure carries a `dimension`, and the runner aggregates a
+per-model leaderboard from them:
 
-Phase 3+ fills out the scenario set (init-gate variants, plan navigation,
-notebook discipline, confusables hint, session lifecycle), with Tier 2
-scenarios automatically running across the matrix. See the plan for the
-full sequencing.
+- **validity** -- a well-formed `## Plan X: <title> [routing]` block with
+  enough described steps. The gate: a model that can't emit a parseable plan
+  fails everything downstream.
+- **routing** -- did the plan pick the correct routing tag? Scenarios set
+  `plan.routingIn` to the *correct* answer(s) (e.g. metagenomics -> `[galaxy,
+  hybrid]`, consumer pharmacogenomics -> `[local, hybrid]`), so an incorrect
+  route is graded as wrong rather than waved through.
+- **tools** -- did the plan name a sane analysis tool? `plan.mentionsOneOf`
+  is a curated, generous allow-set per assay (a coarse heuristic, not an
+  oracle; nuance is left to a future judge layer).
+- **behavior** -- Loom-contract checks that need no Galaxy. Today:
+  `behavior.asksClarifyingQuestion` -- an underspecified prompt should make
+  the agent ask, not fabricate a plan.
+
+Plans are read from wherever they land (`plan.source` defaults to `"any"` =
+notebook if it has a plan, else chat), because the matrix models don't
+reliably follow Loom's draft-in-chat-then-write gate.
+
+Each (scenario, model) cell runs **n=3** times by default (`scenario.runs`
+overrides; Tier 1 runs once). A dimension's cell verdict is a majority of the
+runs (`pass >= ceil(total/2)`), so a flaky model shows as a pass-rate rather
+than a coin-flip. The runner prints a `model x dimension` leaderboard grid
+and writes one JSON line per run to `evals/results/<date>-<sha>.jsonl`
+(gitignored) for diffing models over time and across Loom prompt changes.
+
+## Model matrix
+
+`evals/models.json` is the 7-model TACC matrix (all on the one SambaNova
+proxy): MiniMax-M2.7, gpt-oss-120b, Qwen3-32B, Llama-3.3-70B,
+Llama-4-Maverick, Llama-3.1-8B, gemma-4-31B. gpt-oss-120b is flagged
+`reasoningModel` (its chain-of-thought lands in `reasoning_content`; see the
+findings log for the live caveat). To add a paid reference baseline
+(Anthropic/OpenAI/Google), append an entry with that provider and the right
+`envRequires` -- the matrix design makes it a one-line config change.
+
+## Out of scope (for now)
+
+LLM-judge plan-*quality* scoring (the same scenarios with a rubric pass),
+end-to-end execution against a recorded/live Galaxy MCP, and notebook
+discipline / session-lifecycle scenarios. The assertion library leaves seams
+for each. See the plan for sequencing.
+
+## Known issue
+
+Loom does not exit cleanly under `--mode json` after a single slash-command
+invocation -- the Galaxy poller's `setInterval` keeps the event loop alive
+even when print mode finishes. The runner SIGTERMs each scenario at its
+`timeoutMs`, so this doesn't break evals, but it bloats wall-clock and is
+worth fixing Loom-side (either `unref()` the poller's timer or wire
+`stopGalaxyPoller` into print-mode dispose). Scenarios with no Galaxy
+configured (smoke-echo, plan-creation) exit cleanly in ~2s, so this only
+bites Galaxy-connected scenarios.
 
 ## Known issue
 

--- a/evals/findings.md
+++ b/evals/findings.md
@@ -1,9 +1,11 @@
 # Loom evals -- harness findings log
 
 What we learned by iterating on the eval suite against the TACC SambaNova
-matrix (Llama-3.3-70B, Llama-4-Maverick, Qwen3-32B). Useful both as a
-record of why the suite is shaped the way it is, and as a starter list
-for future runs.
+matrix. Started as the 3-model lineup (Llama-3.3-70B, Llama-4-Maverick,
+Qwen3-32B); now 7 (added MiniMax-M2.7, gpt-oss-120b, Llama-3.1-8B,
+gemma-4-31B). Useful both as a record of why the suite is shaped the way it
+is, and as a starter list for future runs. Entries are roughly chronological;
+the newest section is at the bottom.
 
 ## Loom-side bugs surfaced by the matrix
 
@@ -177,3 +179,73 @@ Maverick especially shows nondeterminism on tool-call format.)
    (skipping chat-draft) and picks `[local]` routing despite the
    Galaxy-first prompt. Worth a focused prompt-tightening cycle if we
    want it to score above 2/5.
+
+## 2026-06-17: decision-correctness layer + 7-model matrix
+
+We stopped grading *shape* and started grading *decisions*. Every scenario
+now carries the correct answer (tightened `routingIn`, a `mentionsOneOf` tool
+allow-set), failures are tagged with a dimension (validity / routing / tools /
+behavior), each (scenario, model) cell runs n=3, and the runner prints a
+`model x dimension` leaderboard and persists per-run JSONL to
+`evals/results/`. This closes suggested-iterations #1 (n=3) and #3 (results
+artifact) above. Matrix expanded from 3 to 7 TACC models: added MiniMax-M2.7,
+gpt-oss-120b, Llama-3.1-8B, gemma-4-31B.
+
+### The eval surfaced its own grading bug (now fixed)
+
+The first live `plan-creation-rnaseq` matrix run showed gpt-oss-120b,
+Llama-3.1-8B, and gemma -- all of which emitted *no plan at all* -- scoring
+`routing 3/3, tools 3/3` on the leaderboard. Cause: `evaluatePlan`'s
+no-plan branch pushed only a `validity` failure and returned, so the
+declared routing/tools dimensions recorded no failure and the aggregator
+read them as green. The plan's own intent is "validity is the gate -- a
+model that can't emit a parseable plan fails everything downstream," so the
+fix makes the no-plan branch also fail every other declared dimension. After
+the fix the three no-plan models correctly read `0/0/0`. Good reminder that a
+leaderboard's green cells need the same scrutiny as its red ones.
+
+### gpt-oss-120b returns empty content through Pi
+
+gpt-oss-120b fails `smoke-echo` 3/3 -- it never emits the echo token -- and
+produces no plan on `plan-creation-rnaseq`. Its chain-of-thought lands in
+`reasoning_content`; Pi (or the litellm adapter under it) doesn't surface a
+usable assistant `content`, so from Loom's side the model says nothing. The
+matrix entry is flagged `reasoningModel: true` and given `maxTokens: 8192`,
+but that alone doesn't fix it -- this needs Loom/Pi to read `reasoning_content`
+(or strip-and-promote it) before gpt-oss-120b is usable as a Loom driver. Left
+in the matrix so the regression is visible; it shows red until handled.
+
+### Live leaderboard (plan-creation-rnaseq, n=3, post-fix)
+
+| model            | validity | routing | tools | notes                                                            |
+| ---------------- | -------- | ------- | ----- | ---------------------------------------------------------------- |
+| Llama-4-Maverick | 3/3      | 3/3     | 3/3   | cleanest run this round                                          |
+| MiniMax-M2.7     | 3/3      | 1/3     | 3/3   | routed `[local]` on 2 of 3 runs -- variance n=1 would have hidden |
+| Qwen3-32B        | 2/3      | 2/3     | 2/3   | one run emitted no plan; the other two routed `[galaxy]` cleanly  |
+| Llama-3.3-70B    | 0/3      | 3/3     | 3/3   | right decisions, wrong format (see below)                        |
+| gpt-oss-120b     | 0/3      | 0/3     | 0/3   | empty content (reasoning_content; see above)                     |
+| Llama-3.1-8B     | 0/3      | 0/3     | 0/3   | no plan; one run hit the 150s timeout                            |
+| gemma-4-31B      | 0/3      | 0/3     | 0/3   | no plan                                                          |
+
+Two findings worth their own follow-up:
+
+- **Llama-3.3-70B makes the right calls but won't use checkbox steps.** It
+  routes `[galaxy]` and names fastp/STAR/featureCounts/DESeq2 every run
+  (routing + tools 3/3), but writes its steps as a `1.`-numbered list rather
+  than `- [ ]` checkboxes, so `minPendingSteps` sees 0 pending steps and
+  validity fails 0/3. That's a real format-adherence gap -- the init-gate
+  parser and step tracking both key off `- [ ]`. Either tighten the prompt's
+  step format or decide the parser should also count numbered steps; the eval
+  is correctly flagging a divergence, not a false negative.
+- **Routing is genuinely noisy across models and runs.** MiniMax flips between
+  `[galaxy]` and `[local]` run-to-run; Qwen3 routed `[local]` in an earlier
+  run and `[galaxy]` here. Routing judgment on a clearly-Galaxy task is not
+  yet reliable on the open matrix -- the single most actionable prompt-tuning
+  target, and exactly what n=3 + the routing dimension are built to track.
+
+### What's deliberately still out of scope
+
+No LLM-judge plan-*quality* scoring (tool allow-sets stay coarse
+substring heuristics -- a model naming a tool in surrounding prose can pass
+`mentionsOneOf`), no end-to-end execution, no recorded/live Galaxy MCP. The
+assertion library leaves seams for each.

--- a/evals/lib/aggregate.ts
+++ b/evals/lib/aggregate.ts
@@ -1,0 +1,69 @@
+/**
+ * Group per-run results into (scenario, model) cells and compute a majority
+ * pass/fail verdict per dimension. A dimension counts toward a cell only if
+ * the scenario declares an assertion for it -- otherwise an unexercised
+ * dimension would read as a vacuous 100% pass.
+ */
+
+import type { Assertions, Cell, Dimension, PlanAssertions, Scenario, ScenarioRun } from "./types.js";
+
+export function declaredDimensions(scenario: Scenario): Set<Dimension> {
+  const a = scenario.assertions;
+  const dims = new Set<Dimension>();
+  const planLikes: (PlanAssertions | undefined)[] = [a.plan, a.chatPlan, a.notebook?.plan];
+
+  for (const p of planLikes) {
+    if (!p) continue;
+    if (p.exists || p.minPendingSteps !== undefined || p.eachStepHasDescription) dims.add("validity");
+    if (p.routingIn) dims.add("routing");
+    if (p.mentionsOneOf || p.mentionsNoneOf) dims.add("tools");
+  }
+  if (a.behavior?.asksClarifyingQuestion) dims.add("behavior");
+  if (otherDeclared(a)) dims.add("other");
+  return dims;
+}
+
+function otherDeclared(a: Assertions): boolean {
+  return Boolean(
+    a.exitCode !== undefined ||
+      a.toolCalls ||
+      a.events ||
+      a.chatText ||
+      a.notebook?.contains?.length ||
+      a.notebook?.mustNotContain?.length ||
+      a.notebook?.exists !== undefined,
+  );
+}
+
+export function aggregateCells(runs: ScenarioRun[]): Cell[] {
+  const byCell = new Map<string, ScenarioRun[]>();
+  for (const r of runs) {
+    const key = `${r.scenario.name}::${r.model?.id ?? ""}`;
+    const list = byCell.get(key) ?? [];
+    list.push(r);
+    byCell.set(key, list);
+  }
+
+  const cells: Cell[] = [];
+  for (const list of byCell.values()) {
+    const scenario = list[0].scenario;
+    const declared = declaredDimensions(scenario);
+    const total = list.length;
+    const dimensions: Cell["dimensions"] = {};
+    for (const dim of declared) {
+      let pass = 0;
+      for (const r of list) {
+        const failedThisDim = r.failures.some((f) => f.dimension === dim);
+        if (!failedThisDim) pass++;
+      }
+      dimensions[dim] = { pass, total, verdict: pass >= Math.ceil(total / 2) };
+    }
+    cells.push({
+      scenarioName: scenario.name,
+      modelId: list[0].model?.id ?? "(none)",
+      runs: total,
+      dimensions,
+    });
+  }
+  return cells;
+}

--- a/evals/lib/aggregate.ts
+++ b/evals/lib/aggregate.ts
@@ -14,7 +14,7 @@ export function declaredDimensions(scenario: Scenario): Set<Dimension> {
 
   for (const p of planLikes) {
     if (!p) continue;
-    if (p.exists || p.minPendingSteps !== undefined || p.eachStepHasDescription) dims.add("validity");
+    if (p.exists !== undefined || p.minPendingSteps !== undefined || p.eachStepHasDescription) dims.add("validity");
     if (p.routingIn) dims.add("routing");
     if (p.mentionsOneOf || p.mentionsNoneOf) dims.add("tools");
   }

--- a/evals/lib/assertions.ts
+++ b/evals/lib/assertions.ts
@@ -11,6 +11,7 @@ import { parseLatestPlan } from "./notebook-parser.js";
 import type {
   AnyEvent,
   Assertions,
+  Dimension,
   NotebookAssertions,
   PlanAssertions,
   ScenarioFailure,
@@ -25,6 +26,7 @@ export function evaluate(run: ScenarioRun): ScenarioFailure[] {
     failures.push({
       assertion: "exitCode",
       detail: `expected ${a.exitCode}, got ${run.exitCode}`,
+      dimension: "other",
     });
   }
 
@@ -48,6 +50,7 @@ function evaluateToolCalls(events: AnyEvent[], a: Assertions, failures: Scenario
       failures.push({
         assertion: "toolCalls.mustNotInclude",
         detail: `banned tool '${banned}' was called`,
+        dimension: "other",
       });
     }
   }
@@ -60,6 +63,7 @@ function evaluateToolCalls(events: AnyEvent[], a: Assertions, failures: Scenario
         failures.push({
           assertion: "toolCalls.mustInclude",
           detail: `expected tool '${expected.name}' not found in remaining sequence`,
+          dimension: "other",
         });
         break;
       }
@@ -97,6 +101,7 @@ function evaluateEvents(events: AnyEvent[], a: Assertions, failures: ScenarioFai
       failures.push({
         assertion: "events.mustInclude",
         detail: `expected event type '${required}' was not emitted`,
+        dimension: "other",
       });
     }
   }
@@ -105,6 +110,7 @@ function evaluateEvents(events: AnyEvent[], a: Assertions, failures: ScenarioFai
       failures.push({
         assertion: "events.mustNotInclude",
         detail: `banned event type '${banned}' was emitted`,
+        dimension: "other",
       });
     }
   }
@@ -125,6 +131,7 @@ function evaluateChatText(
       failures.push({
         assertion: "chatText.mustInclude",
         detail: `chat text did not include '${needle}'`,
+        dimension: "other",
       });
     }
   }
@@ -133,6 +140,7 @@ function evaluateChatText(
       failures.push({
         assertion: "chatText.mustNotInclude",
         detail: `chat text included banned '${needle}'`,
+        dimension: "other",
       });
     }
   }
@@ -167,6 +175,7 @@ function evaluateNotebook(
       failures.push({
         assertion: "notebook.exists",
         detail: `expected exists=${a.exists}, got ${present}`,
+        dimension: "other",
       });
     }
   }
@@ -177,6 +186,7 @@ function evaluateNotebook(
       failures.push({
         assertion: "notebook",
         detail: "notebook.md was not present at end of run",
+        dimension: "other",
       });
     }
     return;
@@ -187,6 +197,7 @@ function evaluateNotebook(
       failures.push({
         assertion: "notebook.contains",
         detail: `notebook did not contain '${needle}'`,
+        dimension: "other",
       });
     }
   }
@@ -195,6 +206,7 @@ function evaluateNotebook(
       failures.push({
         assertion: "notebook.mustNotContain",
         detail: `notebook contained banned '${needle}'`,
+        dimension: "other",
       });
     }
   }
@@ -234,6 +246,7 @@ function evaluatePlan(
       failures.push({
         assertion: `${prefix}.exists`,
         detail: `no \`## Plan X: <title> [routing]\` heading found in ${surfaceLabel}`,
+        dimension: "validity",
       });
     }
     return;
@@ -243,6 +256,7 @@ function evaluatePlan(
     failures.push({
       assertion: `${prefix}.exists`,
       detail: `expected no plan heading in ${surfaceLabel} but found "${plan.title}"`,
+      dimension: "validity",
     });
     return;
   }
@@ -251,6 +265,7 @@ function evaluatePlan(
     failures.push({
       assertion: `${prefix}.routingIn`,
       detail: `plan routing '${plan.routing}' not in [${a.routingIn.join(", ")}]`,
+      dimension: "routing",
     });
   }
 
@@ -258,6 +273,7 @@ function evaluatePlan(
     failures.push({
       assertion: `${prefix}.minPendingSteps`,
       detail: `expected >= ${a.minPendingSteps} pending steps, got ${plan.pendingSteps.length}`,
+      dimension: "validity",
     });
   }
 
@@ -269,6 +285,7 @@ function evaluatePlan(
         detail: `${skinny.length} step(s) lack a description >= 8 chars (lines ${skinny
           .map((s) => s.line + 1)
           .join(", ")})`,
+        dimension: "validity",
       });
     }
   }

--- a/evals/lib/assertions.ts
+++ b/evals/lib/assertions.ts
@@ -126,8 +126,7 @@ function evaluateChatText(
   failures: ScenarioFailure[],
 ): void {
   if (!a.chatText) return;
-  let text = collectChatText(events);
-  if (stripThinkingTags) text = stripThinking(text);
+  const text = getChatText(events, stripThinkingTags);
 
   for (const needle of a.chatText.mustInclude ?? []) {
     if (!text.includes(needle)) {
@@ -165,6 +164,11 @@ function stripThinking(text: string): string {
   return text.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
 }
 
+function getChatText(events: AnyEvent[], stripThinkingTags: boolean): string {
+  const text = collectChatText(events);
+  return stripThinkingTags ? stripThinking(text) : text;
+}
+
 function evaluateBehavior(
   run: ScenarioRun,
   a: BehaviorAssertions | undefined,
@@ -173,8 +177,7 @@ function evaluateBehavior(
 ): void {
   if (!a) return;
   if (a.asksClarifyingQuestion) {
-    let chat = collectChatText(run.events);
-    if (stripThinkingTags) chat = stripThinking(chat);
+    const chat = getChatText(run.events, stripThinkingTags);
     const askedQuestion = chat.includes("?");
     const chatPlan = parseLatestPlan(chat);
     const notebookPlan = run.notebookContent ? parseLatestPlan(run.notebookContent) : null;
@@ -262,8 +265,7 @@ function evaluateChatPlan(
   failures: ScenarioFailure[],
 ): void {
   if (!a) return;
-  let text = collectChatText(events);
-  if (stripThinkingTags) text = stripThinking(text);
+  const text = getChatText(events, stripThinkingTags);
   evaluatePlan(text, a, failures, "chatPlan", "chat text");
 }
 
@@ -275,8 +277,7 @@ function evaluateUnifiedPlan(
 ): void {
   if (!a) return;
   const source = a.source ?? "any";
-  let chat = collectChatText(run.events);
-  if (stripThinkingTags) chat = stripThinking(chat);
+  const chat = getChatText(run.events, stripThinkingTags);
   const notebook = run.notebookContent ?? "";
 
   let content: string;

--- a/evals/lib/assertions.ts
+++ b/evals/lib/assertions.ts
@@ -35,6 +35,7 @@ export function evaluate(run: ScenarioRun): ScenarioFailure[] {
   evaluateEvents(run.events, a, failures);
   evaluateChatText(run.events, a, stripThink, failures);
   evaluateChatPlan(run.events, a.chatPlan, stripThink, failures);
+  evaluateUnifiedPlan(run, a.plan, stripThink, failures);
   evaluateNotebook(run.notebookContent, a.notebook, failures);
 
   return failures;
@@ -224,6 +225,35 @@ function evaluateChatPlan(
   let text = collectChatText(events);
   if (stripThinkingTags) text = stripThinking(text);
   evaluatePlan(text, a, failures, "chatPlan", "chat text");
+}
+
+function evaluateUnifiedPlan(
+  run: ScenarioRun,
+  a: PlanAssertions | undefined,
+  stripThinkingTags: boolean,
+  failures: ScenarioFailure[],
+): void {
+  if (!a) return;
+  const source = a.source ?? "any";
+  let chat = collectChatText(run.events);
+  if (stripThinkingTags) chat = stripThinking(chat);
+  const notebook = run.notebookContent ?? "";
+
+  let content: string;
+  let label: string;
+  if (source === "notebook") {
+    content = notebook;
+    label = "notebook";
+  } else if (source === "chat") {
+    content = chat;
+    label = "chat text";
+  } else {
+    const notebookHasPlan = notebook.length > 0 && parseLatestPlan(notebook) !== null;
+    content = notebookHasPlan ? notebook : chat;
+    label = notebookHasPlan ? "notebook" : "chat text";
+  }
+
+  evaluatePlan(content, a, failures, "plan", label);
 }
 
 /**

--- a/evals/lib/assertions.ts
+++ b/evals/lib/assertions.ts
@@ -314,11 +314,28 @@ function evaluatePlan(
       a.mentionsOneOf ||
       a.mentionsNoneOf
     ) {
+      // Validity is the gate -- emit the primary existence failure first.
       failures.push({
         assertion: `${prefix}.exists`,
         detail: `no \`## Plan X: <title> [routing]\` heading found in ${surfaceLabel}`,
         dimension: "validity",
       });
+      // Also fail every other declared dimension so the leaderboard doesn't
+      // show false-green scores for a model that emitted no plan at all.
+      if (a.routingIn) {
+        failures.push({
+          assertion: `${prefix}.routingIn`,
+          detail: `no plan in ${surfaceLabel}, so routing could not be graded`,
+          dimension: "routing",
+        });
+      }
+      if (a.mentionsOneOf?.length || a.mentionsNoneOf?.length) {
+        failures.push({
+          assertion: `${prefix}.mentionsOneOf`,
+          detail: `no plan in ${surfaceLabel}, so tools could not be graded`,
+          dimension: "tools",
+        });
+      }
     }
     return;
   }

--- a/evals/lib/assertions.ts
+++ b/evals/lib/assertions.ts
@@ -217,12 +217,18 @@ function evaluateNotebook(
 
   if (content === null) {
     // remaining checks need content; bail with a clear failure if any were asked for
-    if (a.contains?.length || a.mustNotContain?.length || a.plan) {
+    if (a.contains?.length || a.mustNotContain?.length) {
       failures.push({
         assertion: "notebook",
         detail: "notebook.md was not present at end of run",
         dimension: "other",
       });
+    }
+    // Run evaluatePlan against empty content so every declared plan dimension
+    // (validity, routing, tools) gets a failure -- not just a generic 'other'.
+    // Without this, a model that emits no notebook looks green on routing/tools.
+    if (a.plan) {
+      evaluatePlan("", a.plan, failures, "notebook.plan", "notebook");
     }
     return;
   }

--- a/evals/lib/assertions.ts
+++ b/evals/lib/assertions.ts
@@ -331,7 +331,7 @@ function evaluatePlan(
       }
       if (a.mentionsOneOf?.length || a.mentionsNoneOf?.length) {
         failures.push({
-          assertion: `${prefix}.mentionsOneOf`,
+          assertion: `${prefix}.mentions`,
           detail: `no plan in ${surfaceLabel}, so tools could not be graded`,
           dimension: "tools",
         });

--- a/evals/lib/assertions.ts
+++ b/evals/lib/assertions.ts
@@ -361,6 +361,12 @@ function evaluatePlan(
     }
   }
 
+  // Mention checks scan the whole surface (`content`), not just the parsed
+  // plan section, by design: tool names legitimately land in sub-bullets and
+  // param tables the parser doesn't capture, so scoping to step lines would
+  // cause false negatives. The trade-off is a coarse heuristic -- a tool named
+  // in surrounding prose can pass mentionsOneOf -- which the suite accepts;
+  // nuance is the (deferred) judge layer's job.
   const lower = content.toLowerCase();
   if (a.mentionsOneOf && a.mentionsOneOf.length > 0) {
     const hit = a.mentionsOneOf.some((t) => lower.includes(t.toLowerCase()));

--- a/evals/lib/assertions.ts
+++ b/evals/lib/assertions.ts
@@ -242,7 +242,14 @@ function evaluatePlan(
   const plan = parseLatestPlan(content);
 
   if (!plan) {
-    if (a.exists || a.routingIn || a.minPendingSteps !== undefined || a.eachStepHasDescription) {
+    if (
+      a.exists ||
+      a.routingIn ||
+      a.minPendingSteps !== undefined ||
+      a.eachStepHasDescription ||
+      a.mentionsOneOf ||
+      a.mentionsNoneOf
+    ) {
       failures.push({
         assertion: `${prefix}.exists`,
         detail: `no \`## Plan X: <title> [routing]\` heading found in ${surfaceLabel}`,
@@ -286,6 +293,27 @@ function evaluatePlan(
           .map((s) => s.line + 1)
           .join(", ")})`,
         dimension: "validity",
+      });
+    }
+  }
+
+  const lower = content.toLowerCase();
+  if (a.mentionsOneOf && a.mentionsOneOf.length > 0) {
+    const hit = a.mentionsOneOf.some((t) => lower.includes(t.toLowerCase()));
+    if (!hit) {
+      failures.push({
+        assertion: `${prefix}.mentionsOneOf`,
+        detail: `${surfaceLabel} mentions none of [${a.mentionsOneOf.join(", ")}]`,
+        dimension: "tools",
+      });
+    }
+  }
+  for (const banned of a.mentionsNoneOf ?? []) {
+    if (lower.includes(banned.toLowerCase())) {
+      failures.push({
+        assertion: `${prefix}.mentionsNoneOf`,
+        detail: `${surfaceLabel} mentions banned '${banned}'`,
+        dimension: "tools",
       });
     }
   }

--- a/evals/lib/assertions.ts
+++ b/evals/lib/assertions.ts
@@ -11,6 +11,7 @@ import { parseLatestPlan } from "./notebook-parser.js";
 import type {
   AnyEvent,
   Assertions,
+  BehaviorAssertions,
   Dimension,
   NotebookAssertions,
   PlanAssertions,
@@ -36,6 +37,7 @@ export function evaluate(run: ScenarioRun): ScenarioFailure[] {
   evaluateChatText(run.events, a, stripThink, failures);
   evaluateChatPlan(run.events, a.chatPlan, stripThink, failures);
   evaluateUnifiedPlan(run, a.plan, stripThink, failures);
+  evaluateBehavior(run, a.behavior, stripThink, failures);
   evaluateNotebook(run.notebookContent, a.notebook, failures);
 
   return failures;
@@ -161,6 +163,38 @@ function collectChatText(events: AnyEvent[]): string {
 
 function stripThinking(text: string): string {
   return text.replace(/<think>[\s\S]*?<\/think>/g, "").trim();
+}
+
+function evaluateBehavior(
+  run: ScenarioRun,
+  a: BehaviorAssertions | undefined,
+  stripThinkingTags: boolean,
+  failures: ScenarioFailure[],
+): void {
+  if (!a) return;
+  if (a.asksClarifyingQuestion) {
+    let chat = collectChatText(run.events);
+    if (stripThinkingTags) chat = stripThinking(chat);
+    const askedQuestion = chat.includes("?");
+    const chatPlan = parseLatestPlan(chat);
+    const notebookPlan = run.notebookContent ? parseLatestPlan(run.notebookContent) : null;
+    const fabricatedPlan = chatPlan !== null || notebookPlan !== null;
+
+    if (!askedQuestion) {
+      failures.push({
+        assertion: "behavior.asksClarifyingQuestion",
+        detail: "agent did not ask a clarifying question (no '?' in chat)",
+        dimension: "behavior",
+      });
+    }
+    if (fabricatedPlan) {
+      failures.push({
+        assertion: "behavior.asksClarifyingQuestion",
+        detail: "agent fabricated a plan instead of asking for clarification",
+        dimension: "behavior",
+      });
+    }
+  }
 }
 
 function evaluateNotebook(

--- a/evals/lib/matrix.ts
+++ b/evals/lib/matrix.ts
@@ -61,7 +61,7 @@ export function writePiModelsConfig(model: ModelEntry, agentDir: string): void {
           {
             id: model.model,
             name: model.model,
-            reasoning: false,
+            reasoning: model.reasoningModel ?? false,
             input: ["text"],
             contextWindow: cfg.contextWindow ?? 32000,
             maxTokens: cfg.maxTokens ?? 4096,

--- a/evals/lib/persist.ts
+++ b/evals/lib/persist.ts
@@ -1,0 +1,46 @@
+/**
+ * Append per-run results to evals/results/<date>-<sha>.jsonl for later
+ * model-vs-model and prompt-regression diffing. One JSON object per run.
+ * This is a normal Node process -- Date and git are fine to call here.
+ */
+
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import type { ScenarioRun } from "./types.js";
+
+function gitShortSha(): string {
+  try {
+    return execSync("git rev-parse --short HEAD", { encoding: "utf-8" }).trim();
+  } catch {
+    return "nosha";
+  }
+}
+
+function turnUsage(run: ScenarioRun): unknown {
+  const turnEnd = run.events.find((e) => e.type === "turn_end");
+  return (turnEnd as { usage?: unknown } | undefined)?.usage ?? null;
+}
+
+export function writeResultsJsonl(runs: ScenarioRun[], outDir: string): string | null {
+  if (runs.length === 0) return null;
+  fs.mkdirSync(outDir, { recursive: true });
+  const date = new Date().toISOString().slice(0, 10);
+  const file = path.join(outDir, `${date}-${gitShortSha()}.jsonl`);
+
+  const lines = runs.map((r) =>
+    JSON.stringify({
+      scenario: r.scenario.name,
+      modelId: r.model?.id ?? null,
+      runIndex: r.runIndex ?? 0,
+      exitCode: r.exitCode,
+      passed: r.failures.length === 0,
+      failedDimensions: [...new Set(r.failures.map((f) => f.dimension ?? "other"))],
+      failures: r.failures.map((f) => ({ assertion: f.assertion, detail: f.detail })),
+      usage: turnUsage(r),
+      durationMs: r.durationMs,
+    }),
+  );
+  fs.writeFileSync(file, lines.join("\n") + "\n");
+  return file;
+}

--- a/evals/lib/persist.ts
+++ b/evals/lib/persist.ts
@@ -1,6 +1,8 @@
 /**
- * Append per-run results to evals/results/<date>-<sha>.jsonl for later
+ * Write per-run results to evals/results/<date>-<sha>.jsonl for later
  * model-vs-model and prompt-regression diffing. One JSON object per run.
+ * One file is created per date + short SHA; re-running on the same commit
+ * overwrites the existing file for that slot rather than appending.
  * This is a normal Node process -- Date and git are fine to call here.
  */
 

--- a/evals/lib/report.ts
+++ b/evals/lib/report.ts
@@ -2,7 +2,49 @@
  * Plain-stdout reporter. One line per scenario; per-failure detail when red.
  */
 
-import type { ScenarioRun } from "./types.js";
+import type { Cell, Dimension, ScenarioRun } from "./types.js";
+
+const DIMENSION_ORDER: Dimension[] = ["validity", "routing", "tools", "behavior", "other"];
+
+/**
+ * Markdown grid: rows are models, columns are dimensions, cells aggregate the
+ * pass count over total runs across all scenarios that exercised that
+ * dimension for that model. "--" when a model never exercised a dimension.
+ */
+export function renderLeaderboard(cells: Cell[]): string {
+  const models = [...new Set(cells.map((c) => c.modelId))].sort();
+  const totals = new Map<string, Map<Dimension, { pass: number; total: number }>>();
+
+  for (const cell of cells) {
+    const row = totals.get(cell.modelId) ?? new Map<Dimension, { pass: number; total: number }>();
+    for (const dim of DIMENSION_ORDER) {
+      const d = cell.dimensions[dim];
+      if (!d) continue;
+      const acc = row.get(dim) ?? { pass: 0, total: 0 };
+      acc.pass += d.pass;
+      acc.total += d.total;
+      row.set(dim, acc);
+    }
+    totals.set(cell.modelId, row);
+  }
+
+  const activeDims = DIMENSION_ORDER.filter((dim) =>
+    cells.some((c) => c.dimensions[dim] !== undefined),
+  );
+
+  const header = `| model | ${activeDims.join(" | ")} |`;
+  const sep = `| --- | ${activeDims.map(() => "---").join(" | ")} |`;
+  const rows = models.map((m) => {
+    const row = totals.get(m);
+    const cellsText = activeDims.map((dim) => {
+      const acc = row?.get(dim);
+      return acc ? `${acc.pass}/${acc.total}` : "--";
+    });
+    return `| ${m} | ${cellsText.join(" | ")} |`;
+  });
+
+  return ["## Leaderboard (pass / total runs per dimension)", "", header, sep, ...rows].join("\n");
+}
 
 const GREEN = "\x1b[32m";
 const RED = "\x1b[31m";

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -90,9 +90,16 @@ export interface Scenario {
   assertions: Assertions;
 }
 
+/**
+ * Which decision-correctness axis a failure belongs to. Lets the report
+ * group results into a model x dimension leaderboard.
+ */
+export type Dimension = "validity" | "routing" | "tools" | "behavior" | "other";
+
 export interface ScenarioFailure {
   assertion: string;
   detail: string;
+  dimension?: Dimension;
 }
 
 /**

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -37,6 +37,12 @@ export interface Assertions {
    * the galaxy/brc Python harnesses with LLMJudge.
    */
   notebook?: NotebookAssertions;
+  /**
+   * Source-aware plan check. Unlike `chatPlan` / `notebook.plan` (which are
+   * pinned to one surface), this reads the latest plan from wherever it landed
+   * per `source` (default "any"). Preferred for decision-correctness scenarios.
+   */
+  plan?: PlanAssertions;
   exitCode?: number;
 }
 
@@ -54,6 +60,12 @@ export interface NotebookAssertions {
 export interface PlanAssertions {
   /** at least one `## Plan X: ... [routing]` heading must exist */
   exists?: boolean;
+  /**
+   * Where to read the plan from. "any" (default) = notebook.md if it contains
+   * a plan, else the chat text. Models don't reliably follow Loom's
+   * draft-in-chat-then-write gate, so "any" is the right default for grading.
+   */
+  source?: "chat" | "notebook" | "any";
   /** routing tag in the heading must be one of these */
   routingIn?: ("local" | "galaxy" | "hybrid" | "remote")[];
   /** plan section must have at least N pending (`- [ ]`) steps */

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -63,6 +63,14 @@ export interface PlanAssertions {
    * Mirrors init-gate's >= 8 chars heuristic (number/title/anchor stripped).
    */
   eachStepHasDescription?: boolean;
+  /**
+   * The plan-source text must mention at least one of these (case-insensitive
+   * substring). Used as a coarse tool/approach-appropriateness check -- a
+   * heuristic, not an oracle. Curate generously to limit false negatives.
+   */
+  mentionsOneOf?: string[];
+  /** The plan-source text must mention none of these (case-insensitive). */
+  mentionsNoneOf?: string[];
 }
 
 export interface Scenario {

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -106,6 +106,9 @@ export interface Scenario {
    * path (slash-command preflight, etc.) leave it false and run once.
    */
   requiresModel?: boolean;
+  /** How many times to run each (scenario, model) cell. Default 3 when
+   *  requiresModel, else 1. Lets flaky models surface as pass-rates. */
+  runs?: number;
   inputs: string[];
   env?: Record<string, string>;
   /**
@@ -186,6 +189,8 @@ export interface ScenarioRun {
   scenario: Scenario;
   /** null for Tier 1 scenarios that don't traverse the matrix. */
   model: ModelEntry | null;
+  /** 0-based index of this run within its (scenario, model) cell. */
+  runIndex?: number;
   exitCode: number;
   events: AnyEvent[];
   stdout: string;
@@ -199,4 +204,17 @@ export interface ScenarioRun {
 export interface AnyEvent {
   type: string;
   [k: string]: unknown;
+}
+
+export interface CellDimension {
+  pass: number;
+  total: number;
+  verdict: boolean;
+}
+
+export interface Cell {
+  scenarioName: string;
+  modelId: string;
+  runs: number;
+  dimensions: Partial<Record<Dimension, CellDimension>>;
 }

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -44,6 +44,16 @@ export interface Assertions {
    */
   plan?: PlanAssertions;
   exitCode?: number;
+  behavior?: BehaviorAssertions;
+}
+
+export interface BehaviorAssertions {
+  /**
+   * The agent should ask a clarifying question rather than fabricate a plan.
+   * Passes iff the final chat contains a `?` AND no plan heading was emitted
+   * in chat or notebook.
+   */
+  asksClarifyingQuestion?: boolean;
 }
 
 export interface NotebookAssertions {

--- a/evals/lib/types.ts
+++ b/evals/lib/types.ts
@@ -132,6 +132,12 @@ export interface ModelEntry {
    * thinking-mode models (Qwen3-32B) emit them by default.
    */
   stripThinkingTags?: boolean;
+  /**
+   * Reasoning models (gpt-oss-120b) emit chain-of-thought in `reasoning_content`
+   * rather than inline. Surface that to Pi so it gives the model room and reads
+   * the field instead of returning empty `content`.
+   */
+  reasoningModel?: boolean;
 }
 
 export interface ModelMatrix {

--- a/evals/models.json
+++ b/evals/models.json
@@ -43,6 +43,64 @@
         "contextWindow": 32000,
         "maxTokens": 4096
       }
+    },
+    {
+      "id": "tacc:minimax-m2.7",
+      "provider": "tacc-sambanova",
+      "model": "MiniMax-M2.7",
+      "stripThinkingTags": true,
+      "envRequires": ["PROXY_URL", "PROXY_API_KEY"],
+      "providerConfig": {
+        "type": "openai-compatible",
+        "baseUrl": "PROXY_URL",
+        "baseUrlIsEnvVar": true,
+        "apiKeyEnvVar": "PROXY_API_KEY",
+        "contextWindow": 128000,
+        "maxTokens": 4096
+      }
+    },
+    {
+      "id": "tacc:gpt-oss-120b",
+      "provider": "tacc-sambanova",
+      "model": "gpt-oss-120b",
+      "reasoningModel": true,
+      "envRequires": ["PROXY_URL", "PROXY_API_KEY"],
+      "providerConfig": {
+        "type": "openai-compatible",
+        "baseUrl": "PROXY_URL",
+        "baseUrlIsEnvVar": true,
+        "apiKeyEnvVar": "PROXY_API_KEY",
+        "contextWindow": 128000,
+        "maxTokens": 8192
+      }
+    },
+    {
+      "id": "tacc:llama-3.1-8b",
+      "provider": "tacc-sambanova",
+      "model": "Meta-Llama-3.1-8B-Instruct",
+      "envRequires": ["PROXY_URL", "PROXY_API_KEY"],
+      "providerConfig": {
+        "type": "openai-compatible",
+        "baseUrl": "PROXY_URL",
+        "baseUrlIsEnvVar": true,
+        "apiKeyEnvVar": "PROXY_API_KEY",
+        "contextWindow": 128000,
+        "maxTokens": 4096
+      }
+    },
+    {
+      "id": "tacc:gemma-4-31b",
+      "provider": "tacc-sambanova",
+      "model": "gemma-4-31B-it",
+      "envRequires": ["PROXY_URL", "PROXY_API_KEY"],
+      "providerConfig": {
+        "type": "openai-compatible",
+        "baseUrl": "PROXY_URL",
+        "baseUrlIsEnvVar": true,
+        "apiKeyEnvVar": "PROXY_API_KEY",
+        "contextWindow": 128000,
+        "maxTokens": 4096
+      }
     }
   ]
 }

--- a/evals/run.ts
+++ b/evals/run.ts
@@ -48,15 +48,34 @@ async function main() {
   }
 
   const matrix = loadMatrix(args.modelFilter);
+
+  // Guard 1: --model filter matched nothing in models.json at all.
+  if (
+    args.modelFilter &&
+    matrix.available.length === 0 &&
+    matrix.skipped.length === 0
+  ) {
+    console.error(
+      `error: --model filter matched no models in models.json: ${args.modelFilter.join(", ")}`,
+    );
+    process.exit(2);
+  }
+
   for (const { model, missing } of matrix.skipped) {
     console.warn(`[skip] ${model.id} -- missing env: ${missing.join(", ")}`);
   }
 
   const runs: ScenarioRun[] = [];
+  let hasRequiresModel = false;
+  let modelCellsRun = 0;
   for (const dir of scenarioDirs) {
     const scenario = readScenario(dir);
     const cells: (ModelEntry | null)[] = scenario.requiresModel ? [...matrix.available] : [null];
+    if (scenario.requiresModel) {
+      hasRequiresModel = true;
+    }
     for (const model of cells) {
+      if (model !== null) modelCellsRun++;
       const runCount = scenario.requiresModel ? (scenario.runs ?? 3) : (scenario.runs ?? 1);
       for (let i = 0; i < runCount; i++) {
         const run = await runScenario(dir, model);
@@ -68,6 +87,12 @@ async function main() {
     if (scenario.requiresModel && matrix.available.length === 0) {
       console.warn(`[skip] ${scenario.name} -- requiresModel but no available models in matrix`);
     }
+  }
+
+  // Guard 2: had requiresModel scenarios but no model actually ran (no creds).
+  if (hasRequiresModel && modelCellsRun === 0) {
+    console.error("error: no models available; graded 0 model evals -- check credentials");
+    process.exit(1);
   }
 
   report(runs);

--- a/evals/run.ts
+++ b/evals/run.ts
@@ -55,9 +55,13 @@ async function main() {
     const scenario = readScenario(dir);
     const cells: (ModelEntry | null)[] = scenario.requiresModel ? [...matrix.available] : [null];
     for (const model of cells) {
-      const run = await runScenario(dir, model);
-      run.failures = evaluate(run);
-      runs.push(run);
+      const runCount = scenario.requiresModel ? (scenario.runs ?? 3) : (scenario.runs ?? 1);
+      for (let i = 0; i < runCount; i++) {
+        const run = await runScenario(dir, model);
+        run.runIndex = i;
+        run.failures = evaluate(run);
+        runs.push(run);
+      }
     }
     if (scenario.requiresModel && matrix.available.length === 0) {
       console.warn(`[skip] ${scenario.name} -- requiresModel but no available models in matrix`);

--- a/evals/run.ts
+++ b/evals/run.ts
@@ -19,7 +19,9 @@ import { fileURLToPath } from "url";
 import { evaluate } from "./lib/assertions.js";
 import { loadDotEnv } from "./lib/env.js";
 import { loadMatrix } from "./lib/matrix.js";
-import { report } from "./lib/report.js";
+import { aggregateCells } from "./lib/aggregate.js";
+import { renderLeaderboard, report } from "./lib/report.js";
+import { writeResultsJsonl } from "./lib/persist.js";
 import { runScenario } from "./lib/runner.js";
 import type { ModelEntry, Scenario, ScenarioRun } from "./lib/types.js";
 
@@ -68,8 +70,20 @@ async function main() {
     }
   }
 
-  const { failed } = report(runs);
-  process.exit(failed === 0 ? 0 : 1);
+  report(runs);
+
+  const cells = aggregateCells(runs);
+  if (cells.some((c) => c.modelId !== "(none)")) {
+    console.log("");
+    console.log(renderLeaderboard(cells));
+  }
+
+  const resultsDir = path.join(evalsDir, "results");
+  const written = writeResultsJsonl(runs, resultsDir);
+  if (written) console.log(`\nresults: ${path.relative(process.cwd(), written)}`);
+
+  const anyDimFailed = cells.some((c) => Object.values(c.dimensions).some((d) => d && !d.verdict));
+  process.exit(anyDimFailed ? 1 : 0);
 }
 
 function readScenario(dir: string): Scenario {

--- a/evals/scenarios/behavior-underspecified-ask/scenario.json
+++ b/evals/scenarios/behavior-underspecified-ask/scenario.json
@@ -1,0 +1,13 @@
+{
+  "name": "behavior: an underspecified request should prompt a clarifying question",
+  "description": "The user says only 'analyze my data' with no context -- no data type, no goal. The correct behavior is to ask a clarifying question, not fabricate a full plan. Weak models barrel ahead and invent an analysis; this discriminates them. Single-turn on purpose.",
+  "tier": 2,
+  "requiresModel": true,
+  "loomArgs": ["--tools", "read,write,edit"],
+  "inputs": ["Analyze my data."],
+  "timeoutMs": 90000,
+  "assertions": {
+    "events": { "mustInclude": ["agent_start", "turn_end"] },
+    "behavior": { "asksClarifyingQuestion": true }
+  }
+}

--- a/evals/scenarios/plan-creation-metagenomics/scenario.json
+++ b/evals/scenarios/plan-creation-metagenomics/scenario.json
@@ -11,14 +11,12 @@
   "timeoutMs": 150000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
-    "notebook": {
+    "plan": {
       "exists": true,
-      "plan": {
-        "exists": true,
-        "routingIn": ["galaxy", "hybrid", "local", "remote"],
-        "minPendingSteps": 4,
-        "eachStepHasDescription": true
-      }
+      "routingIn": ["galaxy", "hybrid"],
+      "minPendingSteps": 4,
+      "eachStepHasDescription": true,
+      "mentionsOneOf": ["Kraken", "MetaPhlAn", "Kaiju", "Centrifuge", "Bracken"]
     }
   }
 }

--- a/evals/scenarios/plan-creation-pharmacogenomics/scenario.json
+++ b/evals/scenarios/plan-creation-pharmacogenomics/scenario.json
@@ -11,14 +11,11 @@
   "timeoutMs": 150000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
-    "notebook": {
+    "plan": {
       "exists": true,
-      "plan": {
-        "exists": true,
-        "routingIn": ["local", "hybrid"],
-        "minPendingSteps": 3,
-        "eachStepHasDescription": true
-      }
+      "routingIn": ["local", "hybrid"],
+      "minPendingSteps": 3,
+      "eachStepHasDescription": true
     }
   }
 }

--- a/evals/scenarios/plan-creation-rnaseq/scenario.json
+++ b/evals/scenarios/plan-creation-rnaseq/scenario.json
@@ -13,14 +13,12 @@
     "events": {
       "mustInclude": ["agent_start", "turn_end"]
     },
-    "notebook": {
+    "plan": {
       "exists": true,
-      "plan": {
-        "exists": true,
-        "routingIn": ["galaxy", "hybrid", "local", "remote"],
-        "minPendingSteps": 4,
-        "eachStepHasDescription": true
-      }
+      "routingIn": ["galaxy", "hybrid"],
+      "minPendingSteps": 4,
+      "eachStepHasDescription": true,
+      "mentionsOneOf": ["HISAT2", "STAR", "salmon", "kallisto", "DESeq2", "edgeR", "limma", "featureCounts"]
     }
   }
 }

--- a/evals/scenarios/plan-creation-scrna-celltypes/scenario.json
+++ b/evals/scenarios/plan-creation-scrna-celltypes/scenario.json
@@ -11,14 +11,12 @@
   "timeoutMs": 150000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
-    "notebook": {
+    "plan": {
       "exists": true,
-      "plan": {
-        "exists": true,
-        "routingIn": ["galaxy", "hybrid", "local", "remote"],
-        "minPendingSteps": 4,
-        "eachStepHasDescription": true
-      }
+      "routingIn": ["galaxy", "hybrid"],
+      "minPendingSteps": 4,
+      "eachStepHasDescription": true,
+      "mentionsOneOf": ["Scanpy", "Seurat", "STARsolo", "CellRanger", "Cell Ranger", "AnnData"]
     }
   }
 }

--- a/evals/scenarios/plan-creation-somatic-variants/scenario.json
+++ b/evals/scenarios/plan-creation-somatic-variants/scenario.json
@@ -11,14 +11,12 @@
   "timeoutMs": 150000,
   "assertions": {
     "events": { "mustInclude": ["agent_start", "turn_end"] },
-    "notebook": {
+    "plan": {
       "exists": true,
-      "plan": {
-        "exists": true,
-        "routingIn": ["galaxy", "hybrid", "local", "remote"],
-        "minPendingSteps": 5,
-        "eachStepHasDescription": true
-      }
+      "routingIn": ["galaxy", "hybrid"],
+      "minPendingSteps": 5,
+      "eachStepHasDescription": true,
+      "mentionsOneOf": ["Mutect", "VarScan", "Strelka", "GATK", "FreeBayes", "bcftools"]
     }
   }
 }

--- a/evals/scenarios/routing-clear-galaxy/scenario.json
+++ b/evals/scenarios/routing-clear-galaxy/scenario.json
@@ -1,0 +1,22 @@
+{
+  "name": "routing: a compute-heavy genomics task should route to Galaxy",
+  "description": "Whole-genome alignment of many samples against a reference -- far beyond a laptop. The correct routing is galaxy (or hybrid). Tests that the model recognizes when to offload to Galaxy.",
+  "tier": 2,
+  "requiresModel": true,
+  "loomArgs": ["--tools", "read,write,edit"],
+  "inputs": [
+    "I need to align 50 whole-genome sequencing samples (paired-end FASTQ, ~30x each) against the human reference hg38. That's way more than my laptop can handle. Help me draft a plan. Don't run anything yet.",
+    "Yes, hg38 is right and these need real compute. Go ahead and draft the formal plan now."
+  ],
+  "timeoutMs": 150000,
+  "assertions": {
+    "events": { "mustInclude": ["agent_start", "turn_end"] },
+    "plan": {
+      "exists": true,
+      "routingIn": ["galaxy"],
+      "minPendingSteps": 3,
+      "eachStepHasDescription": true,
+      "mentionsOneOf": ["BWA", "bwa-mem", "Bowtie", "minimap", "DRAGEN"]
+    }
+  }
+}

--- a/evals/scenarios/routing-clear-local/scenario.json
+++ b/evals/scenarios/routing-clear-local/scenario.json
@@ -1,0 +1,21 @@
+{
+  "name": "routing: a plainly local task should not be routed to Galaxy",
+  "description": "A small file-wrangling task with no bioinformatics compute. The correct routing is local (or hybrid) -- a model that reflexively sends everything to Galaxy fails the routing dimension. Tests routing restraint, the inverse of the bioinformatics scenarios.",
+  "tier": 2,
+  "requiresModel": true,
+  "loomArgs": ["--tools", "read,write,edit"],
+  "inputs": [
+    "I have a folder of about 200 scanned PDFs with messy inconsistent filenames on my laptop. Help me draft a plan to rename them into a consistent scheme. Don't run anything yet.",
+    "Yes, that scheme is fine. Go ahead and draft the formal plan now."
+  ],
+  "timeoutMs": 150000,
+  "assertions": {
+    "events": { "mustInclude": ["agent_start", "turn_end"] },
+    "plan": {
+      "exists": true,
+      "routingIn": ["local", "hybrid"],
+      "minPendingSteps": 2,
+      "eachStepHasDescription": true
+    }
+  }
+}

--- a/tests/evals-aggregate.test.ts
+++ b/tests/evals-aggregate.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { aggregateCells, declaredDimensions } from "../evals/lib/aggregate";
+import type { Assertions, Scenario, ScenarioRun } from "../evals/lib/types";
+
+function run(modelId: string, runIndex: number, failDims: string[]): ScenarioRun {
+  return {
+    scenarioDir: "/tmp/s",
+    scenario: { name: "s", tier: 2, requiresModel: true, inputs: ["x"], assertions: {} },
+    model: { id: modelId, provider: "p", model: "m" },
+    runIndex,
+    exitCode: 0,
+    events: [],
+    stdout: "",
+    stderr: "",
+    notebookContent: null,
+    failures: failDims.map((d) => ({ assertion: d, detail: "", dimension: d as never })),
+    durationMs: 1,
+  };
+}
+
+describe("evals aggregate", () => {
+  it("declaredDimensions reflects which assertions a scenario uses", () => {
+    const a: Assertions = {
+      plan: { routingIn: ["galaxy"], minPendingSteps: 3, mentionsOneOf: ["X"] },
+      behavior: { asksClarifyingQuestion: true },
+    };
+    const s = { name: "s", tier: 2, inputs: ["x"], assertions: a } as Scenario;
+    const dims = declaredDimensions(s);
+    expect([...dims].sort()).toEqual(["behavior", "routing", "tools", "validity"]);
+  });
+
+  it("computes majority verdict per dimension across 3 runs", () => {
+    const runs: ScenarioRun[] = [
+      run("tacc:x", 0, ["routing"]),
+      run("tacc:x", 1, []),
+      run("tacc:x", 2, []),
+    ];
+    // declare routing for the scenario so it's counted
+    runs.forEach((r) => (r.scenario.assertions = { plan: { routingIn: ["galaxy"] } }));
+    const cells = aggregateCells(runs);
+    expect(cells).toHaveLength(1);
+    expect(cells[0].dimensions.routing.pass).toBe(2);
+    expect(cells[0].dimensions.routing.total).toBe(3);
+    expect(cells[0].dimensions.routing.verdict).toBe(true); // 2/3 majority
+  });
+});

--- a/tests/evals-aggregate.test.ts
+++ b/tests/evals-aggregate.test.ts
@@ -30,6 +30,16 @@ describe("evals aggregate", () => {
     expect([...dims].sort()).toEqual(["behavior", "routing", "tools", "validity"]);
   });
 
+  it("declaredDimensions includes 'validity' when plan.exists is false", () => {
+    // exists: false means the scenario asserts no plan should appear.
+    // aggregation must count that dimension -- otherwise a model that writes a
+    // plan when it shouldn't passes silently (false green).
+    const a: Assertions = { plan: { exists: false } };
+    const s = { name: "s", tier: 2, inputs: ["x"], assertions: a } as Scenario;
+    const dims = declaredDimensions(s);
+    expect(dims).toContain("validity");
+  });
+
   it("computes majority verdict per dimension across 3 runs", () => {
     const runs: ScenarioRun[] = [
       run("tacc:x", 0, ["routing"]),

--- a/tests/evals-aggregate.test.ts
+++ b/tests/evals-aggregate.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { aggregateCells, declaredDimensions } from "../evals/lib/aggregate";
+import { renderLeaderboard } from "../evals/lib/report";
 import type { Assertions, Scenario, ScenarioRun } from "../evals/lib/types";
 
 function run(modelId: string, runIndex: number, failDims: string[]): ScenarioRun {
@@ -42,5 +43,36 @@ describe("evals aggregate", () => {
     expect(cells[0].dimensions.routing.pass).toBe(2);
     expect(cells[0].dimensions.routing.total).toBe(3);
     expect(cells[0].dimensions.routing.verdict).toBe(true); // 2/3 majority
+  });
+});
+
+describe("evals leaderboard render", () => {
+  it("renders a model x dimension grid with pass-rates", () => {
+    const cells = [
+      {
+        scenarioName: "s1",
+        modelId: "tacc:qwen3-32b",
+        runs: 3,
+        dimensions: {
+          routing: { pass: 3, total: 3, verdict: true },
+          tools: { pass: 2, total: 3, verdict: true },
+        },
+      },
+      {
+        scenarioName: "s1",
+        modelId: "tacc:llama-3.1-8b",
+        runs: 3,
+        dimensions: {
+          routing: { pass: 0, total: 3, verdict: false },
+          tools: { pass: 1, total: 3, verdict: false },
+        },
+      },
+    ];
+    const md = renderLeaderboard(cells);
+    expect(md).toContain("tacc:qwen3-32b");
+    expect(md).toContain("tacc:llama-3.1-8b");
+    expect(md).toContain("routing");
+    // qwen passed routing in 3/3 -> shows 3/3; llama 0/3
+    expect(md).toMatch(/tacc:qwen3-32b.*3\/3/s);
   });
 });

--- a/tests/evals-assertions.test.ts
+++ b/tests/evals-assertions.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { evaluate } from "../evals/lib/assertions";
+import type { AnyEvent, Assertions, ModelEntry, ScenarioRun } from "../evals/lib/types";
+
+function textEvents(text: string): AnyEvent[] {
+  return [
+    { type: "agent_start" },
+    { type: "message_update", assistantMessageEvent: { type: "text_delta", delta: text } },
+    { type: "turn_end" },
+  ];
+}
+
+function makeRun(opts: {
+  events?: AnyEvent[];
+  notebookContent?: string | null;
+  assertions: Assertions;
+  model?: ModelEntry | null;
+}): ScenarioRun {
+  return {
+    scenarioDir: "/tmp/x",
+    scenario: {
+      name: "test",
+      tier: 2,
+      inputs: ["go"],
+      assertions: opts.assertions,
+    },
+    model: opts.model ?? null,
+    exitCode: 0,
+    events: opts.events ?? [],
+    stdout: "",
+    stderr: "",
+    notebookContent: opts.notebookContent ?? null,
+    failures: [],
+    durationMs: 1,
+  };
+}
+
+describe("evals assertions: dimension tagging", () => {
+  it("tags a routing failure as 'routing' and a validity failure as 'validity'", () => {
+    const run = makeRun({
+      notebookContent: "## Plan 1: Thing [local]\n- [ ] 1. **Do** -- a real description here",
+      assertions: { notebook: { plan: { routingIn: ["galaxy"], minPendingSteps: 3 } } },
+    });
+    const failures = evaluate(run);
+    const routing = failures.find((f) => f.assertion.endsWith("routingIn"));
+    const validity = failures.find((f) => f.assertion.endsWith("minPendingSteps"));
+    expect(routing?.dimension).toBe("routing");
+    expect(validity?.dimension).toBe("validity");
+  });
+
+  it("tags exitCode failures as 'other'", () => {
+    const run = makeRun({ assertions: { exitCode: 0 } });
+    run.exitCode = 1;
+    const failures = evaluate(run);
+    expect(failures[0].dimension).toBe("other");
+  });
+});

--- a/tests/evals-assertions.test.ts
+++ b/tests/evals-assertions.test.ts
@@ -89,3 +89,36 @@ describe("evals assertions: tool mentions", () => {
     expect(f[0].assertion).toContain("mentionsNoneOf");
   });
 });
+
+describe("evals assertions: source-aware plan (Assertions.plan)", () => {
+  it("reads the notebook plan when source defaults to 'any' and notebook has one", () => {
+    const run = makeRun({
+      events: textEvents("Here is a draft idea, no formal plan."),
+      notebookContent: "## Plan 1: Real [galaxy]\n- [ ] 1. **Align** -- HISAT2 over hg38 reads",
+      assertions: { plan: { routingIn: ["galaxy"], mentionsOneOf: ["HISAT2"] } },
+    });
+    expect(evaluate(run)).toHaveLength(0);
+  });
+
+  it("falls back to chat when no notebook plan exists", () => {
+    const run = makeRun({
+      events: textEvents("## Plan 1: Chatted [local]\n- [ ] 1. **Rename** -- tidy the files up"),
+      notebookContent: null,
+      assertions: { plan: { routingIn: ["local"] } },
+    });
+    expect(evaluate(run)).toHaveLength(0);
+  });
+
+  it("honors an explicit source: 'chat' and does not read the notebook", () => {
+    const run = makeRun({
+      events: textEvents("## Plan 1: Chatted [hybrid]\n- [ ] 1. **Step** -- do the thing here"),
+      notebookContent: "## Plan 1: Notebook [galaxy]\n- [ ] 1. **Step** -- other thing here",
+      assertions: { plan: { source: "chat", routingIn: ["galaxy"] } },
+    });
+    // chat routing is hybrid; expected galaxy -> exactly one routing failure.
+    // If `plan` is unimplemented this yields 0 failures and the test fails.
+    const f = evaluate(run);
+    expect(f).toHaveLength(1);
+    expect(f[0].dimension).toBe("routing");
+  });
+});

--- a/tests/evals-assertions.test.ts
+++ b/tests/evals-assertions.test.ts
@@ -154,6 +154,31 @@ describe("evals assertions: behavior asksClarifyingQuestion", () => {
   });
 });
 
+describe("evals assertions: null notebook content with plan assertions", () => {
+  it("produces validity, routing, AND tools failures when notebook is absent but plan assertions are declared", () => {
+    // When notebookContent is null and notebook.plan is declared, the old code
+    // pushed only a single generic 'other' failure and returned early, leaving
+    // routing and tools dimensions showing false green on the leaderboard.
+    const run = makeRun({
+      notebookContent: null,
+      assertions: {
+        notebook: {
+          plan: {
+            exists: true,
+            routingIn: ["galaxy"],
+            mentionsOneOf: ["STAR"],
+          },
+        },
+      },
+    });
+    const failures = evaluate(run);
+    const dims = new Set(failures.map((f) => f.dimension));
+    expect(dims).toContain("validity");
+    expect(dims).toContain("routing");
+    expect(dims).toContain("tools");
+  });
+});
+
 describe("evals assertions: null plan fails all declared dimensions", () => {
   it("produces validity, routing, AND tools failures when no plan is found", () => {
     // A run with no plan anywhere -- empty events, null notebookContent.

--- a/tests/evals-assertions.test.ts
+++ b/tests/evals-assertions.test.ts
@@ -55,3 +55,37 @@ describe("evals assertions: dimension tagging", () => {
     expect(failures[0].dimension).toBe("other");
   });
 });
+
+describe("evals assertions: tool mentions", () => {
+  const nb = (body: string) => `## Plan 1: Metagenomics [galaxy]\n- [ ] 1. **Classify** -- ${body}`;
+
+  it("passes when the plan mentions one of the allowed tools (case-insensitive)", () => {
+    const run = makeRun({
+      notebookContent: nb("run kraken2 to assign taxonomy to reads"),
+      assertions: { notebook: { plan: { mentionsOneOf: ["Kraken", "MetaPhlAn"] } } },
+    });
+    expect(evaluate(run)).toHaveLength(0);
+  });
+
+  it("fails (dimension tools) when none of the allowed tools appear", () => {
+    const run = makeRun({
+      notebookContent: nb("eyeball the reads and guess the organisms"),
+      assertions: { notebook: { plan: { mentionsOneOf: ["Kraken", "MetaPhlAn"] } } },
+    });
+    const f = evaluate(run);
+    expect(f).toHaveLength(1);
+    expect(f[0].dimension).toBe("tools");
+    expect(f[0].assertion).toContain("mentionsOneOf");
+  });
+
+  it("fails when a banned tool is named", () => {
+    const run = makeRun({
+      notebookContent: nb("BLAST every read against nt, no classifier"),
+      assertions: { notebook: { plan: { mentionsNoneOf: ["BLAST"] } } },
+    });
+    const f = evaluate(run);
+    expect(f).toHaveLength(1);
+    expect(f[0].dimension).toBe("tools");
+    expect(f[0].assertion).toContain("mentionsNoneOf");
+  });
+});

--- a/tests/evals-assertions.test.ts
+++ b/tests/evals-assertions.test.ts
@@ -153,3 +153,29 @@ describe("evals assertions: behavior asksClarifyingQuestion", () => {
     expect(f.some((x) => x.assertion.includes("asksClarifyingQuestion"))).toBe(true);
   });
 });
+
+describe("evals assertions: null plan fails all declared dimensions", () => {
+  it("produces validity, routing, AND tools failures when no plan is found", () => {
+    // A run with no plan anywhere -- empty events, null notebookContent.
+    // The scenario declares routing and tools assertions alongside exists.
+    // Before the fix, only a single validity failure was pushed; routing and
+    // tools dimensions were silently skipped, making the leaderboard look green.
+    const run = makeRun({
+      events: [],
+      notebookContent: null,
+      assertions: {
+        plan: {
+          exists: true,
+          routingIn: ["galaxy"],
+          minPendingSteps: 4,
+          mentionsOneOf: ["STAR"],
+        },
+      },
+    });
+    const failures = evaluate(run);
+    const dims = new Set(failures.map((f) => f.dimension));
+    expect(dims).toContain("validity");
+    expect(dims).toContain("routing");
+    expect(dims).toContain("tools");
+  });
+});

--- a/tests/evals-assertions.test.ts
+++ b/tests/evals-assertions.test.ts
@@ -122,3 +122,34 @@ describe("evals assertions: source-aware plan (Assertions.plan)", () => {
     expect(f[0].dimension).toBe("routing");
   });
 });
+
+describe("evals assertions: behavior asksClarifyingQuestion", () => {
+  it("passes when the agent asks a question and writes no plan", () => {
+    const run = makeRun({
+      events: textEvents("Happy to help! What data do you have, and what's the goal?"),
+      notebookContent: null,
+      assertions: { behavior: { asksClarifyingQuestion: true } },
+    });
+    expect(evaluate(run)).toHaveLength(0);
+  });
+
+  it("fails (behavior) when the agent fabricates a plan instead of asking", () => {
+    const run = makeRun({
+      events: textEvents("## Plan 1: Guessed [galaxy]\n- [ ] 1. **Align** -- assume RNA-seq here"),
+      notebookContent: null,
+      assertions: { behavior: { asksClarifyingQuestion: true } },
+    });
+    const f = evaluate(run);
+    expect(f.some((x) => x.dimension === "behavior")).toBe(true);
+  });
+
+  it("fails when the agent neither asks nor errors out (no question mark)", () => {
+    const run = makeRun({
+      events: textEvents("Okay."),
+      notebookContent: null,
+      assertions: { behavior: { asksClarifyingQuestion: true } },
+    });
+    const f = evaluate(run);
+    expect(f.some((x) => x.assertion.includes("asksClarifyingQuestion"))).toBe(true);
+  });
+});

--- a/tests/evals-matrix.test.ts
+++ b/tests/evals-matrix.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -21,6 +21,11 @@ const baseProviderConfig = {
 describe("evals matrix: writePiModelsConfig", () => {
   beforeEach(() => {
     process.env.PROXY_URL = "https://proxy.example/v1";
+  });
+
+  afterEach(() => {
+    // don't leak the fake PROXY_URL into other test files in this worker
+    delete process.env.PROXY_URL;
   });
 
   it("marks a reasoning model with reasoning:true and the configured maxTokens", () => {

--- a/tests/evals-matrix.test.ts
+++ b/tests/evals-matrix.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { writePiModelsConfig } from "../evals/lib/matrix";
+import type { ModelEntry } from "../evals/lib/types";
+
+function tmpAgentDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "evals-matrix-"));
+}
+
+const baseProviderConfig = {
+  type: "openai-compatible" as const,
+  baseUrl: "PROXY_URL",
+  baseUrlIsEnvVar: true,
+  apiKeyEnvVar: "PROXY_API_KEY",
+  contextWindow: 128000,
+  maxTokens: 8192,
+};
+
+describe("evals matrix: writePiModelsConfig", () => {
+  beforeEach(() => {
+    process.env.PROXY_URL = "https://proxy.example/v1";
+  });
+
+  it("marks a reasoning model with reasoning:true and the configured maxTokens", () => {
+    const model: ModelEntry = {
+      id: "tacc:gpt-oss-120b",
+      provider: "tacc-sambanova",
+      model: "gpt-oss-120b",
+      reasoningModel: true,
+      providerConfig: baseProviderConfig,
+    };
+    const dir = tmpAgentDir();
+    writePiModelsConfig(model, dir);
+    const cfg = JSON.parse(fs.readFileSync(path.join(dir, "models.json"), "utf-8"));
+    const entry = cfg.providers["tacc-sambanova"].models[0];
+    expect(entry.reasoning).toBe(true);
+    expect(entry.maxTokens).toBe(8192);
+  });
+
+  it("defaults non-reasoning models to reasoning:false", () => {
+    const model: ModelEntry = {
+      id: "tacc:llama-3.3-70b",
+      provider: "tacc-sambanova",
+      model: "Meta-Llama-3.3-70B-Instruct",
+      providerConfig: { ...baseProviderConfig, maxTokens: 4096 },
+    };
+    const dir = tmpAgentDir();
+    writePiModelsConfig(model, dir);
+    const cfg = JSON.parse(fs.readFileSync(path.join(dir, "models.json"), "utf-8"));
+    expect(cfg.providers["tacc-sambanova"].models[0].reasoning).toBe(false);
+  });
+});

--- a/tests/evals-persist.test.ts
+++ b/tests/evals-persist.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { writeResultsJsonl } from "../evals/lib/persist";
+import type { ScenarioRun } from "../evals/lib/types";
+
+function run(modelId: string, idx: number): ScenarioRun {
+  return {
+    scenarioDir: "/tmp/s",
+    scenario: { name: "s", tier: 2, requiresModel: true, inputs: ["x"], assertions: {} },
+    model: { id: modelId, provider: "p", model: "m" },
+    runIndex: idx,
+    exitCode: 0,
+    events: [{ type: "turn_end", usage: { inputTokens: 10, outputTokens: 5 } }],
+    stdout: "",
+    stderr: "",
+    notebookContent: null,
+    failures: [{ assertion: "x", detail: "y", dimension: "routing" }],
+    durationMs: 42,
+  };
+}
+
+describe("evals persist", () => {
+  it("writes one JSONL line per run with model, dims, and duration", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "evals-persist-"));
+    const out = writeResultsJsonl([run("tacc:x", 0), run("tacc:x", 1)], dir);
+    expect(out).not.toBeNull();
+    const lines = fs.readFileSync(out!, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    const first = JSON.parse(lines[0]);
+    expect(first.modelId).toBe("tacc:x");
+    expect(first.scenario).toBe("s");
+    expect(first.failedDimensions).toContain("routing");
+    expect(typeof first.durationMs).toBe("number");
+  });
+});

--- a/tests/evals-scenarios.test.ts
+++ b/tests/evals-scenarios.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import type { Scenario } from "../evals/lib/types";
+
+const __filename2 = fileURLToPath(import.meta.url);
+const scenariosDir = path.resolve(path.dirname(__filename2), "..", "evals", "scenarios");
+
+function loadScenario(name: string): Scenario {
+  return JSON.parse(
+    fs.readFileSync(path.join(scenariosDir, name, "scenario.json"), "utf-8"),
+  ) as Scenario;
+}
+
+describe("evals scenarios: every scenario.json parses with required fields", () => {
+  const dirs = fs
+    .readdirSync(scenariosDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name);
+
+  for (const dir of dirs) {
+    it(`${dir} has name, tier, inputs, assertions`, () => {
+      const s = loadScenario(dir);
+      expect(typeof s.name).toBe("string");
+      expect([1, 2]).toContain(s.tier);
+      expect(Array.isArray(s.inputs)).toBe(true);
+      expect(s.assertions).toBeTruthy();
+    });
+  }
+
+  it("rnaseq routes galaxy/hybrid and names a known RNA-seq tool", () => {
+    const s = loadScenario("plan-creation-rnaseq");
+    expect(s.assertions.plan?.routingIn).toEqual(["galaxy", "hybrid"]);
+    expect(s.assertions.plan?.mentionsOneOf).toContain("HISAT2");
+  });
+
+  it("pharmacogenomics routes local/hybrid (consumer data stays off public Galaxy)", () => {
+    const s = loadScenario("plan-creation-pharmacogenomics");
+    expect(s.assertions.plan?.routingIn).toEqual(["local", "hybrid"]);
+  });
+});

--- a/tests/evals-scenarios.test.ts
+++ b/tests/evals-scenarios.test.ts
@@ -39,4 +39,14 @@ describe("evals scenarios: every scenario.json parses with required fields", () 
     const s = loadScenario("plan-creation-pharmacogenomics");
     expect(s.assertions.plan?.routingIn).toEqual(["local", "hybrid"]);
   });
+
+  it("routing-clear-local must not route to galaxy", () => {
+    const s = loadScenario("routing-clear-local");
+    expect(s.assertions.plan?.routingIn).toEqual(["local", "hybrid"]);
+  });
+
+  it("behavior-underspecified-ask asserts asksClarifyingQuestion", () => {
+    const s = loadScenario("behavior-underspecified-ask");
+    expect(s.assertions.behavior?.asksClarifyingQuestion).toBe(true);
+  });
 });


### PR DESCRIPTION
The eval harness we have measures *shape* -- did the agent emit a well-formed `## Plan X: [routing]` block. It never checked whether the model made the *right* call: every scenario accepted any routing tag, so a plan that sent a consumer's 23andMe data to a public Galaxy scored the same as one that kept it local. This turns that harness into a decision-correctness suite and points it at a 7-model open matrix so we get a leaderboard out of it.

Each scenario now carries the correct answer. Routing is tightened per scenario (metagenomics -> `[galaxy, hybrid]`, consumer pharmacogenomics -> `[local, hybrid]`), a `mentionsOneOf` allow-set checks the plan named a sane tool, and every failure is tagged with a dimension -- validity, routing, tools, or behavior. Plans are read from wherever they land (chat or notebook), since the open models don't reliably follow the draft-in-chat-then-write gate. A new behavior dimension catches the ask-before-assuming contract: an underspecified prompt should make the agent ask, not fabricate a plan.

Because open models are noisy, each (scenario, model) cell runs n=3 and a dimension passes on a majority. The runner prints a model x dimension leaderboard and writes per-run JSONL to `evals/results/` so we can diff models over time and across prompt changes. The matrix grew from 3 to 7 TACC models (added MiniMax-M2.7, gpt-oss-120b, Llama-3.1-8B, gemma-4-31B), all on the one SambaNova proxy.

It already earns its keep. A live `plan-creation-rnaseq` run across all 7 models surfaced:
- **qwen3-32b** formats perfectly but routes RNA-seq to `[local]` -- a real routing error
- **llama-3.3-70b** makes the right calls (routes `[galaxy]`, names STAR/featureCounts/DESeq2) but writes `1.`-numbered steps instead of `- [ ]` checkboxes, so the parser sees zero pending steps
- **gpt-oss-120b** returns empty content -- its reasoning lands in `reasoning_content`, which Pi doesn't surface, so it can't drive Loom until that's handled
- **minimax-m2.7** flaked routing 1-of-3 runs -- variance a single run would have hidden

The live run also caught a grading bug in this very change: models that emit no plan were scoring routing 3/3, tools 3/3 (false green) because the no-plan branch only failed validity. Fixed so validity gates the rest.

Out of scope by design: no LLM-judge plan-*quality* scoring (the tool allow-sets are coarse substring heuristics), no end-to-end execution, no recorded/live Galaxy MCP. The assertion library leaves seams for each.

43 unit tests, all green.
