### PR TITLE
Move the cursor within a wrapped chat message before Up/Down recall history

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -13,6 +13,7 @@ import { refreshGalaxyInvocations } from "./galaxy-invocations.js";
 import { refreshGalaxyHistory } from "./galaxy-history.js";
 import { PromptQueue, queuedPreview } from "./prompt-queue.js";
 import { FeedbackDraftStore } from "./feedback-draft.js";
+import { caretVisualLineFlags, shouldRecallOnArrow } from "./input-history-nav.js";
 import { LoomWidgetKey, decodeMarkdownWidget } from "../../../shared/loom-shell-contract.js";
 import { ALLOWED_SKILLS_PREFIX, isAllowedSkillUrl } from "../../../shared/loom-config.js";
 import {
@@ -2058,19 +2059,6 @@ function appendHistoryEntry(text: string): void {
   savePromptHistory();
 }
 
-/** Should ↑/↓ recall instead of moving the caret? Yes when input is empty
- *  or the caret is on the first/last visual line, mirroring shell semantics. */
-function shouldRecallOnArrow(direction: "up" | "down"): boolean {
-  if (inputEl.value === "") return true;
-  const pos = inputEl.selectionStart ?? 0;
-  if (direction === "up") {
-    // First line iff there's no \n before the caret.
-    return inputEl.value.lastIndexOf("\n", pos - 1) === -1;
-  }
-  // Last line iff there's no \n at or after the caret.
-  return inputEl.value.indexOf("\n", pos) === -1;
-}
-
 function recallHistory(direction: "up" | "down"): void {
   if (direction === "up") {
     if (historyCursor <= 0) return;
@@ -2235,7 +2223,7 @@ inputEl.addEventListener("keydown", (e) => {
     // Enter falls through to the regular submit path below.
   }
 
-  if (e.key === "ArrowUp" && shouldRecallOnArrow("up")) {
+  if (e.key === "ArrowUp" && shouldRecallOnArrow("up", caretVisualLineFlags(inputEl))) {
     if (promptHistory.length === 0) return;
     e.preventDefault();
     recallHistory("up");
@@ -2243,7 +2231,7 @@ inputEl.addEventListener("keydown", (e) => {
   }
   if (
     e.key === "ArrowDown" &&
-    shouldRecallOnArrow("down") &&
+    shouldRecallOnArrow("down", caretVisualLineFlags(inputEl)) &&
     historyCursor < promptHistory.length
   ) {
     e.preventDefault();

--- a/app/src/renderer/input-history-nav.ts
+++ b/app/src/renderer/input-history-nav.ts
@@ -1,0 +1,115 @@
+// Helpers for shell-like prompt-history recall in the chat input.
+//
+// ↑/↓ should first move the caret within a multi-line message and only recall
+// prompt history once the caret is on the first line (↑) or last line (↓).
+// The tricky part is that the chat input soft-wraps: a long single-logical-line
+// message spans several *visual* rows with no "\n", so a newline scan alone
+// can't tell which visual row the caret sits on (issue #314). We measure the
+// caret's visual row with a hidden mirror element and fall back to the
+// newline-based check when measurement isn't available.
+
+export interface LineFlags {
+  /** caret is on the first (visual) line of the input */
+  onFirstLine: boolean;
+  /** caret is on the last (visual) line of the input */
+  onLastLine: boolean;
+}
+
+/** Geometry-free first/last-line check based on explicit newlines. Correct for
+ *  hard line breaks; blind to soft-wrapped rows (callers prefer
+ *  {@link caretVisualLineFlags}, which falls back to this). */
+export function logicalLineFlags(value: string, caretPos: number): LineFlags {
+  const pos = Math.max(0, Math.min(caretPos, value.length));
+  return {
+    onFirstLine: value.lastIndexOf("\n", pos - 1) === -1,
+    onLastLine: value.indexOf("\n", pos) === -1,
+  };
+}
+
+/** Pure decision: should ↑/↓ recall prompt history instead of moving the caret?
+ *  Yes only at the first line going up, or the last line going down. */
+export function shouldRecallOnArrow(direction: "up" | "down", lines: LineFlags): boolean {
+  return direction === "up" ? lines.onFirstLine : lines.onLastLine;
+}
+
+const MIRROR_STYLE_PROPS = [
+  "fontFamily",
+  "fontSize",
+  "fontWeight",
+  "fontStyle",
+  "fontVariant",
+  "letterSpacing",
+  "textTransform",
+  "lineHeight",
+  "textIndent",
+  "wordSpacing",
+  "tabSize",
+  "wordBreak",
+  "overflowWrap",
+  "whiteSpace",
+] as const;
+
+/** First/last *visual* line flags for the caret in a (possibly soft-wrapped)
+ *  textarea. Renders the text into a hidden mirror sized to the textarea's
+ *  content width so wrapping matches what the user sees, then reads the caret
+ *  row from a marker's offset. Falls back to {@link logicalLineFlags} when the
+ *  measurement can't run (e.g. no layout engine in tests). */
+export function caretVisualLineFlags(ta: HTMLTextAreaElement): LineFlags {
+  const value = ta.value;
+  const caretPos = ta.selectionStart ?? 0;
+  if (value === "") return { onFirstLine: true, onLastLine: true };
+  return measureCaretLines(ta, value, caretPos) ?? logicalLineFlags(value, caretPos);
+}
+
+function measureCaretLines(
+  ta: HTMLTextAreaElement,
+  value: string,
+  caretPos: number,
+): LineFlags | null {
+  if (typeof document === "undefined" || typeof getComputedStyle !== "function") {
+    return null;
+  }
+  const cs = getComputedStyle(ta);
+  const lineHeight = parseFloat(cs.lineHeight) || parseFloat(cs.fontSize) * 1.2;
+  // Content width excludes padding (and any scrollbar), so wrapping in the
+  // mirror matches the textarea regardless of its box-sizing.
+  const contentWidth =
+    ta.clientWidth - (parseFloat(cs.paddingLeft) || 0) - (parseFloat(cs.paddingRight) || 0);
+  if (!(lineHeight > 0) || !(contentWidth > 0)) return null;
+
+  const mirror = document.createElement("div");
+  for (const prop of MIRROR_STYLE_PROPS) {
+    mirror.style[prop] = cs[prop];
+  }
+  mirror.style.whiteSpace = "pre-wrap";
+  mirror.style.overflowWrap = cs.overflowWrap || "break-word";
+  mirror.style.boxSizing = "content-box";
+  mirror.style.width = `${contentWidth}px`;
+  mirror.style.padding = "0";
+  mirror.style.border = "0";
+  mirror.style.position = "absolute";
+  mirror.style.visibility = "hidden";
+  mirror.style.left = "-9999px";
+  mirror.style.top = "0";
+  mirror.style.height = "auto";
+  mirror.style.maxHeight = "none";
+  mirror.style.overflow = "hidden";
+
+  mirror.appendChild(document.createTextNode(value.slice(0, caretPos)));
+  const marker = document.createElement("span");
+  // Non-empty so the marker lays out on the caret's line; the remaining text
+  // also gives the mirror its full height for the last-line check.
+  marker.textContent = value.slice(caretPos) || ".";
+  mirror.appendChild(marker);
+
+  document.body.appendChild(mirror);
+  const markerTop = marker.offsetTop;
+  const contentHeight = mirror.scrollHeight;
+  document.body.removeChild(mirror);
+
+  if (!Number.isFinite(markerTop) || !Number.isFinite(contentHeight)) return null;
+  return {
+    onFirstLine: markerTop < lineHeight,
+    onLastLine: markerTop + lineHeight > contentHeight - 0.5,
+  };
+}

--- a/tests/input-history-nav.test.ts
+++ b/tests/input-history-nav.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest";
+import { logicalLineFlags, shouldRecallOnArrow } from "../app/src/renderer/input-history-nav.js";
+
+// `logicalLineFlags` is the geometry-free fallback: it decides first/last
+// *logical* line from explicit newlines. It powers prompt-history recall when
+// the caret is at the top/bottom of the input.
+describe("logicalLineFlags", () => {
+  test("a single-line value is both the first and last line everywhere", () => {
+    expect(logicalLineFlags("hello", 0)).toEqual({ onFirstLine: true, onLastLine: true });
+    expect(logicalLineFlags("hello", 3)).toEqual({ onFirstLine: true, onLastLine: true });
+    expect(logicalLineFlags("hello", 5)).toEqual({ onFirstLine: true, onLastLine: true });
+  });
+
+  test("empty value is first and last line", () => {
+    expect(logicalLineFlags("", 0)).toEqual({ onFirstLine: true, onLastLine: true });
+  });
+
+  test("caret on the first of multiple lines: first but not last", () => {
+    // "line1\nline2", caret inside line1
+    expect(logicalLineFlags("line1\nline2", 3)).toEqual({
+      onFirstLine: true,
+      onLastLine: false,
+    });
+    // caret at end of line1, just before the newline
+    expect(logicalLineFlags("line1\nline2", 5)).toEqual({
+      onFirstLine: true,
+      onLastLine: false,
+    });
+  });
+
+  test("caret on the last line: last but not first", () => {
+    // caret at start of line2, just after the newline
+    expect(logicalLineFlags("line1\nline2", 6)).toEqual({
+      onFirstLine: false,
+      onLastLine: true,
+    });
+    // caret at end of line2
+    expect(logicalLineFlags("line1\nline2", 11)).toEqual({
+      onFirstLine: false,
+      onLastLine: true,
+    });
+  });
+
+  test("caret on a middle line: neither first nor last", () => {
+    expect(logicalLineFlags("a\nb\nc", 3)).toEqual({
+      onFirstLine: false,
+      onLastLine: false,
+    });
+  });
+
+  test("caret position is clamped to the value bounds", () => {
+    expect(logicalLineFlags("hi", -5)).toEqual({ onFirstLine: true, onLastLine: true });
+    expect(logicalLineFlags("hi", 999)).toEqual({ onFirstLine: true, onLastLine: true });
+  });
+});
+
+// `shouldRecallOnArrow` is the pure decision: recall prompt history (instead of
+// moving the caret) only when the caret is on the first line going up, or the
+// last line going down -- symmetric in both directions.
+describe("shouldRecallOnArrow", () => {
+  const first = { onFirstLine: true, onLastLine: false };
+  const last = { onFirstLine: false, onLastLine: true };
+  const only = { onFirstLine: true, onLastLine: true };
+  const middle = { onFirstLine: false, onLastLine: false };
+
+  test("up recalls only when the caret is on the first line", () => {
+    expect(shouldRecallOnArrow("up", first)).toBe(true);
+    expect(shouldRecallOnArrow("up", only)).toBe(true);
+    expect(shouldRecallOnArrow("up", last)).toBe(false);
+    expect(shouldRecallOnArrow("up", middle)).toBe(false);
+  });
+
+  test("down recalls only when the caret is on the last line", () => {
+    expect(shouldRecallOnArrow("down", last)).toBe(true);
+    expect(shouldRecallOnArrow("down", only)).toBe(true);
+    expect(shouldRecallOnArrow("down", first)).toBe(false);
+    expect(shouldRecallOnArrow("down", middle)).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #314.

Pressing Up in a multi-line chat message recalled prompt history instead of first moving the cursor up a line. The input is a soft-wrapping textarea, so a long prompt spans several visual rows with no actual newline -- and the old first-line check (`value.lastIndexOf("\n", pos-1) === -1`) is always true when there's no `\n`, so Up recalled from any row. Down only looked correct because its recall is additionally gated on having already navigated into history, which hid the same blind spot.

The string check was already correct for hard newlines; the gap was purely soft-wrap. So instead of scanning for `\n`, this measures the caret's actual visual row with a hidden mirror element sized to the textarea's content width, and recalls only when the caret is on the first visual row (Up) or last visual row (Down) -- symmetric now, and correct for both hard breaks and soft wraps.

The decision moved into `input-history-nav.ts`: `shouldRecallOnArrow(direction, lines)` (pure, unit-tested both directions), `logicalLineFlags(value, caret)` (geometry-free newline fallback for the node test env), and `caretVisualLineFlags(textarea)` (the mirror measurement).

Testing: unit tests for the pure helpers. The mirror geometry can't run under the node test env, so I verified it in a real Chromium (Electron's engine) -- reproduced the original bug, then confirmed Up navigates wrapped rows and recalls only at the top, Down is symmetric, and explicit-newline navigation is unchanged. Full root suite green; root + app typecheck / prettier / eslint clean.

Noted from review, out of scope here: this keydown handler doesn't guard `e.isComposing`, so IME candidate-navigation arrows can be intercepted as history recall. That's pre-existing (unchanged by this PR) -- happy to fix separately.
