### PR TITLE
Keep the chat pane title fully draggable (#315)

### DIFF
--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -735,13 +735,18 @@ body:not(.artifact-collapsed) #artifact-toggle {
 /* Children of .pane-title default to "drag" (titlebar drag region on macOS).
    Re-enable clicks on interactive children. If you add a new interactive
    element (textarea, [role=button], a custom clickable container, etc.) inside
-   any .pane-title, add it here or it will swallow clicks on macOS. */
+   any .pane-title, add it here or it will swallow clicks on macOS.
+
+   Non-interactive text labels (.pane-title-label, .files-title-label) are
+   deliberately NOT listed -- they stay part of the drag region. The chat title
+   centers its label with `flex: 1`, so a no-drag label spans nearly the whole
+   band and leaves only the ~8px edge padding draggable, which is why dragging
+   the window over the chat pane only caught in the gaps (#315). Keep plain
+   text labels out of this list. */
 .pane-title button,
 .pane-title input,
 .pane-title select,
 .pane-title a,
-.pane-title .pane-title-label,
-.pane-title .files-title-label,
 .pane-title .pane-title-actions,
 .pane-title .files-title-actions {
   -webkit-app-region: no-drag;


### PR DESCRIPTION
## What

On macOS the Orbit window uses `titleBarStyle: "hiddenInset"`, so there's no native title bar -- draggability is defined entirely by CSS `-webkit-app-region` regions on the pane headers. Dragging the window by the chat pane's header only worked intermittently, while the Files and Notebook/Activity headers dragged reliably (#315).

## Why

Every `.pane-title` is a `drag` region, with a whitelist marking interactive children `no-drag`. That whitelist also included the plain text labels `.pane-title-label` and `.files-title-label`. For the Files header that's harmless -- the label is short and naturally sized. But the chat title centers its label with `flex: 1`, so the `no-drag` "Chat" label stretched across nearly the whole header, leaving only the ~8px edge padding draggable. Dragging only caught in those slivers.

## The fix

Drop the two non-interactive text labels from the `no-drag` whitelist so they rejoin the titlebar drag region. The chat header's `flex: 1` label becomes a continuous drag band; the three small toggle/export buttons stay `no-drag` islands -- matching how the Files and Notebook headers already behave. The genuinely interactive controls (buttons, inputs, selects, links, action containers) are untouched, and the chat message area (`#messages`) is a separate element, so conversation text selection is unaffected.

## Verification

- Root `npm test`: 994 passed, 1 skipped (live-network test). `cd app && npx tsc --noEmit`: clean. Prettier: clean.
- No automated test added: the root suite runs in `node` (no jsdom/layout) and `-webkit-app-region` is native macOS chrome, so this can't be asserted in a unit test.

Worth a quick eyeball on a Mac:
- Drag the window by the Chat header (anywhere but the three buttons) -- should move reliably, not just in the edge gaps. Confirm Files + Notebook/Activity headers still drag.
- The chat buttons (files-toggle, export-chat, notebook-toggle), Files buttons (refresh, show-hidden), and Notebook/Activity/File tabs all still click.
- Text selection in the chat conversation still works.
- Pre-existing, not caused by this change: with Files collapsed the Chat header becomes leftmost without the 78px traffic-light inset -- worth confirming the lights don't overlap the files-toggle there (reproduces on `main` too).

Closes #315
