### PR TITLE
Keep the file-preview classifier out of electron's import path

### DIFF
--- a/app/src/main/file-preview-classification.ts
+++ b/app/src/main/file-preview-classification.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure file-preview classification, split out from files-handler.ts so it can
+ * be unit-tested without dragging in the latter's top-level `electron` import.
+ * The root vitest run installs only root deps (no app/node_modules), so a test
+ * that transitively imports `electron` fails to even resolve at transform time
+ * -- which is exactly what broke the publish-npm prepublishOnly gate. Keeping
+ * this module dependency-free (no electron, no node-only APIs) keeps it cheap
+ * to test from anywhere.
+ */
+
+// Mirrors the renderer's TEXT_EXTS in file-viewer.ts -- the head-preview
+// path only makes sense for files the renderer would draw as text. Returning
+// 64 KB of head bytes for an image / pdf / binary would just produce a
+// broken <img> or corrupted pdf in the renderer, with no useful signal to
+// the user. Files outside this set in the (5 MB, 1 GB] band get the same
+// "too large" rejection they got before head-preview existed.
+const TEXT_PREVIEW_EXTS = new Set([
+  ".md",
+  ".txt",
+  ".log",
+  ".rst",
+  ".py",
+  ".js",
+  ".ts",
+  ".tsx",
+  ".jsx",
+  ".sh",
+  ".rb",
+  ".pl",
+  ".r",
+  ".go",
+  ".rs",
+  ".json",
+  ".jsonl",
+  ".yml",
+  ".yaml",
+  ".toml",
+  ".ini",
+  ".cfg",
+  ".conf",
+  ".xml",
+  ".html",
+  ".htm",
+  ".css",
+  ".csv",
+  ".tsv",
+  ".tab",
+  ".tabular",
+  ".fa",
+  ".fasta",
+  ".fna",
+  ".faa",
+  ".ffn",
+  ".fastq",
+  ".fq",
+  ".fastqsanger",
+  ".fastqillumina",
+  ".fastqsolexa",
+  ".fastqcssanger",
+  ".vcf",
+  ".bed",
+  ".interval",
+  ".bedgraph",
+  ".wig",
+  ".gff",
+  ".gff3",
+  ".gtf",
+  ".sam",
+  ".pdb",
+  ".cif",
+  ".nwk",
+  ".newick",
+  ".tree",
+  ".phy",
+  ".phylip",
+]);
+
+export function isTextLikeForPreview(name: string): boolean {
+  const dot = name.lastIndexOf(".");
+  // No extension -- the renderer treats these as text (READMEs, configs).
+  if (dot <= 0) return true;
+  return TEXT_PREVIEW_EXTS.has(name.slice(dot).toLowerCase());
+}

--- a/app/src/main/files-handler.ts
+++ b/app/src/main/files-handler.ts
@@ -9,6 +9,7 @@
 
 import { ipcMain, BrowserWindow } from "electron";
 import { createIdempotentIpc } from "./ipc-registry.js";
+import { isTextLikeForPreview } from "./file-preview-classification.js";
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
@@ -43,80 +44,6 @@ const MAX_READ_BYTES = 5 * 1024 * 1024; // 5 MB — full read up to here
 const MAX_PREVIEW_BYTES = 1024 * 1024 * 1024; // 1 GB — hard refuse above this
 const PREVIEW_LINE_COUNT = 10;
 const PREVIEW_BYTE_BUDGET = 64 * 1024; // 64 KB cap on the head we read
-
-// Mirrors the renderer's TEXT_EXTS in file-viewer.ts -- the head-preview
-// path only makes sense for files the renderer would draw as text. Returning
-// 64 KB of head bytes for an image / pdf / binary would just produce a
-// broken <img> or corrupted pdf in the renderer, with no useful signal to
-// the user. Files outside this set in the (5 MB, 1 GB] band get the same
-// "too large" rejection they got before head-preview existed.
-const TEXT_PREVIEW_EXTS = new Set([
-  ".md",
-  ".txt",
-  ".log",
-  ".rst",
-  ".py",
-  ".js",
-  ".ts",
-  ".tsx",
-  ".jsx",
-  ".sh",
-  ".rb",
-  ".pl",
-  ".r",
-  ".go",
-  ".rs",
-  ".json",
-  ".jsonl",
-  ".yml",
-  ".yaml",
-  ".toml",
-  ".ini",
-  ".cfg",
-  ".conf",
-  ".xml",
-  ".html",
-  ".htm",
-  ".css",
-  ".csv",
-  ".tsv",
-  ".tab",
-  ".tabular",
-  ".fa",
-  ".fasta",
-  ".fna",
-  ".faa",
-  ".ffn",
-  ".fastq",
-  ".fq",
-  ".fastqsanger",
-  ".fastqillumina",
-  ".fastqsolexa",
-  ".fastqcssanger",
-  ".vcf",
-  ".bed",
-  ".interval",
-  ".bedgraph",
-  ".wig",
-  ".gff",
-  ".gff3",
-  ".gtf",
-  ".sam",
-  ".pdb",
-  ".cif",
-  ".nwk",
-  ".newick",
-  ".tree",
-  ".phy",
-  ".phylip",
-]);
-
-export function isTextLikeForPreview(name: string): boolean {
-  const dot = name.lastIndexOf(".");
-  // No extension -- the renderer treats these as text (READMEs, configs).
-  if (dot <= 0) return true;
-  return TEXT_PREVIEW_EXTS.has(name.slice(dot).toLowerCase());
-}
 
 /**
  * Clamp a user-supplied path to the current cwd. Throws if it escapes.

--- a/tests/file-preview-classification.test.ts
+++ b/tests/file-preview-classification.test.ts
@@ -1,14 +1,8 @@
 // @vitest-environment happy-dom
-import { describe, it, expect, vi } from "vitest";
-
-// files-handler.ts imports { ipcMain, BrowserWindow } from "electron" at module
-// top-level. In a clean checkout app/node_modules/electron isn't installed, so
-// vitest needs the named exports stubbed -- the functions under test never call
-// into them.
-vi.mock("electron", () => ({ ipcMain: {}, BrowserWindow: {} }));
+import { describe, it, expect } from "vitest";
 
 import { kindOf } from "../app/src/renderer/files/file-viewer.js";
-import { isTextLikeForPreview } from "../app/src/main/files-handler.js";
+import { isTextLikeForPreview } from "../app/src/main/file-preview-classification.js";
 
 // Regression coverage for #269: Galaxy downloads tabular datasets as *.tabular,
 // but the file viewer's text-extension allowlist only knew .tsv/.csv/.tab, so


### PR DESCRIPTION
The 0.5.0 publish-npm job failed. That job installs root deps only, then runs the prepublishOnly gate (`typecheck && test && smoke:pack`). `tests/file-preview-classification.test.ts` imported `isTextLikeForPreview` from `app/src/main/files-handler.ts`, which imports `electron` at module top level -- and with no `app/node_modules`, vite can't even resolve the bare `electron` specifier at transform time, so the whole suite fails to load and the publish aborts. The existing `vi.mock("electron")` doesn't save it; the mock applies after resolution.

This splits the pure classifier into its own electron-free module (`app/src/main/file-preview-classification.ts`) and points the test at it. Nothing else imported the helper externally.

Validated by reproducing the publish-npm environment exactly -- a root-only `npm ci` (no app install) -- then running the full prepublishOnly chain: typecheck clean, 1159 tests pass, smoke:pack OK.
