### PR TITLE
Clamp the text-selection Copy button to the chat panel bounds

### DIFF
--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -543,7 +543,7 @@ export class ChatPanel {
           width: rect.width,
           height: rect.height,
         },
-        container: { top: crect.top, bottom: crect.bottom },
+        container: { top: crect.top, bottom: crect.bottom, left: crect.left, right: crect.right },
         viewport: { width: window.innerWidth, height: window.innerHeight },
       });
       if (placement.hidden) {

--- a/app/src/renderer/chat/copy-button.ts
+++ b/app/src/renderer/chat/copy-button.ts
@@ -22,9 +22,11 @@ export interface CopyButtonInput {
    * the scroller, so a selection can stay in the DOM but scroll out of view
    * (autoscroll during streaming). When the selection's rect is entirely above
    * or below this band the button is hidden, instead of being stranded at a
-   * stale position over the rest of the pane.
+   * stale position over the rest of the pane. The left/right edges bound the
+   * button horizontally so it can't escape the chat panel into an adjacent
+   * pane when the selection overflows past the container.
    */
-  container: { top: number; bottom: number };
+  container: { top: number; bottom: number; left: number; right: number };
   viewport: { width: number; height: number };
 }
 
@@ -32,6 +34,7 @@ export type CopyButtonPlacement = { hidden: true } | { hidden: false; top: numbe
 
 const BUTTON_HEIGHT = 28;
 const BUTTON_WIDTH = 80;
+const EDGE_PAD = 4;
 
 export function computeCopyButtonPlacement(input: CopyButtonInput): CopyButtonPlacement {
   const { isCollapsed, rangeCount, inContainer, rect, container, viewport } = input;
@@ -51,7 +54,20 @@ export function computeCopyButtonPlacement(input: CopyButtonInput): CopyButtonPl
     rect.bottom + 6 + BUTTON_HEIGHT > viewport.height
       ? rect.top - BUTTON_HEIGHT - 4
       : rect.bottom + 4;
-  const left = Math.max(4, Math.min(rect.right - BUTTON_WIDTH, viewport.width - BUTTON_WIDTH - 4));
+
+  // Anchor the button's right edge to the selection, but never past the chat
+  // container's right edge: a horizontally-scrollable block (e.g. a long line
+  // in a code block) lays its text out far beyond the visible panel, and the
+  // Range rect isn't clipped by that overflow. Clamping to the viewport alone
+  // would fling the button into an adjacent pane (#339), so bound left to the
+  // container's edges -- still kept on-screen by the viewport as a backstop.
+  const desiredLeft = Math.min(rect.right, container.right) - BUTTON_WIDTH;
+  const minLeft = Math.max(EDGE_PAD, container.left + EDGE_PAD);
+  const maxLeft = Math.min(
+    viewport.width - BUTTON_WIDTH - EDGE_PAD,
+    container.right - BUTTON_WIDTH - EDGE_PAD,
+  );
+  const left = Math.max(minLeft, Math.min(desiredLeft, maxLeft));
 
   return { hidden: false, top, left };
 }

--- a/tests/copy-button.test.ts
+++ b/tests/copy-button.test.ts
@@ -12,7 +12,7 @@ function input(overrides: Partial<CopyButtonInput> = {}): CopyButtonInput {
     rangeCount: 1,
     inContainer: true,
     rect: { top: 100, bottom: 120, right: 300, width: 200, height: 20 },
-    container: { top: 0, bottom: 800 },
+    container: { top: 0, bottom: 800, left: 0, right: 1000 },
     viewport: VIEWPORT,
     ...overrides,
   };
@@ -92,20 +92,47 @@ describe("computeCopyButtonPlacement", () => {
   // out of the visible scrollport. The button must hide rather than strand at a
   // stale position over the rest of the pane.
   it("hides when the selection has scrolled above the chat scrollport", () => {
-    const container = { top: 100, bottom: 700 };
+    const container = { top: 100, bottom: 700, left: 0, right: 1000 };
     const rect = { top: 30, bottom: 50, right: 300, width: 200, height: 20 };
     expect(computeCopyButtonPlacement(input({ container, rect }))).toEqual({ hidden: true });
   });
 
   it("hides when the selection has scrolled below the chat scrollport", () => {
-    const container = { top: 100, bottom: 700 };
+    const container = { top: 100, bottom: 700, left: 0, right: 1000 };
     const rect = { top: 740, bottom: 760, right: 300, width: 200, height: 20 };
     expect(computeCopyButtonPlacement(input({ container, rect }))).toEqual({ hidden: true });
   });
 
   it("stays shown when the selection straddles the scrollport's top edge (still partly visible)", () => {
-    const container = { top: 100, bottom: 700 };
+    const container = { top: 100, bottom: 700, left: 0, right: 1000 };
     const rect = { top: 80, bottom: 140, right: 300, width: 200, height: 60 };
     expect(computeCopyButtonPlacement(input({ container, rect }))).toMatchObject({ hidden: false });
+  });
+
+  // #339: a selection inside a wide / horizontally-scrollable block (e.g. a long
+  // line in a code block) lays its text out far beyond the visible chat panel --
+  // Range rects aren't clipped by ancestor overflow. Clamping to the viewport
+  // alone flings the button into the right-hand pane. It must clamp to the chat
+  // container's right edge instead.
+  it("clamps the right edge to the chat container, not the viewport, when the selection overflows right", () => {
+    const container = { top: 0, bottom: 800, left: 0, right: 600 };
+    const rect = { top: 100, bottom: 120, right: 1400, width: 1200, height: 20 };
+    expect(computeCopyButtonPlacement(input({ container, rect }))).toEqual({
+      hidden: false,
+      top: 124,
+      left: 516,
+    });
+  });
+
+  // The container can be inset from the viewport's left edge too (a left gutter
+  // or shell). The left clamp must use the container's left, not the viewport's.
+  it("clamps the left edge to the chat container when the container is inset from the left", () => {
+    const container = { top: 0, bottom: 800, left: 300, right: 1000 };
+    const rect = { top: 100, bottom: 120, right: 320, width: 20, height: 20 };
+    expect(computeCopyButtonPlacement(input({ container, rect }))).toEqual({
+      hidden: false,
+      top: 124,
+      left: 304,
+    });
   });
 });


### PR DESCRIPTION
Closes #339.

When you select text inside a wide or horizontally-scrollable block in the chat (a long line in a code block, say), the floating "Copy" button could jump to the far right of the window and land in the right-hand pane.

Root cause: `computeCopyButtonPlacement` clamped the button's left position to the *viewport* width, not the chat panel. A Range's `getBoundingClientRect()` isn't clipped by ancestor overflow, so a selection inside an overflowing block reports a `right` edge well past the chat panel; the viewport clamp then parked the button at the far right of the whole window -- in the sidebar. The earlier #299 work added a vertical band check but nothing horizontal.

Fix: anchor the button's right edge to the selection as before, but bound `left` to the chat container's left/right edges, with the viewport still acting as an on-screen backstop. The button still tracks the selection but can't escape the panel into an adjacent pane.

The placement math already had a pure, DOM-free helper with unit tests (from #299); I extended it to take the container's horizontal bounds and added cases covering a right-overflowing selection and a left-inset container. Test-first.

Checks: root `npm test` green (1166 passing), app `tsc --noEmit` clean. I haven't eyeballed it on WSLg myself -- the placement math is platform-agnostic, so the unit tests cover the regression, but a live look on WSLg would be good before this goes in.

Known limitation / possible follow-up: repositioning only fires on the outer messages scroller, so horizontally scrolling a selected code block *after* selecting won't live-update the button position. It stays put -- but now stays clamped inside the panel rather than escaping. That's pre-existing behavior from #299, not introduced here; worth a separate look if we want the button to track nested scrolling.