### PR TITLE
Surface the udt-authoring skill in the skills router (+ eval)

### DIFF
--- a/evals/findings.md
+++ b/evals/findings.md
@@ -135,6 +135,20 @@ Maverick especially shows nondeterminism on tool-call format.)
 | Llama-3.3-70B    | 2 / 5              | Writes to notebook on turn 1 (skips chat-draft stage). Defaults to `[local]` routing despite Galaxy-first guidance in the prompt. Heading format now correct after the worked-example fix.                                                                                                                                                                                                    |
 | Llama-4-Maverick | 3 / 5              | Highest variance run-to-run. Mostly correct format when it does write; failures are nondeterministic "drafted in chat, never invoked write tool" -- not a fundamental limit. A direct re-run of one of the eval-runner failures (pharmacogenomics) produced a perfect 5-step plan. n=3 median scoring (Phase 6) will smooth this out; today's single-run snapshot under-represents the model. |
 
+### udt-authoring-threads: progressive disclosure universal, outcome gates on capability
+
+First run of the UDT-authoring scenario (added alongside the skills-router
+fix). All three models called `skills_fetch({ path: "udt-authoring/..." })` --
+the router steering works across the whole matrix. The `$GALAXY_SLOTS` outcome
+split on capability: Qwen3-32B drafted a full `class: GalaxyUserTool` YAML
+wiring `$GALAXY_SLOTS` into the thread flag (pass); Llama-3.3-70B ran to the
+120s timeout without emitting the YAML; Llama-4-Maverick fetched then ended its
+turn in ~5s without drafting. Same "fetched the skill, never produced the
+artifact" shape the plan-creation scenarios show for the Llamas -- consistent
+with the Maverick-variance / n>=3 caveat above, not an eval defect. The positive
+`$GALAXY_SLOTS` check (vs. a brittle "must not contain `-@ 8`" absence check) is
+what lets the pass/fail track capability cleanly.
+
 ## What the eval is good at, and what it isn't
 
 **Good at:**

--- a/evals/scenarios/udt-authoring-threads/README.md
+++ b/evals/scenarios/udt-authoring-threads/README.md
@@ -1,0 +1,61 @@
+# udt-authoring-threads
+
+A Tier-2 scenario that checks whether Loom's skills router actually steers the
+agent to the `udt-authoring` skill before it hand-writes a User-Defined Tool,
+and whether the resulting tool respects Galaxy's core allocation.
+
+## What it tests
+
+Two things, in order:
+
+1. **Progressive disclosure** -- did the agent fetch `udt-authoring` at all?
+   The prompt asks for a `samtools sort` UDT, which is squarely the kind of
+   glue-tool the skill exists to teach. If the router does its job the agent
+   calls `skills_fetch({ path: "udt-authoring/SKILL.md" })` instead of drafting
+   the YAML from training priors. Asserted via the `skills_fetch` tool call.
+
+2. **The outcome** -- does the drafted UDT wire `$GALAXY_SLOTS` into the thread
+   flag? The prompt deliberately asks for two things at once: multithreaded
+   sorting _and_ logging the core count "for debugging." That is the exact shape
+   that tempts a model to `echo $GALAXY_SLOTS` to the log while still passing a
+   hardcoded number to `--threads` / `-@` -- it looks core-aware while ignoring
+   the allocation. We assert the YAML actually contains `$GALAXY_SLOTS` (and is a
+   `class: GalaxyUserTool` definition).
+
+`--tools skills_fetch` restricts the tool surface so the agent can't create the
+tool on the server or write it to a file -- it has to draft the full definition
+in chat, where the `chatText` assertions can see it.
+
+## Why there's no `mustNotInclude` for hardcoded thread counts
+
+The tempting negative assertion would be "the YAML must not contain `-@ 8` or
+`--threads 4`." We don't do that on purpose: the specific hardcoded value varies
+across models (`4`, `8`, `$(nproc)`, whatever), so an absence check is brittle
+and prone to false greens/reds. The positive `$GALAXY_SLOTS` check is the robust
+proxy -- if the thread flag is fed by `$GALAXY_SLOTS`, it isn't hardcoded.
+
+## Prerequisites to run green
+
+- A Tier-2 model with credentials in `evals/.env` (this scenario sets
+  `requiresModel: true`, so it runs across every model in `evals/models.json`
+  whose env vars are present).
+- Network access for `skills_fetch` to reach the galaxy-skills repo.
+- The `$GALAXY_SLOTS` chatText assertion needs `udt-authoring` to be fetchable on
+  the seeded galaxy-skills branch, since the skill content is what teaches the
+  `$GALAXY_SLOTS` pattern. As of this scenario, `udt-authoring` is merged to
+  galaxy-skills `main` (PR #30) with `metadata.surfaces: [loom]`, so this
+  prerequisite is satisfied on the default branch.
+
+The `skills_fetch`-call assertion (progressive disclosure) is meaningful even
+without the skill content: `tool_execution_start` fires whether the fetch returns
+200 or 404, so this scenario can catch a router regression -- the agent forgetting
+to consult the skill at all -- independently of whether the skill is fetchable.
+
+## A note on the tool surface
+
+`--tools skills_fetch` is intended to (a) keep the skills router in the system
+prompt -- the router is gated on the enabled skill repos, not on the tool
+surface, so it stays -- (b) expose `skills_fetch` so the fetch can happen, and
+(c) force chat-drafted output by withholding the create/write tools. If a future
+harness change means the router or `skills_fetch` needs to be requested
+differently, adjust `loomArgs` accordingly.

--- a/evals/scenarios/udt-authoring-threads/scenario.json
+++ b/evals/scenarios/udt-authoring-threads/scenario.json
@@ -1,0 +1,19 @@
+{
+  "name": "udt-authoring: consult the skill and thread via $GALAXY_SLOTS",
+  "description": "Tier-2 check of progressive disclosure for UDT authoring. Asks for a multithreaded samtools-sort UDT that also logs the core count -- the exact shape that tempts 'echo $GALAXY_SLOTS but hardcode --threads'. Asserts the agent (a) actually fetched the udt-authoring skill via skills_fetch, and (b) wired $GALAXY_SLOTS into the thread flag in the drafted GalaxyUserTool YAML. Restricting --tools to skills_fetch forces the agent to draft the YAML in chat (no MCP create, no file write) so chatText assertions can see it. NOTE: the skills_fetch CALL is asserted via tool_execution_start, which fires whether the fetch 200s or 404s -- so the progressive-disclosure assertion is meaningful even before udt-authoring merges to galaxy-skills main; the $GALAXY_SLOTS outcome assertion needs the skill content, i.e. galaxy-skills PR #30 merged to the seeded branch.",
+  "tier": 2,
+  "requiresModel": true,
+  "loomArgs": ["--tools", "skills_fetch"],
+  "inputs": [
+    "I want to wrap `samtools sort` as a Galaxy user-defined tool I can run in my own account. It should sort a BAM file using multiple threads so it's fast, and also print to the job log how many CPU cores the job was given, for debugging. Draft the full GalaxyUserTool YAML definition -- show me the complete definition, don't create it on the server yet."
+  ],
+  "timeoutMs": 120000,
+  "assertions": {
+    "toolCalls": {
+      "mustInclude": [{ "name": "skills_fetch", "argsContains": { "path": "udt-authoring" } }]
+    },
+    "chatText": {
+      "mustInclude": ["class: GalaxyUserTool", "$GALAXY_SLOTS"]
+    }
+  }
+}

--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -294,7 +294,9 @@ resources before deciding what runs where:
   \`galaxy_delete_user_tool\`. **Do not generate old-style XML tool
   wrappers locally when the user asks for a UDT** — that's a different
   concept (legacy ToolShed tools). Reach for the MCP tools rather than
-  inventing a local workaround.
+  inventing a local workaround. When authoring the UDT definition, fetch
+  the \`udt-authoring\` skill first (see Skills repositories below) rather
+  than writing the YAML from memory.
 - **Workflow invocation**: a single run of a Galaxy workflow on a
   history. Tracked in the notebook via \`loom-invocation\` blocks.
 - **IWC**: Intergalactic Workflow Commission — registry of curated
@@ -965,6 +967,22 @@ function buildSkillsContext(): string {
   \`nf-to-galaxy/check-tool-availability.md\`,
   \`nf-to-galaxy/testing-and-validation.md\`,
   \`tool-dev/references/testing.md\` (Planemo).
+
+- **Authoring a User-Defined Tool** (the \`class: GalaxyUserTool\` YAML a
+  non-admin user creates and runs via \`galaxy_create_user_tool\` /
+  \`galaxy_run_user_tool\` — wrapping a container + command as their own
+  tool; the preferred way to fill glue gaps between Galaxy steps) →
+  \`skills_fetch({ path: "udt-authoring/SKILL.md" })\`. **Fetch this before
+  drafting any UDT YAML — don't hand-write the definition from memory.**
+  References:
+  - \`udt-authoring/references/templating.md\` — \`$(...)\` ECMAScript
+    templating, \`$GALAXY_SLOTS\` for threads (pass it as the flag's value,
+    don't just echo it), shell escaping.
+  - \`udt-authoring/references/schema-reference.md\` — UserToolSource
+    fields, input/output types, the validators.
+  - \`udt-authoring/references/common-mistakes.md\` — pre-submit checklist.
+  - \`udt-authoring/examples/\` — seven complete, validated UDTs.
+  This is the \`GalaxyUserTool\` YAML format, NOT classic XML \`tool-dev\`.
 
 - **Galaxy tool development** (XML wrappers, packaging, testing, where to
   put tools) → \`skills_fetch({ path: "tool-dev/SKILL.md" })\`. Sub-skill:


### PR DESCRIPTION
## Why

The hardcoded galaxy-skills router in `buildSkillsContext()` lists most skills but never `udt-authoring`, so the agent never learns the `class: GalaxyUserTool` path and authors UDTs from training priors. The tell is a generated UDT that echoes `$GALAXY_SLOTS` to the job log "for debugging" but still passes a hardcoded number to `--threads` -- looks core-aware, ignores the allocation. The skill already teaches the right pattern; we just weren't surfacing it.

## What

- New router bullet for `udt-authoring` (before tool-dev), with the templating / schema-reference / common-mistakes / examples references and a "fetch before drafting -- this is the GalaxyUserTool YAML, not classic XML" framing.
- A one-line pointer from the UDT terminology entry to the skill.
- A Tier-2 eval (`evals/scenarios/udt-authoring-threads/`) asserting the agent (a) fetches `udt-authoring` via `skills_fetch` and (b) wires `$GALAXY_SLOTS` into the thread flag in the drafted YAML. `--tools skills_fetch` forces the YAML into chat so the assertions can read it.

## Relationship to #181

This edits the *hardcoded* router that #181 (tag-driven router) removes, so the two overlap in `context.ts` and whichever lands second needs a trivial rebase. I'd treat this as the immediate fix -- it ships now without waiting on #181's draft state. `udt-authoring` already carries `metadata.surfaces: [loom]` on galaxy-skills `main`, so #181's tree-walk will surface it automatically once it lands; the one remaining #181 gap is its `BUILTIN_CATALOG` cold-start fallback, handled separately. The eval is mechanism-agnostic -- it asserts the fetch happens regardless of how the router is generated -- so it keeps protecting this after #181.

## Tests

`npx tsc --noEmit`, eslint, and prettier all clean. The eval's `skills_fetch`-call assertion works regardless; the `$GALAXY_SLOTS` outcome assertion is unblocked now that udt-authoring is merged+fetchable on galaxy-skills `main` (not run here to avoid spending model credits).
