### PR TITLE
Ship Windows as a portable .zip; defer the Squirrel installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,12 +118,15 @@ jobs:
           draft: true
           prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true
+          # No *.exe yet: the Windows Squirrel installer is deferred (see
+          # app/forge.config.ts), so win32 ships the .zip. Re-add
+          # artifacts/**/*.exe when the Squirrel maker is re-enabled, or
+          # fail_on_unmatched_files will fail the publish on the empty glob.
           files: |
             artifacts/**/*.dmg
             artifacts/**/*.zip
             artifacts/**/*.deb
             artifacts/**/*.rpm
-            artifacts/**/*.exe
           fail_on_unmatched_files: true
 
   # Publish the @galaxyproject/loom npm package (the Loom CLI -- not Orbit) via

--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -329,15 +329,32 @@ const config: ForgeConfig = {
         format: "ULFO",
       },
     },
-    {
-      name: "@electron-forge/maker-squirrel",
-      config: {
-        name: "Orbit",
-        setupIcon: "resources/icon.ico",
-        // Squirrel is happy unsigned for dev/internal builds; production
-        // distribution will need a code-signing cert configured here.
-      },
-    },
+    // The Windows Squirrel installer is deferred. The first real run of the
+    // win32 leg (in the 0.5.0 release) showed electron-winstaller's `nuget pack`
+    // tripping the Win32 260-char MAX_PATH on the deeply-nested staged Loom
+    // bundle -- @mistralai/mistralai's auto-generated SDK files under
+    // pi-coding-agent. The Loom CLI ships as real (non-asar) files because it's
+    // spawned as a subprocess, so that depth is unavoidable, and even with the
+    // deepest path pruned to 254 chars nuget's internal staging still exceeds
+    // 260. Windows ships as the portable maker-zip .zip until the installer's
+    // path problem is solved; set LOOM_WIN_SQUIRREL=1 to build the installer
+    // while iterating on it.
+    ...(process.env.LOOM_WIN_SQUIRREL === "1"
+      ? [
+          {
+            name: "@electron-forge/maker-squirrel",
+            config: {
+              name: "Orbit",
+              // electron-winstaller writes this into the generated nuspec as the
+              // required <authors> field; without it the maker fails outright.
+              authors: "Galaxy Project contributors",
+              setupIcon: "resources/icon.ico",
+              // Squirrel is happy unsigned for dev/internal builds; production
+              // distribution will need a code-signing cert configured here.
+            },
+          },
+        ]
+      : []),
     {
       name: "@electron-forge/maker-deb",
       config: {


### PR DESCRIPTION
The win32 release leg added in #197 ran for real for the first time in the 0.5.0 build, and the Squirrel maker hard-failed on the Win32 260-char MAX_PATH: electron-winstaller's `nuget pack` chokes on the deeply-nested staged Loom bundle -- @mistralai/mistralai's long auto-generated SDK filenames, nested under pi-coding-agent. Because the Loom CLI ships as real, non-asar files (it's spawned as a subprocess), that depth can't be collapsed, and even after pruning the deepest path to 254 chars, nuget's internal staging still exceeds 260. (PR checks only run typecheck/test, never the electron-forge `make`, which is why this never showed up before the release.)

The win32 zip distributable builds cleanly, so 0.5.0 ships Windows as the portable `.zip`. The Squirrel `Setup.exe` maker is gated behind `LOOM_WIN_SQUIRREL=1` -- with #335's `authors` fix folded in -- until the path problem is solved (tracked in a follow-up issue). Also drops the `artifacts/**/*.exe` publish glob so `fail_on_unmatched_files` doesn't fail the draft release on the now-empty match.

Supersedes #335.
