### PR TITLE
Fold the v0.5.0 release lessons into the release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -31,11 +31,15 @@ Abort cleanly (change nothing) on any failure, with a specific message.
 
 ```bash
 git rev-parse --abbrev-ref HEAD            # must be: main
-test -z "$(git status --porcelain)"        # working tree must be clean
+# Clean tree. A pre-release smoke/package run can leave stray artifacts that
+# trip this (e.g. app/test-results/, app/out/) -- remove them, don't commit them.
+test -z "$(git status --porcelain)"
 gh auth status                             # gh must be authenticated
 # Canonical remote = whichever remote pushes to galaxyproject/loom (works from a
-# fork-origin checkout or a galaxyproject-origin clone -- don't assume "upstream"):
-CANON=$(git remote -v | awk '$3=="(push)" && $2 ~ /[:/]galaxyproject\/loom(\.git)?$/ {print $1; exit}')
+# fork-origin checkout or a galaxyproject-origin clone -- don't assume "upstream").
+# grep, not awk: BSD/macOS awk chokes on the /[:/]/ char class, and the line ends
+# in " (push)" so a trailing-$ anchor never matches anyway.
+CANON=$(git remote -v | grep '(push)' | grep 'galaxyproject/loom' | head -1 | cut -f1)
 test -n "$CANON"                           # abort if no canonical remote found
 git fetch "$CANON" --tags
 git merge-base --is-ancestor "$CANON/main" HEAD && git merge-base --is-ancestor HEAD "$CANON/main"  # local main == canonical main
@@ -46,15 +50,22 @@ CUR=$(node -p "require('./package.json').version")
 
 ## Phase 1 -- Generate highlights (the nice things)
 
-Gather the merged PRs since the last tag:
+Gather the merged PRs since the last tag. The **commit range is the source of truth**
+for *which* PRs shipped -- the date search alone is wrong whenever two tags share a day
+(it pulls in same-day PRs that were already in the earlier tag), and `gh pr list`
+silently truncates at 30 without `--limit`:
 
 ```bash
-gh pr list --repo galaxyproject/loom --state merged --base main \
+# Authoritative PR set: merge commits since the last tag.
+git log "$LAST_TAG"..HEAD --merges --oneline | grep -oE '#[0-9]+' | sort -un
+# Titles/authors/labels for those PRs (--limit: default is 30, which silently drops PRs):
+gh pr list --repo galaxyproject/loom --state merged --base main --limit 200 \
   --search "merged:>=$LAST_DATE" --json number,title,author,labels,mergedAt
 ```
 
-Distill them into a `### Highlights` list per the **Editorial rules** below -- this is
-judgment, you do it, not a regex. Then determine the target version: from the
+Cross-check the two: distill only PRs that appear in the commit range, using the gh
+output for titles. Distill them into a `### Highlights` list per the **Editorial rules**
+below -- this is judgment, you do it, not a regex. Then determine the target version: from the
 `/release <version>` arg, or ask for a bump (patch / minor / major + optional prerelease
 channel alpha/beta/rc) and compute it from `$CUR`.
 
@@ -92,6 +103,33 @@ git --no-pager show --stat HEAD             # show what was committed
 
 Reversible: `git reset --hard HEAD~1` undoes everything so far.
 
+## Phase 2.5 -- Pre-tag validation (catch the publish-npm landmine)
+
+The `publish-npm` job installs **root deps only** (`npm ci`, no `app/` install), then
+runs the `prepublishOnly` gate (`typecheck && test && smoke:pack`). If any **root**
+test transitively imports an **app-only** module -- anything that pulls `electron` via
+`app/src/main/...`, or app-only deps -- vite can't even resolve the bare specifier at
+transform time and the whole suite fails to load. A normal local `npm test` does NOT
+catch this, because you usually have `app/node_modules` installed too; that false
+confidence has now sunk three releases (0.4.0 dompurify/marked, 0.5.0 electron).
+
+So reproduce publish-npm faithfully before tagging -- root deps only, no app install:
+
+```bash
+# from a throwaway clone/checkout at the release commit (so app/node_modules is absent):
+npm ci
+npm run typecheck && npm test && npm run smoke:pack
+```
+
+If it fails, the tag push will fail the same way and **nothing will publish** -- fix on
+main and re-run. To also validate the Orbit build matrix (and any **brand-new installer
+platform leg** -- whose `make` may never have actually run, since PR checks only do
+typecheck/test), dry-run the installers with no publish and no tag:
+
+```bash
+gh workflow run release.yml --ref <branch>   # builds all legs; publish/publish-npm are tag-gated, so they're skipped
+```
+
 ## Phase 3 -- GATE 1: tag push  (STOP)
 
 ⛔ **Hard stop.** State plainly: pushing will run `release.yml`, which **publishes
@@ -113,16 +151,47 @@ RUN=$(gh run list --repo galaxyproject/loom --workflow release.yml --limit 1 --j
 gh run watch --repo galaxyproject/loom "$RUN"
 ```
 
-## Phase 4 -- Curated release body
+### If the run fails
 
-The workflow makes a **draft** release with auto-generated "What's Changed". Replace its
-body with the curated highlights ABOVE the auto notes (same highlights from Phase 1):
+First check whether `publish-npm` succeeded -- that determines recovery:
 
 ```bash
-AUTO=$(gh release view "v$NEW" --repo galaxyproject/loom --json body -q .body)
-gh release edit "v$NEW" --repo galaxyproject/loom \
-  --notes "$(printf '## Highlights\n\n%s\n\n---\n\n%s' "$HIGHLIGHTS" "$AUTO")"
+npm view @galaxyproject/loom@$NEW version 2>/dev/null   # empty/404 = NOT published
 ```
+
+- **A build leg failed on flaky infra** (e.g. macOS `hdiutil detach -- No such file or
+  directory` during DMG, a runner timeout) -- don't re-cut. Re-run just the failed jobs;
+  this re-runs the failed leg and the `publish` job it gated, and leaves a succeeded
+  `publish-npm` alone (so npm isn't republished):
+  ```bash
+  gh run rerun --failed "$RUN"
+  ```
+- **It failed before npm published** (prepublishOnly failed, or a build leg died before
+  the `publish`/`publish-npm` jobs) and `npm view` shows nothing -- the version is clean
+  to **reuse**: fix on main, then delete and re-cut the tag:
+  ```bash
+  git tag -d "v$NEW"; git push "$CANON" --delete "v$NEW"
+  git tag "v$NEW"; git push "$CANON" "v$NEW"     # fires release.yml again
+  ```
+  Re-run Phase 2.5 on the new HEAD first. **Only if npm actually published** must you
+  bump to a new version instead -- npm can't un-publish a version.
+
+## Phase 4 -- Curated release body
+
+The `publish` job makes a **draft** release with auto-generated "What's Changed". (If a
+build leg failed, `publish` is skipped and there's no draft yet -- fix per Phase 3's
+rerun guidance first.) Replace its body with the curated highlights ABOVE the auto notes
+(same highlights from Phase 1). Build the body in a file and use `--notes-file` --
+robust for large bodies where inline `--notes` with `printf` gets fragile:
+
+```bash
+gh release view "v$NEW" --repo galaxyproject/loom --json body -q .body > /tmp/auto.md
+{ printf '## Highlights\n\n%s\n\n---\n\n' "$HIGHLIGHTS"; cat /tmp/auto.md; } > /tmp/body.md
+gh release edit "v$NEW" --repo galaxyproject/loom --notes-file /tmp/body.md
+```
+
+If anything user-facing shifted late (e.g. an installer dropped to a portable `.zip`),
+add a one-line note under the highlights so the download page sets the right expectation.
 
 ## Phase 5 -- GATE 2: promote draft  (STOP)
 
@@ -143,7 +212,7 @@ npm publish already happened in `release.yml` on the tag push -- the skill does 
 
 The core value -- match the voice of the existing `CHANGELOG.md` entries.
 
-- **2-4 bullets.** User-facing benefit framing, present tense, concrete, no marketing. Group related PRs into one bullet.
+- **2-5 bullets, scaled to the release.** A patch release is 2-3; a big multi-feature release can run 5-6. User-facing benefit framing, present tense, concrete, no marketing. Group related PRs into one bullet.
 - **Keep:** new features, new commands, user-visible fixes, new model/provider support, safety/security changes users care about, notable performance wins.
 - **Drop:** CI/release-plumbing PRs, the `cut`/`bump X.Y.Z` PRs, dependency bumps (unless user-visible, e.g. "Opus 4.8 available"), pure internal refactors, docs-only and test-only PRs.
 - **Voice:** casual, direct; plain hyphens, never a Unicode em-dash (restructure instead); name user-facing things (`/compact`, `loom update`), not PR numbers.
@@ -155,7 +224,9 @@ The core value -- match the voice of the existing `CHANGELOG.md` entries.
 - About to push to the fork (`origin` = your fork) instead of `$CANON` -> wrong remote.
 - About to ship the auto-generated PR-title list as the release body -> that's the noise this skill replaces; curate first.
 - Skipped `check-version-lockstep.mjs`, or bumped only one `package.json` -> CI will fail; fix before tagging.
+- About to tag without the Phase 2.5 root-only dry-run -> the publish-npm gate can fail on a root test that imports app-only code, and a local `npm test` won't have caught it.
 - CI failed but proceeding to promote -> never promote a failed build.
+- Re-tagging after a *flaky* leg instead of `gh run rerun --failed` -> wasteful, and risks republish errors if npm already succeeded on the first attempt.
 
 ## Common mistakes
 
@@ -165,4 +236,7 @@ The core value -- match the voice of the existing `CHANGELOG.md` entries.
 | Versions out of lockstep | Bump both via `npm version ... --prefix app`; run the lockstep check |
 | Raw commit list as notes | Distill per the editorial rules; curate the release body too |
 | Promote before CI is green | Watch the run; only `--draft=false` after green + eyeball |
-| Re-cut after a bad publish | npm can't un-publish -- bump to a new version; never reuse a tag |
+| Trusting a local `npm test` for publish-npm | It runs root-only; do the Phase 2.5 root-only dry-run -- a root test importing app/electron code passes locally but breaks publish-npm |
+| `gh pr list` silently drops PRs | Pass `--limit 200`; use the commit range (`$LAST_TAG..HEAD --merges`) as the PR-set source of truth |
+| Re-cutting after a flaky leg | `gh run rerun --failed "$RUN"` re-runs only the failed leg + `publish`; don't re-tag |
+| Re-cut after a failed release | Reuse the tag (delete + re-push) **only if `npm view` shows the version never published**; if it did publish, bump -- npm can't un-publish |


### PR DESCRIPTION
Folds the lessons from the v0.5.0 cut back into the `/release` skill.

The headline addition is a **Phase 2.5 root-only prepublish dry-run**. `publish-npm` installs root deps only, then runs `prepublishOnly` (`typecheck && test && smoke:pack`). A root test that transitively imports app-only code (this time `electron` via `app/src/main/files-handler.ts`) fails to even resolve at transform time -- but a normal local `npm test` passes because app deps are usually installed too. That false confidence has now broken three releases (0.4.0 dompurify/marked, 0.5.0 electron). The new phase reproduces publish-npm faithfully (root-only `npm ci` + the gate) before tagging.

Other fixes from the same cut:
- Phase 0 canonical-remote detection: `awk` -> `grep` (BSD/macOS awk chokes on the `/[:/]/` char class, and the `$`-anchor never matched the ` (push)` suffix anyway).
- Phase 1 PR set: use the commit range (`$LAST_TAG..HEAD --merges`) as the source of truth and add `gh pr list --limit 200` -- the date search over-includes same-day-but-pre-tag PRs when two tags share a day, and `gh pr list` silently truncates at 30.
- Phase 3 recovery: `gh run rerun --failed` for a flaky leg (e.g. macOS `hdiutil detach`) instead of re-cutting; and reuse-the-tag-only-if-`npm view`-shows-it-never-published (vs bump if it did).
- Phase 4: `--notes-file` instead of inline `printf --notes`; note to add a one-liner when an artifact shifts late (e.g. Windows dropping to a portable `.zip`).
- Smaller notes: clean-tree can trip on smoke/package artifacts; a brand-new installer platform's `make` never runs until a real release; editorial bullet count scales with release size.
