### PR TITLE
Persist the active analysis directory across restarts

### DIFF
--- a/app/src/main/agent.ts
+++ b/app/src/main/agent.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import fs from "node:fs";
 import os from "node:os";
 import { app, type BrowserWindow } from "electron";
-import { loadConfig } from "./config.js";
+import { loadConfig, saveConfig, getConfigPath } from "./config.js";
 import { resolveLlmApiKey, resolveGalaxyApiKey } from "./secure-config.js";
 import { loadSessionHistory, newestSessionFile } from "./session-replay.js";
 import { collectDescendantsOf } from "./proc-monitor.js";
@@ -222,7 +222,17 @@ export class AgentManager {
     log("cwd set to", cwd);
   }
 
-  switchCwd(cwd: string): boolean {
+  /**
+   * Switch to a new analysis directory and restart the brain there.
+   *
+   * `persist` (default true) writes the new directory to config.defaultCwd so a
+   * clean restart reopens it (#312). In-app directory picks (File > Open, the
+   * top-bar change button) persist; pass `persist: false` for transient `--cwd`
+   * overrides so a one-off CLI launch never becomes the permanent default --
+   * matching the first-instance path, which routes `--cwd` through getDefaultCwd
+   * at construction and likewise doesn't persist it.
+   */
+  switchCwd(cwd: string, opts: { persist?: boolean } = {}): boolean {
     if (cwd === this.cwd) return false;
     this.cwd = cwd;
     this.refreshWindowTitle();
@@ -234,11 +244,44 @@ export class AgentManager {
     this.nextStartSkipContinue = false;
     this.nextStartIsFresh = false;
     log("switching cwd to", cwd);
+    if (opts.persist !== false) this.persistCwd(cwd);
     if (this.process) {
       this.stop();
       this.start();
     }
     return true;
+  }
+
+  /**
+   * Persist the active analysis directory so a clean restart reopens it (#312).
+   * Reads-merges-writes through the shared config so unrelated keys (creds,
+   * skills, ...) survive. Best-effort: a config-write failure must not abort
+   * the in-progress directory switch, so log and move on rather than throw.
+   *
+   * Fails closed when config.json exists but won't parse: loadConfig() silently
+   * returns {} on a read/parse error, so writing that back would wipe stored
+   * credentials. Refuse rather than clobber -- a genuinely absent file is still
+   * fine to create. Mirrors setTesterId() in extensions/loom/tester-id-command.ts.
+   */
+  private persistCwd(cwd: string): void {
+    try {
+      const configPath = getConfigPath();
+      if (fs.existsSync(configPath)) {
+        try {
+          JSON.parse(fs.readFileSync(configPath, "utf-8"));
+        } catch {
+          log("skipped persisting cwd -- ~/.loom/config.json is unreadable");
+          return;
+        }
+      }
+      const cfg = loadConfig();
+      if (cfg.defaultCwd === cwd) return;
+      cfg.defaultCwd = cwd;
+      saveConfig(cfg);
+      log("persisted defaultCwd:", cwd);
+    } catch (err) {
+      log("failed to persist cwd:", err);
+    }
   }
 
   getCwd(): string {

--- a/app/src/main/main.ts
+++ b/app/src/main/main.ts
@@ -22,6 +22,7 @@ import { migratePlaintextSecrets, isAvailable as safeStorageAvailable } from "./
 import { getConfigDir, getConfigPath } from "../../../shared/loom-config.js";
 import { parseCliArgs, type CliArgs } from "./cli-args.js";
 import { initAutoUpdate } from "./auto-update.js";
+import { resolveStartupCwd } from "./startup-cwd.js";
 
 // Workaround for systems where chrome-sandbox isn't suid root
 app.commandLine.appendSwitch("no-sandbox");
@@ -133,17 +134,24 @@ function startConfigWatcher(): void {
 
 function getDefaultCwd(cliArgs?: CliArgs): string {
   // Priority: --cwd CLI arg > LOOM_CWD env > brain config.defaultCwd > hardcoded.
-  let cwd = cliArgs?.cwd || process.env.LOOM_CWD;
-  if (!cwd) {
+  // config.defaultCwd is rewritten by AgentManager.switchCwd on every in-app
+  // directory change, so a clean restart reopens the last-used directory (#312).
+  let configDefaultCwd: string | undefined;
+  if (!cliArgs?.cwd && !process.env.LOOM_CWD) {
     try {
       const configPath = path.join(LOOM_DIR, "config.json");
       if (fs.existsSync(configPath)) {
         const cfg = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-        if (cfg.defaultCwd) cwd = cfg.defaultCwd;
+        if (cfg.defaultCwd) configDefaultCwd = cfg.defaultCwd;
       }
     } catch {}
   }
-  cwd = cwd || DEFAULT_CWD;
+  let cwd = resolveStartupCwd({
+    cliCwd: cliArgs?.cwd,
+    envCwd: process.env.LOOM_CWD,
+    configDefaultCwd,
+    fallback: DEFAULT_CWD,
+  });
   if (cwd.startsWith("~")) cwd = path.join(os.homedir(), cwd.slice(1));
   mkdirSync(cwd, { recursive: true });
   return cwd;
@@ -540,7 +548,10 @@ app.whenReady().then(() => {
     if (resolvedCwd === agentManager.getCwd()) return;
     const ok = await confirmCwdChange(mainWindow ?? undefined, resolvedCwd);
     if (!ok) return;
-    if (agentManager.switchCwd(resolvedCwd)) {
+    // A `--cwd` override is a transient session choice, not a new default:
+    // don't persist it, mirroring first-instance startup (getDefaultCwd reads
+    // --cwd at construction without writing it back).
+    if (agentManager.switchCwd(resolvedCwd, { persist: false })) {
       log("switched cwd from second instance to:", resolvedCwd);
       mainWindow?.webContents.send("agent:cwd-changed", resolvedCwd);
       if (mainWindow) startFilesWatcher(mainWindow, resolvedCwd);

--- a/app/src/main/startup-cwd.ts
+++ b/app/src/main/startup-cwd.ts
@@ -1,0 +1,30 @@
+/**
+ * Inputs to the startup analysis-directory decision. Kept as a plain value
+ * object (no fs/env access) so the precedence is unit-testable apart from the
+ * electron-app glue in main.ts.
+ */
+export interface StartupCwdSources {
+  /** `--cwd` CLI argument, if passed. */
+  cliCwd?: string;
+  /** `LOOM_CWD` environment override, if set. */
+  envCwd?: string;
+  /** Persisted `config.defaultCwd` -- the last analysis directory used (#312). */
+  configDefaultCwd?: string;
+  /** Hardcoded default (`~/.loom/analyses`) used when nothing else applies. */
+  fallback: string;
+}
+
+/**
+ * Decide which analysis directory Orbit opens to.
+ *
+ * Priority: `--cwd` CLI arg > `LOOM_CWD` env > persisted `config.defaultCwd` >
+ * hardcoded fallback. The persisted `defaultCwd` is written by
+ * AgentManager.switchCwd whenever the user changes directories in-app, so a
+ * clean restart reopens the most recently used directory (#312).
+ *
+ * Returns the raw choice; the caller still expands a leading `~` and ensures
+ * the directory exists.
+ */
+export function resolveStartupCwd(sources: StartupCwdSources): string {
+  return sources.cliCwd || sources.envCwd || sources.configDefaultCwd || sources.fallback;
+}

--- a/tests/cwd-persistence.test.ts
+++ b/tests/cwd-persistence.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// agent.ts -> secure-config.ts imports `electron` at module top. Stub the
+// small surface area so the root vitest run never needs app/node_modules/electron.
+vi.mock("electron", () => ({
+  app: { isPackaged: false },
+  safeStorage: {
+    isEncryptionAvailable: () => false,
+    encryptString: () => Buffer.from(""),
+    decryptString: () => "",
+  },
+}));
+
+// loadConfig/saveConfig resolve ~/.loom via os.homedir(). Point homedir at a
+// temp dir so the test exercises a real read/write round-trip without touching
+// the developer's actual config.
+let tmp: string;
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "loom-cwd-"));
+  vi.spyOn(os, "homedir").mockReturnValue(tmp);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+function writeConfig(obj: Record<string, unknown>): void {
+  fs.mkdirSync(path.join(tmp, ".loom"), { recursive: true });
+  fs.writeFileSync(path.join(tmp, ".loom", "config.json"), JSON.stringify(obj));
+}
+function readConfig(): Record<string, any> {
+  return JSON.parse(fs.readFileSync(path.join(tmp, ".loom", "config.json"), "utf-8"));
+}
+function makeWindow() {
+  return { isDestroyed: () => false, setTitle: vi.fn(), webContents: { send: vi.fn() } };
+}
+
+describe("switchCwd persists the active analysis directory (#312)", () => {
+  it("writes the new directory to config.defaultCwd", async () => {
+    const { AgentManager } = await import("../app/src/main/agent.js");
+    const manager = new AgentManager(makeWindow() as any, path.join(tmp, "old"));
+
+    expect(manager.switchCwd(path.join(tmp, "new"))).toBe(true);
+
+    const { loadConfig } = await import("../shared/loom-config.js");
+    expect(loadConfig().defaultCwd).toBe(path.join(tmp, "new"));
+  });
+
+  it("preserves stored credentials and other keys when persisting the cwd", async () => {
+    writeConfig({
+      testerId: "orbit-007",
+      llm: {
+        active: "anthropic",
+        providers: { anthropic: { apiKeyEncrypted: "ENC", model: "x" } },
+      },
+      defaultCwd: path.join(tmp, "old"),
+    });
+    const { AgentManager } = await import("../app/src/main/agent.js");
+    const manager = new AgentManager(makeWindow() as any, path.join(tmp, "old"));
+
+    manager.switchCwd(path.join(tmp, "new"));
+
+    const cfg = readConfig();
+    expect(cfg.defaultCwd).toBe(path.join(tmp, "new"));
+    expect(cfg.testerId).toBe("orbit-007");
+    expect(cfg.llm.providers.anthropic.apiKeyEncrypted).toBe("ENC");
+  });
+
+  it("does not rewrite config when the cwd is unchanged", async () => {
+    // Config drift: disk says "/stale" while the manager sits at "/same". A
+    // no-op switch must not touch config, so the stale value is left intact.
+    writeConfig({ defaultCwd: path.join(tmp, "stale") });
+    const { AgentManager } = await import("../app/src/main/agent.js");
+    const manager = new AgentManager(makeWindow() as any, path.join(tmp, "same"));
+
+    expect(manager.switchCwd(path.join(tmp, "same"))).toBe(false);
+    expect(readConfig().defaultCwd).toBe(path.join(tmp, "stale"));
+  });
+
+  it("does not persist a transient --cwd override (persist: false)", async () => {
+    // A second-instance `Orbit --cwd X` is a one-off session choice, not a new
+    // default -- it must switch the directory without rewriting config.
+    writeConfig({ defaultCwd: path.join(tmp, "saved") });
+    const { AgentManager } = await import("../app/src/main/agent.js");
+    const manager = new AgentManager(makeWindow() as any, path.join(tmp, "saved"));
+
+    expect(manager.switchCwd(path.join(tmp, "scratch"), { persist: false })).toBe(true);
+    expect(readConfig().defaultCwd).toBe(path.join(tmp, "saved"));
+  });
+
+  it("fails closed: a corrupt config.json is switched against but never clobbered", async () => {
+    // loadConfig() returns {} on a parse error, so a naive write-back would wipe
+    // the user's credentials. The switch still happens in-memory; the file is left
+    // untouched for the user to repair.
+    fs.mkdirSync(path.join(tmp, ".loom"), { recursive: true });
+    const cfgPath = path.join(tmp, ".loom", "config.json");
+    fs.writeFileSync(cfgPath, "{ not valid json");
+    const { AgentManager } = await import("../app/src/main/agent.js");
+    const manager = new AgentManager(makeWindow() as any, path.join(tmp, "old"));
+
+    expect(manager.switchCwd(path.join(tmp, "new"))).toBe(true);
+    expect(fs.readFileSync(cfgPath, "utf-8")).toBe("{ not valid json");
+  });
+});
+
+describe("resolveStartupCwd precedence", () => {
+  it("prefers the --cwd CLI arg above everything", async () => {
+    const { resolveStartupCwd } = await import("../app/src/main/startup-cwd.js");
+    expect(
+      resolveStartupCwd({
+        cliCwd: "/cli",
+        envCwd: "/env",
+        configDefaultCwd: "/cfg",
+        fallback: "/fb",
+      }),
+    ).toBe("/cli");
+  });
+
+  it("falls back to LOOM_CWD env when there is no CLI arg", async () => {
+    const { resolveStartupCwd } = await import("../app/src/main/startup-cwd.js");
+    expect(resolveStartupCwd({ envCwd: "/env", configDefaultCwd: "/cfg", fallback: "/fb" })).toBe(
+      "/env",
+    );
+  });
+
+  it("restores the persisted config.defaultCwd when no CLI arg or env is set", async () => {
+    const { resolveStartupCwd } = await import("../app/src/main/startup-cwd.js");
+    expect(resolveStartupCwd({ configDefaultCwd: "/cfg", fallback: "/fb" })).toBe("/cfg");
+  });
+
+  it("uses the hardcoded fallback when nothing else is set", async () => {
+    const { resolveStartupCwd } = await import("../app/src/main/startup-cwd.js");
+    expect(resolveStartupCwd({ fallback: "/fb" })).toBe("/fb");
+  });
+});


### PR DESCRIPTION
Closes #312.

Switching the analysis directory in-app (File > Open, or the top-bar change
button) updated the in-memory cwd and restarted the brain, but never wrote the
new directory back to `~/.loom/config.json`. On the next launch
`getDefaultCwd()` read `config.defaultCwd` and fell through to the last-saved
value (or the `~/.loom/analyses` fallback), so the in-session switch was
silently lost.

`switchCwd` now reads-merges-writes `config.defaultCwd` through the shared
config loader (the same read-modify-write path `setTesterId` and
`guardian:set-bypass` use), so a clean restart reopens the last directory you
worked in. `getDefaultCwd`'s precedence (`--cwd` > `LOOM_CWD` >
`config.defaultCwd` > fallback) moved into a small pure `resolveStartupCwd`
helper so it's unit-testable without the electron glue in `main.ts`.

Two guards keep the write safe:

- **Fails closed on an unreadable config.** `loadConfig()` returns `{}` on a
  parse error, so a naive write-back would wipe stored credentials. If
  `config.json` exists but won't parse we skip the write and leave the file for
  the user to repair, rather than clobber it.
- **Transient `--cwd` stays transient.** A second-instance `Orbit --cwd X`
  launch routes through `switchCwd`; it now passes `persist: false` so a one-off
  CLI directory never becomes the permanent default. That matches first-instance
  startup, which reads `--cwd` at construction without persisting it.

One intended consequence: `defaultCwd` now doubles as "last-used directory", so
the Preferences field reflects wherever you last switched to. I reused
`defaultCwd` instead of adding a separate `lastCwd` key on purpose -- a separate
key would need a startup-precedence change that shadows a freshly-set
Preferences default, which is a worse surprise.

Tests: new `tests/cwd-persistence.test.ts` covers round-trip persistence,
credential/key preservation, the no-op and `persist: false` paths, the
fail-closed corrupt-config guard, and `resolveStartupCwd` precedence. Full root
suite green, root + app typecheck clean. Not live-eyeballed in a packaged build
yet.