### PR TITLE
Humanize the opaque "An unknown error occurred" provider error

### DIFF
--- a/app/src/renderer/chat/error-humanizer.ts
+++ b/app/src/renderer/chat/error-humanizer.ts
@@ -55,6 +55,23 @@ function isContextOverflowError(text: string): boolean {
   return CONTEXT_OVERFLOW_PATTERNS.some((p) => p.test(text));
 }
 
+// pi-ai's provider streams (google, anthropic, mistral, bedrock, openai-*, ...)
+// all throw a bare `new Error("An unknown error occurred")` when a turn ends
+// with stopReason "error"/"aborted". For Gemini that maps from finishReasons
+// like SAFETY, RECITATION, MALFORMED_FUNCTION_CALL and OTHER (#320) -- the
+// specific reason is discarded upstream, so by the time we see this sentinel
+// there's nothing left to classify. Echoing it verbatim is unactionable; detect
+// the fixed phrase and point the user at the moves that actually help.
+// Anchored to the whole (already-trimmed) message: the sentinel arrives
+// context-less, so a bare string that merely embeds the phrase (e.g. "stream
+// failed: an unknown error occurred mid-response") keeps its own, more useful
+// text instead of being swallowed into the generic nudge.
+const UNKNOWN_PROVIDER_ERROR = /^an unknown error occurred[.!?]*$/i;
+
+function isOpaqueProviderError(text: string): boolean {
+  return UNKNOWN_PROVIDER_ERROR.test(text);
+}
+
 export function humanizeAgentError(raw: string | undefined | null): HumanizedError {
   if (!raw) return { text: "Unknown error", retriable: false };
   const trimmed = raw.trim();
@@ -72,6 +89,21 @@ export function humanizeAgentError(raw: string | undefined | null): HumanizedErr
   }
 
   if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    // The opaque provider sentinel is always a bare string (pi throws
+    // `new Error("An unknown error occurred")`), so only catch it here -- a
+    // structured error that merely embeds the phrase should still get the typed
+    // handling below rather than being swallowed by this catch.
+    if (isOpaqueProviderError(trimmed)) {
+      return {
+        text:
+          "The model stopped before finishing and the provider gave no details -- " +
+          "often a safety/recitation filter, a malformed tool call, or a cut-off " +
+          "response. Try rephrasing and resending. Asking the model to reproduce a " +
+          "lot of text verbatim (e.g. the whole chat history) is a common trigger, " +
+          "so ask for a summary or a smaller chunk, or switch models.",
+        retriable: false,
+      };
+    }
     return { text: raw, retriable: false };
   }
 

--- a/tests/error-humanizer.test.ts
+++ b/tests/error-humanizer.test.ts
@@ -144,6 +144,55 @@ describe("humanizeAgentError", () => {
     });
   });
 
+  describe("opaque provider 'An unknown error occurred' (#320)", () => {
+    // pi-ai's provider streams throw a bare `new Error("An unknown error
+    // occurred")` whenever a turn ends with stopReason "error"/"aborted" -- for
+    // Gemini that covers SAFETY, RECITATION, MALFORMED_FUNCTION_CALL, OTHER, etc.
+    // (google-shared.ts mapStopReason). The detail is gone by the time it
+    // reaches us, so the sentinel must become an actionable nudge instead of
+    // being echoed verbatim.
+    it("replaces the bare sentinel with an actionable message", () => {
+      const result = humanizeAgentError("An unknown error occurred");
+      expect(result.text).not.toBe("An unknown error occurred");
+      expect(result.text.toLowerCase()).toMatch(/rephras|resend|summary|switch/);
+      expect(result.retriable).toBe(false);
+    });
+
+    it("matches case-insensitively and tolerates a trailing period", () => {
+      const result = humanizeAgentError("an unknown error occurred.");
+      expect(result.text).not.toMatch(/^an unknown error occurred/i);
+      expect(result.text.toLowerCase()).toMatch(/rephras|resend|summary|switch/);
+    });
+
+    it("does not misfire on a different, more specific error", () => {
+      const raw = "Connection reset by peer";
+      expect(humanizeAgentError(raw).text).toBe(raw);
+    });
+
+    it("does not swallow a bare string that merely embeds the phrase", () => {
+      // The real sentinel is context-less. A bare error that happens to contain
+      // the phrase carries its own detail, so it must pass through unchanged
+      // rather than be relabeled with the generic nudge (regex is anchored).
+      const raw = "Stream failed: an unknown error occurred mid-response";
+      const result = humanizeAgentError(raw);
+      expect(result.text).toBe(raw);
+      expect(result.text.toLowerCase()).not.toMatch(/rephras|resend|summary|switch/);
+    });
+
+    it("defers to typed JSON handling when a structured error merely contains the phrase", () => {
+      // The real pi-ai sentinel is always a bare string. A structured provider
+      // error that happens to embed the phrase should still get its typed
+      // treatment, not be swallowed by the sentinel catch.
+      const raw = JSON.stringify({
+        type: "error",
+        error: { type: "api_error", message: "An unknown error occurred upstream" },
+      });
+      const result = humanizeAgentError(raw);
+      expect(result.text).toMatch(/upstream api error/i);
+      expect(result.retriable).toBe(true);
+    });
+  });
+
   describe("context overflow", () => {
     it("humanizes the OpenAI-compatible context-length 400 (deepseek-v4-flash) into a /compact nudge", () => {
       // The verbatim string from issue #209 -- arrives as a plain string, not JSON.


### PR DESCRIPTION
## What this does

Asking the agent to "save the full chat history to a Markdown file" (provider google / gemini-2.5-flash) replied with a bogus *"...saved as chat_history.md"* immediately followed by **"An unknown error occurred"** -- no file written, nothing in the Files pane (#320). This humanizes that opaque error into something the user can act on.

## Root cause

"An unknown error occurred" isn't a Loom string -- it's absent from the repo at every tag (incl. `v0.3.1`) and from git history. It's a **pi-ai provider sentinel**: when a turn ends with `stopReason` `"error"`/`"aborted"`, the provider streams `throw new Error("An unknown error occurred")` and discard the real reason. For Gemini, `mapStopReason` buckets **RECITATION, SAFETY, MALFORMED_FUNCTION_CALL, OTHER, BLOCKLIST, ...** all into `"error"` (only `STOP`/`MAX_TOKENS` escape). The sentinel reaches the renderer via the `message_end` path (`stopReason === "error"`), where `humanizeAgentError` previously echoed the bare string verbatim. pi-ai is pinned `^0.78.0` in both `v0.3.1` and current `main`, so the path is unchanged -- the bug reproduces today.

Asking the model to reproduce the whole conversation verbatim is itself a classic recitation/safety trigger, and there's no agent-callable chat-export tool (the "Export Chat" button is renderer-only), so the model has to reconstruct the transcript -- which is what trips the stop.

## The fix

A sentinel case in `error-humanizer.ts` that detects the fixed phrase and returns an actionable message (rephrase/resend, ask for a summary instead of verbatim text, switch models). The exact reason is gone by the time we see it, so the message names the common causes rather than guessing one. The match is caught only in the bare-string branch, so a *structured* error that merely embeds the phrase still gets its typed handling.

## What's intentionally NOT here

The issue's second angle -- don't let the agent claim "saved as X" when no write happened -- is a model-narration-without-tool-call behavior with no clean deterministic lever (the prose is already streamed before the turn errors). Left for discussion rather than patched, so this **Addresses** #320 but doesn't close it. Open questions:

1. A `context.ts` prompt nudge (write files via a tool and confirm only after success; prefer a summary over reproducing large text verbatim)? Best-effort on weak models, but it would plausibly cut the recitation trigger, not just relabel the failure.
2. A real agent-callable "save transcript" tool (Loom already has `exportAsMarkdown`) so the model never reconstructs the conversation -- sidesteps both the recitation stop and the false claim. That's a feature, not a bugfix.
3. Upstream pi-ai note: the sentinel discards the real finish reason; preserving it would let us give a precise message. This shell-side humanization is the right stopgap regardless.

## Review

Ran a Codex adversarial pass. It surfaced two risks:

- **Ordering / false positive (fixed in this PR):** the sentinel check originally ran ahead of the JSON branch, so a structured `api_error` whose message embedded the phrase would be swallowed instead of getting its typed, retriable handling. Moved into the bare-string branch; added a regression test.
- **Activity feed (noted, out of scope):** `feedShell`'s top-level `error` case appends `event.message` raw. It doesn't affect #320 (this error arrives via `message_end`, which `feedShell` doesn't handle), and that feed is a raw/technical view by design -- flagging rather than widening scope.

## Testing

- Test-first; watched it fail (echoed verbatim) before implementing.
- root `npm test`: 998 passed / 1 skipped · `app` `tsc --noEmit` clean · prettier/eslint clean.
- Not live-eyeballed end-to-end (no Gemini key driven to organically trip the stop); this is a code-path + unit-test reproduction.
