### PR TITLE
Give the Windows Squirrel maker an authors field

### DIFF
--- a/.github/actions/make-orbit/action.yml
+++ b/.github/actions/make-orbit/action.yml
@@ -107,6 +107,18 @@ runs:
         echo "$APPLE_API_KEY_BASE64" | base64 --decode > "$KEY_PATH"
         echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
 
+    # Windows only: belt-and-suspenders for the Squirrel maker's nuget pack,
+    # which trips the 260-char MAX_PATH on the deeply-nested staged bundle. The
+    # primary fix is pruning runtime-irrelevant files in forge.config.ts; this
+    # also flips the OS + git long-path switches in case a future dep pushes a
+    # path back over the edge.
+    - name: Enable Windows long paths
+      if: inputs.platform == 'win32'
+      shell: pwsh
+      run: |
+        reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
+        git config --system core.longpaths true
+
     - name: Make Orbit (${{ inputs.platform }}-${{ inputs.arch }})
       shell: bash
       working-directory: app

--- a/.github/actions/make-orbit/action.yml
+++ b/.github/actions/make-orbit/action.yml
@@ -112,12 +112,18 @@ runs:
     # primary fix is pruning runtime-irrelevant files in forge.config.ts; this
     # also flips the OS + git long-path switches in case a future dep pushes a
     # path back over the edge.
-    - name: Enable Windows long paths
+    - name: Enable Windows long paths + short temp for Squirrel/nuget
       if: inputs.platform == 'win32'
       shell: pwsh
       run: |
         reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
         git config --system core.longpaths true
+        # electron-winstaller stages the nupkg under os.tmpdir() (honors $TEMP).
+        # The default runner temp is deep; a short root keeps nuget's working
+        # paths well under MAX_PATH on the destination side.
+        New-Item -ItemType Directory -Force -Path C:\t | Out-Null
+        "TEMP=C:\t" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        "TMP=C:\t"  | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
     - name: Make Orbit (${{ inputs.platform }}-${{ inputs.arch }})
       shell: bash

--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -348,6 +348,27 @@ const config: ForgeConfig = {
       await stageNodeBundle(platform, arch);
       await stageUvBundle(platform, arch);
     },
+    // TEMP DIAGNOSTIC (win32 MAX_PATH hunt): log the deepest absolute paths in
+    // the packaged app -- exactly what the Squirrel maker's `nuget pack` will
+    // enumerate. Remove once the Windows installer builds.
+    postPackage: async (_forgeConfig, packageResult) => {
+      if (packageResult.platform !== "win32") return;
+      for (const out of packageResult.outputPaths) {
+        const all: string[] = [];
+        const walk = (d: string): void => {
+          for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+            const full = path.join(d, e.name);
+            if (e.isDirectory()) walk(full);
+            else all.push(full);
+          }
+        };
+        walk(out);
+        all.sort((a, b) => b.length - a.length);
+        console.log(`[diag] packaged dir: ${out}`);
+        console.log(`[diag] file count: ${all.length}, longest 8 absolute paths:`);
+        for (const p of all.slice(0, 8)) console.log(`[diag]   ${p.length}  ${p}`);
+      }
+    },
   },
   makers: [
     {

--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -333,6 +333,12 @@ const config: ForgeConfig = {
       name: "@electron-forge/maker-squirrel",
       config: {
         name: "Orbit",
+        // electron-winstaller writes this into the generated Orbit.nuspec as the
+        // required <authors> field (and it's the publisher shown in Windows'
+        // installed-programs list). package.json has no `author`, so without this
+        // the Squirrel maker hard-fails with "Authors is required". Matches the
+        // maintainer string the deb maker uses.
+        authors: "Galaxy Project contributors",
         setupIcon: "resources/icon.ico",
         // Squirrel is happy unsigned for dev/internal builds; production
         // distribution will need a code-signing cert configured here.

--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -92,6 +92,37 @@ function pruneLoomNodeModules(platform: string, arch: string): void {
     path.join(LOOM_STAGE_DIR, "node_modules", "@earendil-works", "pi-coding-agent", "examples"),
     { recursive: true, force: true },
   );
+
+  // Windows only: the Squirrel maker packages the app with `nuget pack`, whose
+  // source-file enumeration throws PathTooLongException at the 260-char Win32
+  // MAX_PATH. The staged bundle's deepest entries -- @mistralai/mistralai's
+  // auto-generated SDK operation files, nested under pi-coding-agent -- reach
+  // ~261 chars once the runner's appDir prefix (D:\a\loom\loom\app\out\
+  // Orbit-win32-x64\resources\) is added. TypeScript declarations/sources and
+  // source maps are never loaded at runtime, so dropping them pulls the deepest
+  // path safely back under the limit (and shrinks the installer). Scoped to
+  // win32 so the already-working mac/linux artifacts are byte-for-byte
+  // unchanged.
+  if (platform === "win32") {
+    stripNonRuntimeSourceFiles(path.join(LOOM_STAGE_DIR, "node_modules"));
+  }
+}
+
+// Recursively remove TypeScript declarations/sources (.ts/.tsx/.mts/.cts,
+// which includes .d.ts) and source maps (.map) from a node_modules tree.
+// None are resolved at runtime -- Node loads .js/.cjs/.mjs/.json/.node -- so
+// they're pure path-depth (and size) overhead. Everything else is kept,
+// including package.json, which drives module resolution.
+function stripNonRuntimeSourceFiles(root: string): void {
+  if (!fs.existsSync(root)) return;
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      stripNonRuntimeSourceFiles(full);
+    } else if (/\.(ts|tsx|mts|cts|map)$/.test(entry.name)) {
+      fs.rmSync(full, { force: true });
+    }
+  }
 }
 
 function findKoffiBuildDirs(root: string): string[] {


### PR DESCRIPTION
The win32 release leg added in #197 never actually ran until I kicked off a release build on main -- it sat on a draft PR the whole time, and the PR CI "build" checks only run typecheck/test, not the electron-forge `make`. First time the Squirrel maker ran for real, it hard-failed:

```
Attempting to build package from 'Orbit.nuspec'.
Authors is required.
```

electron-winstaller writes `<authors>` into the generated nuspec and treats it as required. `app/package.json` has no `author`, and the maker-squirrel config only set `name` + `setupIcon`, so there was nothing to fall back to. This sets it to the same "Galaxy Project contributors" string the deb maker already uses. No other platform's maker needs the field, so it's win32-only -- nothing changes for the mac/linux installers.

Heads up: this clears the *first* of two win32 packaging failures. With authors fixed, the Squirrel maker now gets further and dies on a separate Windows `MAX_PATH` (260-char) error during nuget pack -- so this PR alone does not produce a working `Setup.exe` yet. Tracking that one separately.