### PR TITLE
Flag that a transient API error left the task incomplete (#316)

### DIFF
--- a/app/src/renderer/chat/error-humanizer.ts
+++ b/app/src/renderer/chat/error-humanizer.ts
@@ -17,6 +17,14 @@ interface AnthropicLikeError {
 
 const RETRIABLE_TYPES = new Set(["overloaded_error", "rate_limit_error", "api_error"]);
 
+// A retriable provider error surfaces at the end of an assistant message, which
+// means the turn stopped before finishing -- any task that was in progress (a
+// figure write, a Galaxy run) may be half-done. The bare "Try again." left the
+// user unable to tell what state things were in (issue #316), so every transient
+// termination spells that out and points at the actionable check.
+const INTERRUPTED_TASK_NOTE =
+  "The turn was interrupted before finishing, so any task in progress may be incomplete -- check what completed before resending.";
+
 // Context-overflow errors arrive in many provider-specific phrasings, and for
 // OpenAI-compatible endpoints they're a plain (non-JSON) string the humanizer
 // would otherwise echo verbatim -- e.g. deepseek's "400 This model's maximum
@@ -111,21 +119,21 @@ export function humanizeAgentError(raw: string | undefined | null): HumanizedErr
   switch (errType) {
     case "overloaded_error":
       return {
-        text: "Anthropic is overloaded right now -- give it a moment and resend.",
+        text: `Anthropic is overloaded right now. ${INTERRUPTED_TASK_NOTE}`,
         retriable: true,
       };
     case "rate_limit_error":
       return {
         text: errMsg
-          ? `Rate limited by the API: ${errMsg}. Try again shortly.`
-          : "Rate limited by the API. Try again shortly.",
+          ? `Rate limited by the API: ${errMsg}. ${INTERRUPTED_TASK_NOTE}`
+          : `Rate limited by the API. ${INTERRUPTED_TASK_NOTE}`,
         retriable: true,
       };
     case "api_error":
       return {
         text: errMsg
-          ? `Upstream API error: ${errMsg}. Try again.`
-          : "Upstream API error. Try again.",
+          ? `Upstream API error: ${errMsg}. ${INTERRUPTED_TASK_NOTE}`
+          : `Upstream API error. ${INTERRUPTED_TASK_NOTE}`,
         retriable: true,
       };
     case "authentication_error":

--- a/tests/error-humanizer.test.ts
+++ b/tests/error-humanizer.test.ts
@@ -122,6 +122,16 @@ describe("humanizeAgentError", () => {
       expect(result.text).toMatch(/incomplete/i);
     });
 
+    it("flags incompleteness even when api_error carries no upstream message", () => {
+      // A bare 500 (no message) is the exact shape behind issue #316; the note
+      // has to land on the message-less branch too, not just the errMsg one.
+      const raw = JSON.stringify({ type: "error", error: { type: "api_error" } });
+      const result = humanizeAgentError(raw);
+      expect(result.retriable).toBe(true);
+      expect(result.text).toMatch(/incomplete/i);
+      expect(result.text).not.toContain("{");
+    });
+
     it("does not leak raw JSON noise while adding the note", () => {
       const raw = JSON.stringify({
         type: "error",

--- a/tests/error-humanizer.test.ts
+++ b/tests/error-humanizer.test.ts
@@ -80,6 +80,60 @@ describe("humanizeAgentError", () => {
     expect(result.retriable).toBe(false);
   });
 
+  // A surfaced transient provider error (overloaded / rate limit / 500) ends the
+  // turn mid-task. The bare "Try again." gave the user no way to tell whether the
+  // in-progress work (e.g. a figure write) had completed, so they couldn't act on
+  // it (issue #316). Every retriable termination must say the turn was interrupted
+  // and the task may be incomplete.
+  describe("transient errors flag an interrupted task (issue #316)", () => {
+    it("tells the user the task may be incomplete on a 500 api_error", () => {
+      const raw = JSON.stringify({
+        type: "error",
+        error: { type: "api_error", message: "Internal server error" },
+      });
+      const result = humanizeAgentError(raw);
+      expect(result.retriable).toBe(true);
+      // Keeps the upstream cause...
+      expect(result.text).toContain("Internal server error");
+      // ...and now states the turn was interrupted and may not have finished.
+      expect(result.text).toMatch(/interrupted/i);
+      expect(result.text).toMatch(/incomplete/i);
+    });
+
+    it("flags incompleteness for an overloaded_error too", () => {
+      const raw = JSON.stringify({
+        type: "error",
+        error: { type: "overloaded_error", message: "Overloaded" },
+      });
+      const result = humanizeAgentError(raw);
+      expect(result.retriable).toBe(true);
+      expect(result.text).toMatch(/overloaded/i);
+      expect(result.text).toMatch(/incomplete/i);
+    });
+
+    it("flags incompleteness for a rate_limit_error too", () => {
+      const raw = JSON.stringify({
+        type: "error",
+        error: { type: "rate_limit_error", message: "slow down" },
+      });
+      const result = humanizeAgentError(raw);
+      expect(result.retriable).toBe(true);
+      expect(result.text).toContain("slow down");
+      expect(result.text).toMatch(/incomplete/i);
+    });
+
+    it("does not leak raw JSON noise while adding the note", () => {
+      const raw = JSON.stringify({
+        type: "error",
+        error: { type: "api_error", message: "Internal server error" },
+        request_id: "req_abc",
+      });
+      const result = humanizeAgentError(raw);
+      expect(result.text).not.toContain("{");
+      expect(result.text).not.toContain("request_id");
+    });
+  });
+
   describe("context overflow", () => {
     it("humanizes the OpenAI-compatible context-length 400 (deepseek-v4-flash) into a /compact nudge", () => {
       // The verbatim string from issue #209 -- arrives as a plain string, not JSON.


### PR DESCRIPTION
When a transient provider error ends a turn mid-task -- an Anthropic 500 `api_error`, an overload, or a rate limit -- the humanized message used to end with a bare "Try again." That gave no read on task state: in #316 a figure write was in flight when the 500 hit, and the user couldn't tell whether it had landed (it eventually did, which made the confusion worse).

This makes the message say so. All three retriable terminations now append a shared note:

> The turn was interrupted before finishing, so any task in progress may be incomplete -- check what completed before resending.

The wording is conditional ("any task in progress") so it stays honest when the error hit before any work started. Pure change to `error-humanizer.ts` -- no turn-state or control-flow change.

Scope: this is the user-facing clarity half of #316, not the deeper "preserve in-flight state / auto-retry / resume" behavior. That part is model-driven -- within a live session the brain keeps the full history across the errored turn, so the next message does reach the model with context; the re-plan we saw was the model choosing to re-offer options, not hard context loss. Forcing a resume means either a shell-level auto-retry (risky -- duplicate side effects, and the brain may already retry) or steering the next turn -- both design calls worth their own discussion. So this is deliberately the small, honest fix, and I'd leave #316 open for the continuity decision.

Heads-up: touches `error-humanizer.ts`, same file as the in-flight #320 fix -- trivial reconcile for whichever lands second.

Tests: new `issue #316` block in `tests/error-humanizer.test.ts` (5 cases incl. the message-less 500). 999 pass / 1 skipped, app typecheck clean.