### PR TITLE
Only refresh the open file viewer when the open file changed on disk

### DIFF
--- a/app/src/main/files-handler.ts
+++ b/app/src/main/files-handler.ts
@@ -197,12 +197,29 @@ async function walkDir(
 let watcher: fs.FSWatcher | null = null;
 let watchedCwd: string | null = null;
 let debounceTimer: NodeJS.Timeout | null = null;
+let pendingPaths = new Set<string>();
+let pendingUnknown = false;
 
-function emitChange(window: BrowserWindow | null): void {
+function emitChange(window: BrowserWindow | null, filename: string | null): void {
+  // Accumulate the paths changed during the debounce window. The watcher
+  // coalesces a burst of fs events into one renderer notification, so we ship
+  // the whole batch — the renderer needs every changed path to decide whether
+  // the open file is among them (#313). A null filename means the OS didn't
+  // name what changed; flag the batch unknown so the renderer refreshes anyway
+  // instead of wrongly assuming the open file is untouched.
+  if (filename) {
+    pendingPaths.add(toPosix(filename));
+  } else {
+    pendingUnknown = true;
+  }
   if (debounceTimer) clearTimeout(debounceTimer);
   debounceTimer = setTimeout(() => {
+    const paths = pendingUnknown ? null : [...pendingPaths];
+    pendingPaths = new Set();
+    pendingUnknown = false;
+    debounceTimer = null;
     if (window && !window.isDestroyed()) {
-      window.webContents.send("files:changed");
+      window.webContents.send("files:changed", paths);
     }
   }, 200);
 }
@@ -217,7 +234,7 @@ export function startFilesWatcher(window: BrowserWindow, cwd: string): void {
         const firstSegment = String(filename).split(/[\\/]/)[0];
         if (FS_BLOCKLIST.has(firstSegment)) return;
       }
-      emitChange(window);
+      emitChange(window, filename ? String(filename) : null);
     });
     watcher.on("error", (err) => {
       console.warn("[files] watcher error:", err.message);
@@ -246,6 +263,8 @@ export function stopFilesWatcher(): void {
     clearTimeout(debounceTimer);
     debounceTimer = null;
   }
+  pendingPaths = new Set();
+  pendingUnknown = false;
 }
 
 // --- IPC registration ---------------------------------------------------

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -71,7 +71,9 @@ export interface OrbitAPI {
     | { ok: false; error: string; size?: number }
   >;
   writeFile(relPath: string, content: string): Promise<{ ok: true } | { ok: false; error: string }>;
-  onFilesChanged(callback: () => void): () => void;
+  // changedPaths is the batch of changed cwd-relative paths, or null when the
+  // watcher couldn't name what changed (#313).
+  onFilesChanged(callback: (changedPaths: string[] | null) => void): () => void;
   getConfig(): Promise<Record<string, unknown>>;
   saveConfig(config: Record<string, unknown>): Promise<{ success: boolean; error?: string }>;
   setBypassPermissions(
@@ -172,7 +174,7 @@ const api: OrbitAPI = {
   readFile: (relPath, opts) => ipcRenderer.invoke("files:read", relPath, opts),
   writeFile: (relPath, content) => ipcRenderer.invoke("files:write", relPath, content),
   onFilesChanged: (callback) => {
-    const handler = () => callback();
+    const handler = (_e: unknown, changedPaths: string[] | null) => callback(changedPaths ?? null);
     ipcRenderer.on("files:changed", handler);
     return () => ipcRenderer.removeListener("files:changed", handler);
   },

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -8,6 +8,7 @@ import { ShellPanel } from "./chat/shell-panel.js";
 import { ArtifactPanel } from "./artifacts/artifact-panel.js";
 import { FilesPanel } from "./files/files-panel.js";
 import { FileViewer } from "./files/file-viewer.js";
+import { shouldRefreshOpenFile } from "./files/file-change-match.js";
 import { FeedbackConfirmation } from "./feedback-confirmation.js";
 import { refreshGalaxyInvocations } from "./galaxy-invocations.js";
 import { refreshGalaxyHistory } from "./galaxy-history.js";
@@ -600,9 +601,14 @@ document.addEventListener("mouseup", () => {
 void filesPanel.refresh();
 void refreshGalaxyInvocations(window.orbit);
 void refreshGalaxyHistory(window.orbit);
-window.orbit.onFilesChanged(() => {
+window.orbit.onFilesChanged((changedPaths) => {
   void filesPanel.refresh();
-  void fileViewer.refreshFromDisk();
+  // Only re-read the open file when it's actually among the changed paths.
+  // Refreshing on every event popped the stale-on-disk banner whenever any
+  // unrelated file changed, because a dirty editor always differs from disk (#313).
+  if (shouldRefreshOpenFile(fileViewer.getCurrentPath(), changedPaths)) {
+    void fileViewer.refreshFromDisk();
+  }
   void refreshGalaxyInvocations(window.orbit);
   void refreshGalaxyHistory(window.orbit);
 });

--- a/app/src/renderer/files/file-change-match.ts
+++ b/app/src/renderer/files/file-change-match.ts
@@ -1,0 +1,36 @@
+/**
+ * Decide whether the currently-open file should be re-read from disk given the
+ * set of paths the watcher reported as changed (#313).
+ *
+ * The files watcher coalesces a burst of fs events into one `files:changed`
+ * notification carrying the set of changed cwd-relative paths. Refreshing the
+ * open file on *every* event made the "changed on disk" banner fire whenever any
+ * unrelated file changed: a dirty editor always differs from disk, so the diff
+ * check (editor != disk) tripped even though the open file never changed. Gating
+ * the refresh on a path match fixes that.
+ */
+
+function normalize(p: string): string {
+  // The watcher emits posix paths, but normalize backslashes too so a Windows
+  // relative path still matches the forward-slash open path.
+  let s = p.replace(/\\/g, "/");
+  if (s.startsWith("./")) s = s.slice(2);
+  return s;
+}
+
+/**
+ * @param openPath     cwd-relative path of the open file, or null if none open.
+ * @param changedPaths set of changed cwd-relative paths, or null when the watcher
+ *                     couldn't name what changed (refresh conservatively then).
+ */
+export function shouldRefreshOpenFile(
+  openPath: string | null,
+  changedPaths: readonly string[] | null,
+): boolean {
+  if (!openPath) return false;
+  // Unknown batch -- we can't prove the open file is unaffected, so refresh
+  // rather than risk leaving it stale. Worst case is a redundant re-read.
+  if (changedPaths === null) return true;
+  const open = normalize(openPath);
+  return changedPaths.some((p) => normalize(p) === open);
+}

--- a/tests/file-change-match.test.ts
+++ b/tests/file-change-match.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { shouldRefreshOpenFile } from "../app/src/renderer/files/file-change-match.js";
+
+/**
+ * Issue #313: with a file open in the File-tab editor, creating or modifying any
+ * *unrelated* file in the project popped the "This file changed on disk" banner
+ * over the open file. The watcher sent a bare `files:changed` with no payload, so
+ * the renderer re-read the open file on every event; a dirty editor always differs
+ * from disk, so the stale banner fired even though the open file never changed.
+ *
+ * The fix threads the set of changed paths through the event and only refreshes the
+ * open file when one of them matches it. `shouldRefreshOpenFile` is that pure gate.
+ */
+describe("shouldRefreshOpenFile", () => {
+  it("does not refresh when no file is open", () => {
+    expect(shouldRefreshOpenFile(null, ["README.md"])).toBe(false);
+    expect(shouldRefreshOpenFile(null, null)).toBe(false);
+  });
+
+  it("refreshes when the open file's exact path is among the changed paths", () => {
+    expect(shouldRefreshOpenFile("README.md", ["README.md"])).toBe(true);
+    expect(shouldRefreshOpenFile("docs/notes.md", ["src/a.ts", "docs/notes.md"])).toBe(true);
+  });
+
+  it("does not refresh when only unrelated files changed (#313)", () => {
+    expect(shouldRefreshOpenFile("README.md", ["test"])).toBe(false);
+    expect(shouldRefreshOpenFile("docs/notes.md", ["src/a.ts", "src/b.ts"])).toBe(false);
+  });
+
+  it("does not refresh when nothing nameable changed (empty set)", () => {
+    expect(shouldRefreshOpenFile("README.md", [])).toBe(false);
+  });
+
+  it("refreshes conservatively when the changed set is unknown (null)", () => {
+    // The watcher couldn't name the changed file(s) for this batch, so we can't
+    // prove the open file is unaffected -- err toward a refresh, never a miss.
+    expect(shouldRefreshOpenFile("README.md", null)).toBe(true);
+  });
+
+  it("normalizes backslash separators so a Windows relative path matches", () => {
+    expect(shouldRefreshOpenFile("docs/notes.md", ["docs\\notes.md"])).toBe(true);
+  });
+
+  it("normalizes a leading ./ on a changed path", () => {
+    expect(shouldRefreshOpenFile("README.md", ["./README.md"])).toBe(true);
+  });
+
+  it("does not match a same-named file in a different directory", () => {
+    expect(shouldRefreshOpenFile("a/foo.txt", ["b/foo.txt"])).toBe(false);
+  });
+
+  it("normalizes a leading ./ on the open path too", () => {
+    expect(shouldRefreshOpenFile("./README.md", ["README.md"])).toBe(true);
+  });
+
+  it("treats an empty open path as nothing open", () => {
+    expect(shouldRefreshOpenFile("", ["README.md"])).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #313.

With a file open in the File-tab editor, creating or modifying any unrelated file in the project popped the "This file changed on disk" banner over the open file, even though the open file never changed.

The watcher sent a bare `files:changed` with no payload, so the renderer re-read the open file on every fs event from anywhere in the tree. A dirty editor always differs from what's on disk, so that diff check (`editor.value !== disk`) tripped and showed the stale banner regardless of which file actually changed.

The watcher already had the changed `filename`, it just wasn't passing it along. Now it accumulates the batch of changed paths across the debounce window and ships them with the event (or `null` when the OS didn't name what changed, so we refresh conservatively rather than risk leaving the open file stale). The renderer only re-reads the open file when one of those paths matches it. The files-list panel and the Galaxy refreshes still fire on every event like before -- only the open-file stale check is gated.

The match decision lives in a small pure helper (`shouldRefreshOpenFile`) so it's unit-tested directly: 10 cases covering the path match, separator/`./` normalization, the unknown-batch conservative refresh, and the same-basename-different-dir non-match.

One deliberate tradeoff worth calling out: the matcher uses exact normalized-path comparison with no Windows-basename fallback. The bug was reported on Linux, where recursive `fs.watch` reports full relative paths, so exact matching is airtight. A basename fallback would reintroduce the exact false-positive this fixes -- a root-level `notes.md` change reports the bare token `notes.md`, which would falsely match an open `docs/notes.md`. The benign failure mode it avoids (a missed silent reload, only if some Windows config ever reports basenames) is preferable to reintroducing the banner-pop bug.

Verified: app `tsc --noEmit` clean, full root suite green (1002 passing). Not live-eyeballed in a running Orbit yet.