### PR TITLE
Confirm before destructive Galaxy history delete/purge (#338)

### DIFF
--- a/extensions/loom/exec-guard/gate.ts
+++ b/extensions/loom/exec-guard/gate.ts
@@ -84,6 +84,25 @@ export function registerExecGuard(pi: ExtensionAPI): void {
       return { block: true, reason: result.reason };
     }
 
+    // Destructive Galaxy op (#338): its own yes/no confirm, never cached and never
+    // offered "allow for session"/"trust workspace" -- every irreversible action
+    // re-prompts. Independent of the one-time local-exec consent disclosure (that's
+    // about shell execution; this is its own, more pointed prompt). The decision here
+    // is always "ask" -- the non-interactive case already denied above.
+    if (result.category === "galaxy:destructive") {
+      const proceed = await ctx.ui.confirm(
+        "Confirm destructive Galaxy operation",
+        `${ctx.model?.id ?? "The model"} wants to: ${result.reason}\n\nContinue?`,
+        {},
+      );
+      if (proceed) {
+        audit(event.toolName, input, result, "allowed:destructive-confirm");
+        return;
+      }
+      audit(event.toolName, input, result, "blocked:destructive-user");
+      return { block: true, reason: "Destructive Galaxy operation cancelled by user." };
+    }
+
     // ask: session memory first.
     if (sessionAllow.has(sig(event.toolName, input))) {
       audit(event.toolName, input, result, "allowed:session");

--- a/extensions/loom/exec-guard/policy.ts
+++ b/extensions/loom/exec-guard/policy.ts
@@ -1,6 +1,12 @@
 import { classifyBash } from "./bash-risk";
 import { isSensitivePath, isCredentialStore, isProtectedWritePath } from "./sensitive-read";
 import type { PolicyDeps, PolicyRequest, PolicyResult } from "./types";
+import {
+  classifyGalaxyDestructive,
+  describeGalaxyDestructive,
+  isGalaxyDestructiveCurl,
+} from "../../../shared/galaxy-destructive.js";
+import type { GalaxyDestructiveOp } from "../../../shared/galaxy-destructive.js";
 
 // A dedicated credential store's CONTENTS are never readable by the agent --
 // denied for every tier, not downgraded to an ask. This is the floor that closes
@@ -40,6 +46,21 @@ function finalizeAsk(req: PolicyRequest, category: string, reason: string): Poli
     };
   }
   return { decision: "ask", category, reason };
+}
+
+// A destructive, irreversible Galaxy operation (#338). Always confirm -- regardless of
+// model tier, so it deliberately does NOT go through finalizeAsk (no weak->deny downgrade).
+// A non-interactive session has no one to approve, so it denies rather than running silently.
+function destructiveGalaxy(req: PolicyRequest, op: GalaxyDestructiveOp): PolicyResult {
+  const headline = describeGalaxyDestructive(op).headline;
+  if (!req.interactive) {
+    return {
+      decision: "deny",
+      category: "galaxy:destructive",
+      reason: `${headline} (denied: no interactive session to approve)`,
+    };
+  }
+  return { decision: "ask", category: "galaxy:destructive", reason: headline };
 }
 
 export function decide(req: PolicyRequest, deps: PolicyDeps): PolicyResult {
@@ -82,6 +103,14 @@ export function decide(req: PolicyRequest, deps: PolicyDeps): PolicyResult {
     }
     if (c.kind === "safe") {
       return { decision: "allow", category: "bash:safe", reason: c.reason };
+    }
+    // Destructive Galaxy API call via raw curl/wget (DELETE /api/histories/{id}). A
+    // guardrail, not a boundary -- routes the unknown command to the same destructive
+    // confirm as the MCP path (asks even a weak model) instead of a generic "unknown" ask.
+    // Catastrophic pipes were already denied above, so they never reach here.
+    {
+      const op = isGalaxyDestructiveCurl(command);
+      if (op) return destructiveGalaxy(req, op);
     }
     // Unknown command. A trusted workspace relaxes by one notch only, and only
     // for this category: trusted model ask->allow, weak model deny->ask (the
@@ -162,6 +191,14 @@ export function decide(req: PolicyRequest, deps: PolicyDeps): PolicyResult {
     if (inside)
       return { decision: "allow", category: "write:in-jail", reason: "write inside workspace" };
     return finalizeAsk(req, "write:escape", `write outside workspace: ${p}`);
+  }
+
+  // Destructive Galaxy MCP operations (whole-history delete/purge) -- called directly or
+  // dispatched through the code-mode run_galaxy_tool envelope -- must be confirmed
+  // regardless of tier (#338). Non-destructive Galaxy/MCP tools fall through to the allow.
+  {
+    const op = classifyGalaxyDestructive(toolName, req.toolInput);
+    if (op) return destructiveGalaxy(req, op);
   }
 
   // Everything else is allowed: Galaxy/notebook tools, web fetchers, MCP. These are

--- a/extensions/loom/exec-guard/types.ts
+++ b/extensions/loom/exec-guard/types.ts
@@ -33,7 +33,8 @@ export interface PolicyDeps {
 
 export interface PolicyResult {
   decision: Decision;
-  // e.g. "bypass", "bash:safe", "bash:catastrophic", "write:in-jail", "read:sensitive", "default:ask"
+  // e.g. "bypass", "bash:safe", "bash:catastrophic", "write:in-jail", "read:sensitive",
+  // "galaxy:destructive", "default:ask"
   category: string;
   reason: string; // human-facing
 }

--- a/shared/galaxy-destructive.d.ts
+++ b/shared/galaxy-destructive.d.ts
@@ -1,0 +1,11 @@
+export interface GalaxyDestructiveOp {
+  kind: "history-delete" | "history-purge";
+  historyId?: string;
+  irreversible: boolean;
+}
+export function classifyGalaxyDestructive(
+  toolName: string,
+  input: Record<string, unknown>,
+): GalaxyDestructiveOp | null;
+export function describeGalaxyDestructive(op: GalaxyDestructiveOp): { headline: string };
+export function isGalaxyDestructiveCurl(command: string): GalaxyDestructiveOp | null;

--- a/shared/galaxy-destructive.js
+++ b/shared/galaxy-destructive.js
@@ -39,6 +39,7 @@ const DESTRUCTIVE_OPS = {
  * @param {unknown} toolName @returns {string} */
 function normalize(toolName) {
   return String(toolName == null ? "" : toolName)
+    .trim()
     .toLowerCase()
     .replace(/^galaxy_/, "");
 }
@@ -119,12 +120,12 @@ export function describeGalaxyDestructive(op) {
   };
 }
 
-// A `purge`/`purged` flag set true, in a URL query (?purge=true) or a JSON/body field
-// ("purge": true / purge=true / 'purged': True). Case-insensitive, so Python `True` in a
-// code script matches too.
+// A `purge`/`purged` flag set true, in a URL query (?purge=true) or a JSON/body/kwarg field
+// ("purge": true / purge=true / 'purged': True / "purge": "true"). Case-insensitive (so
+// Python `True` matches) and tolerant of a quoted boolean value (JSON-string / coerced bool).
 /** @param {string} s @returns {boolean} */
 function hasPurge(s) {
-  return /[?&]purged?=true\b/i.test(s) || /["']?purged?["']?\s*[:=]\s*true\b/i.test(s);
+  return /[?&]purged?=true\b/i.test(s) || /["']?purged?["']?\s*[:=]\s*["']?true\b/i.test(s);
 }
 
 // A clean literal id only -- never surface a shell variable / interpolation as the "id".
@@ -170,9 +171,11 @@ export function isGalaxyDestructiveCurl(command) {
  */
 function classifyCode(code) {
   const s = String(code == null ? "" : code);
-  if (!/call_tool\(\s*["']update_history["']/.test(s)) return null;
+  // Tolerate the tool name appearing as a positional or kwarg, with or without the
+  // galaxy_ prefix: call_tool('update_history', ...) / call_tool(name="galaxy_update_history", ...).
+  if (!/call_tool\([^)]*["'](?:galaxy_)?update_history["']/.test(s)) return null;
   const purge = hasPurge(s);
-  if (!purge && !/["']?deleted["']?\s*[:=]\s*true\b/i.test(s)) return null;
+  if (!purge && !/["']?deleted["']?\s*[:=]\s*["']?true\b/i.test(s)) return null;
   /** @type {GalaxyDestructiveOp} */
   const op = {
     kind: purge ? "history-purge" : "history-delete",

--- a/shared/galaxy-destructive.js
+++ b/shared/galaxy-destructive.js
@@ -1,0 +1,184 @@
+// Shared, shell-neutral classifier for destructive Galaxy operations. Used by BOTH
+// tool_call gates -- the brain's exec-guard (Orbit/CLI) and the web-mode-gate (remote) --
+// so "what counts as destructive" has a single home instead of a denylist duplicated per
+// shell. Closes the #338 gap: a destructive Galaxy mutation (whole-history delete/purge)
+// must be confirmed (or, where no confirm UI exists, blocked) regardless of model tier.
+//
+// Two confidence levels here:
+//   - RELIABLE: structured JSON we can read exactly -- a direct tool call, or one wrapped
+//     in the adapter's generic `mcp({tool, args})` proxy (args is a JSON string).
+//   - BEST-EFFORT GUARDRAIL: free-form strings we can only pattern-match -- a raw curl/wget
+//     DELETE, or code-mode's run_galaxy_tool(code=<python>) script. Trivially evadable
+//     (obfuscation, a different client, method override); the goal is to catch the obvious
+//     reach-for-the-nearest-tool case, not to be a security boundary.
+//
+// The op catalog is deliberately tiny and data-driven so it can later defer to galaxy-ops
+// `destructiveHint` metadata (galaxy-mcp PR #61) instead of being hand-maintained here.
+
+/**
+ * @typedef {{ kind: "history-delete" | "history-purge", historyId?: string, irreversible: boolean }} GalaxyDestructiveOp
+ */
+
+// Op-name -> predicate over its input args, returning the destructive shape or null.
+// NOTE: the pinned Galaxy MCP `update_history` tool exposes only `deleted` (a soft,
+// recoverable delete) -- there is no `purged` param there, so an MCP-path history delete is
+// always presented as recoverable. `purged` is still checked defensively (a future tool
+// version or a direct API caller could supply it); irreversible purge in practice comes via
+// the raw curl/code paths below, which carry the purge flag in the query or request body.
+const DESTRUCTIVE_OPS = {
+  /** @param {Record<string, unknown>} args */
+  update_history(args) {
+    if (args.purged === true) return { kind: "history-purge", irreversible: true };
+    if (args.deleted === true) return { kind: "history-delete", irreversible: false };
+    return null;
+  },
+};
+
+/** Lowercase + drop a leading `galaxy_` so both the prefixed MCP name and the bare op name
+ *  (and either gate's casing) resolve the same.
+ * @param {unknown} toolName @returns {string} */
+function normalize(toolName) {
+  return String(toolName == null ? "" : toolName)
+    .toLowerCase()
+    .replace(/^galaxy_/, "");
+}
+
+/** @param {unknown} v @returns {Record<string, unknown>} */
+function asObject(v) {
+  return v && typeof v === "object" ? /** @type {Record<string, unknown>} */ (v) : {};
+}
+
+/** The adapter's generic proxy passes args as a JSON string; tolerate objects and junk.
+ * @param {unknown} v @returns {Record<string, unknown>} */
+function parseArgs(v) {
+  if (v && typeof v === "object") return /** @type {Record<string, unknown>} */ (v);
+  if (typeof v !== "string") return {};
+  try {
+    const parsed = JSON.parse(v);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/** @param {string} opName @param {Record<string, unknown>} args @returns {GalaxyDestructiveOp | null} */
+function classifyOp(opName, args) {
+  const predicate = DESTRUCTIVE_OPS[opName];
+  if (!predicate) return null;
+  const hit = predicate(args);
+  if (!hit) return null;
+  /** @type {GalaxyDestructiveOp} */
+  const op = { kind: hit.kind, irreversible: hit.irreversible };
+  if (typeof args.history_id === "string") op.historyId = args.history_id;
+  return op;
+}
+
+/** Dispatch a resolved (name, args) pair: the code-mode meta-tool routes to the script
+ *  guardrail, everything else to the structured op table.
+ * @param {string} name @param {Record<string, unknown>} args @returns {GalaxyDestructiveOp | null} */
+function classifyNamed(name, args) {
+  if (name === "run_galaxy_tool") return classifyCode(args.code);
+  return classifyOp(name, args);
+}
+
+/**
+ * Classify an MCP tool call. Handles three shapes:
+ *  - direct:     update_history({ deleted, history_id })
+ *  - mcp proxy:  mcp({ tool: "galaxy_update_history", args: "<json string>" }) -- the
+ *                adapter's generic gateway tool, a bypass if left unhandled (#338 F1)
+ *  - code mode:  run_galaxy_tool({ code: "<python calling call_tool(...)>" }) (#338 F2)
+ * @param {string} toolName @param {Record<string, unknown>} input @returns {GalaxyDestructiveOp | null}
+ */
+export function classifyGalaxyDestructive(toolName, input) {
+  const name = normalize(toolName);
+  const inputObj = asObject(input);
+  if (name === "mcp") {
+    return classifyNamed(normalize(inputObj.tool), parseArgs(inputObj.args));
+  }
+  return classifyNamed(name, inputObj);
+}
+
+/**
+ * Honest, user-facing description for a confirmation prompt. Purge wording states it cannot
+ * be undone; delete wording flags the whole-history scope and that it's usually recoverable
+ * -- so the user is not misled either way (a soft delete is not a purge).
+ * @param {GalaxyDestructiveOp} op @returns {{ headline: string }}
+ */
+export function describeGalaxyDestructive(op) {
+  if (op.irreversible) {
+    const target = op.historyId ? `history ${op.historyId}` : "the entire history";
+    return {
+      headline: `Permanently PURGE ${target} -- this deletes all of its datasets and cannot be undone.`,
+    };
+  }
+  const id = op.historyId ? ` (${op.historyId})` : "";
+  return {
+    headline:
+      `Mark the entire history${id} as deleted -- not just specific datasets. ` +
+      `Recoverable via Undelete on most Galaxy servers, but it affects the whole history.`,
+  };
+}
+
+// A `purge`/`purged` flag set true, in a URL query (?purge=true) or a JSON/body field
+// ("purge": true / purge=true / 'purged': True). Case-insensitive, so Python `True` in a
+// code script matches too.
+/** @param {string} s @returns {boolean} */
+function hasPurge(s) {
+  return /[?&]purged?=true\b/i.test(s) || /["']?purged?["']?\s*[:=]\s*true\b/i.test(s);
+}
+
+// A clean literal id only -- never surface a shell variable / interpolation as the "id".
+/** @param {string | undefined} raw @returns {string | undefined} */
+function literalId(raw) {
+  return raw && /^[A-Za-z0-9]+$/.test(raw) ? raw : undefined;
+}
+
+/**
+ * BEST-EFFORT guardrail for the raw-bash path: an HTTP DELETE issued by curl/wget against a
+ * whole Galaxy history (`/api/histories/{id}`, NOT a dataset-level `/contents/` sub-path).
+ * Reversibility is read from a purge flag in the query or the request body. Requires an
+ * actual curl/wget verb so a stray URL in `echo`/text doesn't trip it; the history id is
+ * surfaced only when it's a literal (a `$VAR` is matched but not echoed as a fake id).
+ * @param {string} command @returns {GalaxyDestructiveOp | null}
+ */
+export function isGalaxyDestructiveCurl(command) {
+  const cmd = String(command == null ? "" : command);
+  if (!/\b(?:curl|wget)\b/i.test(cmd)) return null;
+  const isDelete =
+    /(?:-X|--request)[=\s]+["']?DELETE\b/i.test(cmd) ||
+    /-X["']?DELETE\b/i.test(cmd) ||
+    /--method[=\s]+["']?DELETE\b/i.test(cmd);
+  if (!isDelete) return null;
+  // Dataset-level deletes (/api/histories/{id}/contents/{dsid}) are out of v1 scope --
+  // do not claim "entire history" for them.
+  if (/\/api\/histories\/[^/\s"'?]+\/contents\//.test(cmd)) return null;
+  const m = cmd.match(/\/api\/histories\/([^/\s"'?]+)/);
+  if (!m) return null;
+  const irreversible = hasPurge(cmd);
+  /** @type {GalaxyDestructiveOp} */
+  const op = { kind: irreversible ? "history-purge" : "history-delete", irreversible };
+  const id = literalId(m[1]);
+  if (id) op.historyId = id;
+  return op;
+}
+
+/**
+ * BEST-EFFORT guardrail for code mode: run_galaxy_tool(code=<python>) where the only callable
+ * is call_tool(name, params). Flags a script that calls update_history with deleted/purge
+ * true. Coarse by nature (arbitrary Python); over-detection just yields an extra confirm.
+ * @param {unknown} code @returns {GalaxyDestructiveOp | null}
+ */
+function classifyCode(code) {
+  const s = String(code == null ? "" : code);
+  if (!/call_tool\(\s*["']update_history["']/.test(s)) return null;
+  const purge = hasPurge(s);
+  if (!purge && !/["']?deleted["']?\s*[:=]\s*true\b/i.test(s)) return null;
+  /** @type {GalaxyDestructiveOp} */
+  const op = {
+    kind: purge ? "history-purge" : "history-delete",
+    irreversible: purge,
+  };
+  const idm = s.match(/["']?history_id["']?\s*[:=]\s*["']([A-Za-z0-9]+)["']/);
+  if (idm) op.historyId = idm[1];
+  return op;
+}

--- a/tests/exec-guard-gate.test.ts
+++ b/tests/exec-guard-gate.test.ts
@@ -126,3 +126,78 @@ describe("registerExecGuard", () => {
     expect(select).not.toHaveBeenCalled();
   });
 });
+
+describe("registerExecGuard -- destructive Galaxy ops (#338)", () => {
+  const delEvent = (id: string) => ({
+    type: "tool_call",
+    toolName: "galaxy_update_history",
+    toolCallId: id,
+    input: { deleted: true, history_id: "h" },
+  });
+  const purgeEvent = (id: string) => ({
+    type: "tool_call",
+    toolName: "galaxy_update_history",
+    toolCallId: id,
+    input: { purged: true, history_id: "h" },
+  });
+
+  it("uses a yes/no confirm (not the 4-choice select) and blocks on cancel", async () => {
+    const c = ctx(); // confirm -> false
+    const r = await handler(delEvent("d1"), c);
+    expect(c.ui.confirm).toHaveBeenCalled();
+    expect(c.ui.select).not.toHaveBeenCalled();
+    expect(r?.block).toBe(true);
+  });
+
+  it("proceeds when the user confirms", async () => {
+    const c = ctx({ ui: { select: vi.fn(), confirm: vi.fn(async () => true), notify: vi.fn() } });
+    const r = await handler(delEvent("d2"), c);
+    expect(r?.block).toBeFalsy();
+  });
+
+  it("re-prompts every time -- a destructive op is never cached for the session", async () => {
+    const confirm = vi.fn();
+    confirm.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    const c = ctx({ ui: { select: vi.fn(), confirm, notify: vi.fn() } });
+    const r1 = await handler(delEvent("dup"), c);
+    const r2 = await handler(delEvent("dup"), c); // identical input
+    expect(r1?.block).toBeFalsy();
+    expect(r2?.block).toBe(true);
+    expect(confirm).toHaveBeenCalledTimes(2);
+  });
+
+  it("purge confirmation is honest about irreversibility", async () => {
+    const confirm = vi.fn(async () => false);
+    const c = ctx({ ui: { select: vi.fn(), confirm, notify: vi.fn() } });
+    await handler(purgeEvent("d4"), c);
+    const msg = confirm.mock.calls[0][1] as string;
+    expect(msg).toMatch(/purge/i);
+    expect(msg).toMatch(/cannot be undone|permanent/i);
+  });
+
+  it("delete confirmation flags the whole-history scope", async () => {
+    const confirm = vi.fn(async () => false);
+    const c = ctx({ ui: { select: vi.fn(), confirm, notify: vi.fn() } });
+    await handler(delEvent("d5"), c);
+    expect(confirm.mock.calls[0][1] as string).toMatch(/entire history/i);
+  });
+
+  it("non-interactive denies a destructive op without prompting", async () => {
+    const confirm = vi.fn(async () => true);
+    const c = ctx({ hasUI: false, ui: { select: vi.fn(), confirm, notify: vi.fn() } });
+    const r = await handler(delEvent("d6"), c);
+    expect(r?.block).toBe(true);
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("shows its own destructive confirm even before local-exec consent is acknowledged", async () => {
+    fs.writeFileSync(path.join(sandbox, ".loom", "config.json"), JSON.stringify({}));
+    const confirm = vi.fn(async () => false);
+    const c = ctx({ ui: { select: vi.fn(), confirm, notify: vi.fn() } });
+    const r = await handler(delEvent("d7"), c);
+    expect(r?.block).toBe(true);
+    // exactly one confirm -- the destructive one, not a separate consent disclosure first
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(confirm.mock.calls[0][1] as string).toMatch(/entire history/i);
+  });
+});

--- a/tests/exec-guard-policy.test.ts
+++ b/tests/exec-guard-policy.test.ts
@@ -396,3 +396,103 @@ describe("decide", () => {
     ).toBe("allow");
   });
 });
+
+describe("decide -- destructive Galaxy operations (#338)", () => {
+  const del = { toolName: "galaxy_update_history", toolInput: { deleted: true, history_id: "h" } };
+
+  it("a whole-history delete asks for confirmation (interactive)", () => {
+    const r = decide(req(del), deps);
+    expect(r.decision).toBe("ask");
+    expect(r.category).toBe("galaxy:destructive");
+  });
+
+  it("asks EVEN for a weak model -- overrides the usual weak->deny downgrade", () => {
+    const r = decide(req({ ...del, modelTier: "weak" }), deps);
+    expect(r.decision).toBe("ask");
+    expect(r.category).toBe("galaxy:destructive");
+  });
+
+  it("denies when there is no interactive session to approve", () => {
+    expect(decide(req({ ...del, interactive: false }), deps).decision).toBe("deny");
+  });
+
+  it("flags a delete through the code-mode run_galaxy_tool({code}) envelope", () => {
+    const r = decide(
+      req({
+        toolName: "galaxy_run_galaxy_tool",
+        toolInput: { code: "call_tool('update_history', {'history_id':'h','deleted':True})" },
+      }),
+      deps,
+    );
+    expect(r.decision).toBe("ask");
+    expect(r.category).toBe("galaxy:destructive");
+  });
+
+  it("gates the generic mcp proxy wrapping a destructive call -- even weak (#338 F1)", () => {
+    const r = decide(
+      req({
+        toolName: "mcp",
+        toolInput: {
+          server: "galaxy",
+          tool: "galaxy_update_history",
+          args: JSON.stringify({ deleted: true, history_id: "h" }),
+        },
+        modelTier: "weak",
+      }),
+      deps,
+    );
+    expect(r.decision).toBe("ask");
+    expect(r.category).toBe("galaxy:destructive");
+  });
+
+  it("does NOT gate a non-destructive Galaxy tool (catch-all unchanged)", () => {
+    expect(decide(req({ toolName: "galaxy_get_histories", toolInput: {} }), deps).decision).toBe(
+      "allow",
+    );
+  });
+
+  it("does NOT gate a rename-only update_history", () => {
+    expect(
+      decide(req({ toolName: "galaxy_update_history", toolInput: { name: "renamed" } }), deps)
+        .decision,
+    ).toBe("allow");
+  });
+
+  it("routes a raw curl DELETE to /api/histories/ to the destructive confirm (even weak)", () => {
+    const curl = {
+      toolName: "bash",
+      toolInput: { command: "curl -X DELETE https://galaxy.example.org/api/histories/h" },
+      modelTier: "weak" as const,
+    };
+    const r = decide(req(curl), deps);
+    expect(r.decision).toBe("ask");
+    expect(r.category).toBe("galaxy:destructive");
+  });
+
+  it("denies the destructive curl when non-interactive", () => {
+    expect(
+      decide(
+        req({
+          toolName: "bash",
+          toolInput: { command: "curl -X DELETE https://g/api/histories/h" },
+          interactive: false,
+        }),
+        deps,
+      ).decision,
+    ).toBe("deny");
+  });
+
+  it("a piped curl to histories stays catastrophic (deny), not a destructive ask", () => {
+    // Ordering guard: the pipe-to-interpreter catastrophic check fires before the
+    // curl guardrail, so this is denied outright, never downgraded to an ask.
+    const r = decide(
+      req({
+        toolName: "bash",
+        toolInput: { command: "curl -X DELETE https://g/api/histories/h | python3" },
+      }),
+      deps,
+    );
+    expect(r.decision).toBe("deny");
+    expect(r.category).toBe("bash:catastrophic");
+  });
+});

--- a/tests/galaxy-destructive.test.ts
+++ b/tests/galaxy-destructive.test.ts
@@ -106,6 +106,61 @@ describe("classifyGalaxyDestructive -- code mode run_galaxy_tool({code}) (#338 F
   });
 });
 
+describe("classifyGalaxyDestructive -- post-review hardening", () => {
+  it("flags a direct purged=true (defensive, irreversible)", () => {
+    expect(
+      classifyGalaxyDestructive("galaxy_update_history", { purged: true, history_id: "h" }),
+    ).toMatchObject({ kind: "history-purge", irreversible: true });
+  });
+
+  it("flags a purge issued in code mode", () => {
+    expect(
+      classifyGalaxyDestructive("galaxy_run_galaxy_tool", {
+        code: "call_tool('update_history', {'purged': True})",
+      }),
+    ).toMatchObject({ kind: "history-purge", irreversible: true });
+  });
+
+  it("catches the code-mode kwargs form call_tool(name=...)", () => {
+    expect(
+      classifyGalaxyDestructive("galaxy_run_galaxy_tool", {
+        code: "call_tool(name='update_history', params={'deleted': True})",
+      }),
+    ).toMatchObject({ kind: "history-delete" });
+  });
+
+  it("catches a galaxy_-prefixed tool name inside the code script", () => {
+    expect(
+      classifyGalaxyDestructive("galaxy_run_galaxy_tool", {
+        code: "call_tool('galaxy_update_history', {'deleted': True})",
+      }),
+    ).toMatchObject({ kind: "history-delete" });
+  });
+
+  it("catches a string-quoted boolean in code (deleted='True')", () => {
+    expect(
+      classifyGalaxyDestructive("galaxy_run_galaxy_tool", {
+        code: "call_tool('update_history', {'deleted': 'True'})",
+      }),
+    ).toMatchObject({ kind: "history-delete" });
+  });
+
+  it("unwraps a whitespace-padded proxied tool name", () => {
+    expect(
+      classifyGalaxyDestructive("mcp", {
+        tool: " galaxy_update_history ",
+        args: JSON.stringify({ deleted: true, history_id: "h" }),
+      }),
+    ).toMatchObject({ kind: "history-delete" });
+  });
+
+  it("reads a string-quoted purge in a curl JSON body (#338 hardening)", () => {
+    expect(
+      isGalaxyDestructiveCurl(`curl -X DELETE https://g/api/histories/h --json '{"purge":"true"}'`),
+    ).toMatchObject({ kind: "history-purge", irreversible: true });
+  });
+});
+
 describe("describeGalaxyDestructive", () => {
   it("purge wording is honest about irreversibility and names the history", () => {
     const { headline } = describeGalaxyDestructive({

--- a/tests/galaxy-destructive.test.ts
+++ b/tests/galaxy-destructive.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyGalaxyDestructive,
+  describeGalaxyDestructive,
+  isGalaxyDestructiveCurl,
+} from "../shared/galaxy-destructive.js";
+
+describe("classifyGalaxyDestructive -- discrete update_history", () => {
+  it("flags deleted=true as a soft (recoverable) history delete", () => {
+    expect(
+      classifyGalaxyDestructive("galaxy_update_history", { deleted: true, history_id: "abc" }),
+    ).toEqual({ kind: "history-delete", historyId: "abc", irreversible: false });
+  });
+
+  it("does NOT flag a rename-only update_history", () => {
+    expect(classifyGalaxyDestructive("galaxy_update_history", { name: "renamed" })).toBeNull();
+  });
+
+  it("does NOT flag deleted=false", () => {
+    expect(
+      classifyGalaxyDestructive("galaxy_update_history", { deleted: false, history_id: "abc" }),
+    ).toBeNull();
+  });
+
+  it("works on the bare op name (no galaxy_ prefix)", () => {
+    expect(classifyGalaxyDestructive("update_history", { deleted: true })).toMatchObject({
+      kind: "history-delete",
+    });
+  });
+
+  it("normalizes tool-name casing (web-mode passes raw event.toolName)", () => {
+    expect(classifyGalaxyDestructive("GALAXY_UPDATE_HISTORY", { deleted: true })).toMatchObject({
+      kind: "history-delete",
+    });
+  });
+
+  it("ignores unrelated galaxy tools", () => {
+    expect(classifyGalaxyDestructive("galaxy_get_histories", {})).toBeNull();
+    expect(classifyGalaxyDestructive("galaxy_upload_file", { history_id: "abc" })).toBeNull();
+  });
+});
+
+describe("classifyGalaxyDestructive -- generic mcp proxy envelope (#338 F1)", () => {
+  // The pi-mcp-adapter registers a generic `mcp` tool: mcp({ server, tool, args })
+  // where args is a JSON *string*. This must not be a bypass.
+  it("unwraps mcp({tool, args}) and flags the inner delete", () => {
+    expect(
+      classifyGalaxyDestructive("mcp", {
+        server: "galaxy",
+        tool: "galaxy_update_history",
+        args: JSON.stringify({ deleted: true, history_id: "h" }),
+      }),
+    ).toMatchObject({ kind: "history-delete", historyId: "h" });
+  });
+
+  it("does NOT flag a non-destructive proxied call", () => {
+    expect(
+      classifyGalaxyDestructive("mcp", {
+        tool: "galaxy_get_histories",
+        args: "{}",
+      }),
+    ).toBeNull();
+  });
+
+  it("tolerates malformed (non-JSON) proxy args without throwing", () => {
+    expect(
+      classifyGalaxyDestructive("mcp", { tool: "galaxy_update_history", args: "not json" }),
+    ).toBeNull();
+  });
+});
+
+describe("classifyGalaxyDestructive -- code mode run_galaxy_tool({code}) (#338 F2)", () => {
+  // Real code-mode shape: run_galaxy_tool(code=<python>), where the only callable is
+  // call_tool(name, params). Best-effort regex guardrail over the script.
+  it("flags a delete issued via call_tool in the code script", () => {
+    expect(
+      classifyGalaxyDestructive("galaxy_run_galaxy_tool", {
+        code: "r = call_tool('update_history', {'history_id': 'h', 'deleted': True})",
+      }),
+    ).toMatchObject({ kind: "history-delete", historyId: "h" });
+  });
+
+  it("flags it through the prefixed name and the mcp proxy wrapping it", () => {
+    expect(
+      classifyGalaxyDestructive("mcp", {
+        tool: "galaxy_run_galaxy_tool",
+        args: JSON.stringify({ code: "call_tool('update_history', {'deleted': True})" }),
+      }),
+    ).toMatchObject({ kind: "history-delete" });
+  });
+
+  it("does NOT flag a non-destructive code script", () => {
+    expect(
+      classifyGalaxyDestructive("galaxy_run_galaxy_tool", {
+        code: "hs = call_tool('get_histories', {})",
+      }),
+    ).toBeNull();
+  });
+
+  it("does NOT flag a rename in the code script", () => {
+    expect(
+      classifyGalaxyDestructive("galaxy_run_galaxy_tool", {
+        code: "call_tool('update_history', {'name': 'renamed'})",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("describeGalaxyDestructive", () => {
+  it("purge wording is honest about irreversibility and names the history", () => {
+    const { headline } = describeGalaxyDestructive({
+      kind: "history-purge",
+      historyId: "abc",
+      irreversible: true,
+    });
+    expect(headline).toMatch(/purge/i);
+    expect(headline).toMatch(/cannot be undone|permanent/i);
+    expect(headline).toContain("abc");
+  });
+
+  it("delete wording flags the whole-history scope and recoverability", () => {
+    const { headline } = describeGalaxyDestructive({
+      kind: "history-delete",
+      historyId: "abc",
+      irreversible: false,
+    });
+    expect(headline).toMatch(/entire history/i);
+    expect(headline).toMatch(/undelete|recoverable/i);
+  });
+
+  it("tolerates a missing history id", () => {
+    const { headline } = describeGalaxyDestructive({ kind: "history-purge", irreversible: true });
+    expect(typeof headline).toBe("string");
+    expect(headline.length).toBeGreaterThan(0);
+  });
+});
+
+describe("isGalaxyDestructiveCurl", () => {
+  it("flags curl -X DELETE against /api/histories/ (soft)", () => {
+    expect(
+      isGalaxyDestructiveCurl("curl -X DELETE https://galaxy.example.org/api/histories/abc123"),
+    ).toMatchObject({ kind: "history-delete", historyId: "abc123", irreversible: false });
+  });
+
+  it("reads purge=true off the URL query as an irreversible purge", () => {
+    expect(
+      isGalaxyDestructiveCurl("curl -X DELETE 'https://g/api/histories/abc?purge=true'"),
+    ).toMatchObject({ kind: "history-purge", irreversible: true });
+  });
+
+  it("reads purge from the DELETE request BODY, not just the query (#338 F3)", () => {
+    expect(
+      isGalaxyDestructiveCurl(`curl -X DELETE https://g/api/histories/abc -d '{"purge":true}'`),
+    ).toMatchObject({ kind: "history-purge", irreversible: true });
+  });
+
+  it("still flags a command with a shell-variable history id (#338 F4)", () => {
+    const op = isGalaxyDestructiveCurl(`curl -X DELETE "$GALAXY_URL/api/histories/$HID?purge=true"`);
+    expect(op).toMatchObject({ kind: "history-purge", irreversible: true });
+    expect(op?.historyId).toBeUndefined(); // don't surface a fake literal id
+  });
+
+  it("matches the bunched -XDELETE form", () => {
+    expect(isGalaxyDestructiveCurl("curl -XDELETE https://g/api/histories/abc")).toMatchObject({
+      kind: "history-delete",
+    });
+  });
+
+  it("matches the --request DELETE form", () => {
+    expect(
+      isGalaxyDestructiveCurl("curl --request DELETE https://g/api/histories/abc"),
+    ).toMatchObject({ kind: "history-delete" });
+  });
+
+  it("matches wget --method=DELETE (#338 F5)", () => {
+    expect(
+      isGalaxyDestructiveCurl("wget --method=DELETE https://g/api/histories/abc"),
+    ).toMatchObject({ kind: "history-delete" });
+  });
+
+  it("requires an actual curl/wget verb -- a bare DELETE URL elsewhere does not match (#338 F5)", () => {
+    expect(isGalaxyDestructiveCurl("http DELETE https://g/api/histories/abc")).toBeNull();
+  });
+
+  it("does NOT flag dataset-level /contents/ deletes (out of v1 scope) (#338 F5)", () => {
+    expect(
+      isGalaxyDestructiveCurl("curl -X DELETE https://g/api/histories/abc/contents/d1"),
+    ).toBeNull();
+  });
+
+  it("does NOT flag a GET", () => {
+    expect(isGalaxyDestructiveCurl("curl -X GET https://g/api/histories")).toBeNull();
+  });
+
+  it("does NOT flag a DELETE to a non-histories endpoint", () => {
+    expect(isGalaxyDestructiveCurl("curl -X DELETE https://example.com/api/other/abc")).toBeNull();
+  });
+
+  it("does NOT flag a plain (default GET) curl", () => {
+    expect(isGalaxyDestructiveCurl("curl https://g/api/histories/abc")).toBeNull();
+  });
+});

--- a/web/extensions/web-mode-gate.test.ts
+++ b/web/extensions/web-mode-gate.test.ts
@@ -264,3 +264,42 @@ describe("web-mode-gate registration (default export)", () => {
     expect(await handler({ toolName: "galaxy_run_tool", input: {} })).toBeUndefined();
   });
 });
+
+describe("shouldBlockTool -- destructive Galaxy ops (#338)", () => {
+  const allowlist = ["/tmp/loom-session/notebook.md"];
+  const cwd = "/tmp/loom-session";
+
+  it("blocks a whole-history delete (remote mode has no confirmation UI)", () => {
+    const r = shouldBlockTool(
+      "galaxy_update_history",
+      { deleted: true, history_id: "h" },
+      allowlist,
+      cwd,
+    );
+    expect(r?.block).toBe(true);
+  });
+
+  it("blocks a history purge", () => {
+    expect(
+      shouldBlockTool("galaxy_update_history", { purged: true, history_id: "h" }, allowlist, cwd)
+        ?.block,
+    ).toBe(true);
+  });
+
+  it("blocks a delete dispatched through the code-mode run_galaxy_tool({code}) envelope", () => {
+    const r = shouldBlockTool(
+      "galaxy_run_galaxy_tool",
+      { code: "call_tool('update_history', {'deleted': True})" },
+      allowlist,
+      cwd,
+    );
+    expect(r?.block).toBe(true);
+  });
+
+  it("still permits a non-destructive update_history (rename) and reads", () => {
+    expect(
+      shouldBlockTool("galaxy_update_history", { name: "renamed" }, allowlist, cwd),
+    ).toBeUndefined();
+    expect(shouldBlockTool("galaxy_get_histories", {}, allowlist, cwd)).toBeUndefined();
+  });
+});

--- a/web/extensions/web-mode-gate.ts
+++ b/web/extensions/web-mode-gate.ts
@@ -27,6 +27,7 @@
 import { resolve, dirname, basename, join } from "node:path";
 import { realpathSync, lstatSync } from "node:fs";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { classifyGalaxyDestructive } from "../../shared/galaxy-destructive.js";
 
 // pi built-in file tools, confined to the notebook path allowlist.
 const PATH_GATED_TOOLS = new Set(["edit", "write", "read"]);
@@ -91,6 +92,15 @@ export function shouldBlockTool(
     }
     if (isPathAllowed(raw, allowlist, cwd)) return undefined;
     return { block: true, reason: `path "${raw}" is not in the remote-mode allowlist` };
+  }
+  // Destructive Galaxy ops (whole-history delete/purge) -- called directly or via the
+  // code-mode run_galaxy_tool envelope -- are blocked in remote mode: this gate has no
+  // confirmation UI to require an are-you-sure (#338). A remote-confirm UX is a follow-up.
+  if (classifyGalaxyDestructive(toolName, input)) {
+    return {
+      block: true,
+      reason: `${toolName} is a destructive Galaxy operation; blocked in remote mode (no confirmation UI available)`,
+    };
   }
   // Curated remote surface -> allowed.
   if (ALLOWED_EXACT.has(toolName)) return undefined;


### PR DESCRIPTION
Closes #338.

## The problem

A weak model, asked to delete two datasets, reached for the history-level delete tool (`galaxy_update_history(deleted=true)`) and then raw `curl` -- and nothing gated either. The brain exec-guard's policy ends in a catch-all that allows every non-local tool (Galaxy MCP included), and the web-mode gate allows every `galaxy_*` tool by prefix. So a whole ~10GB history was marked deleted with no are-you-sure. There's also no per-dataset delete tool (#228), which is what pushed the model toward the history-level tool and curl in the first place.

## The fix

A shared classifier, `shared/galaxy-destructive.js`, that both `tool_call` gates consume so "what counts as destructive" has one home:

- **Orbit/CLI** (`exec-guard/policy.ts` + `gate.ts`): a whole-history delete/purge routes to a new `galaxy:destructive` decision that **always confirms, regardless of model tier** -- it deliberately bypasses the usual weak->deny downgrade, because the danger in #338 was *silent* execution, not the model proposing the action. Non-interactive sessions deny (no one to approve). The confirm is a yes/no that is **never cached** and never offered "allow for this session", with honest wording that distinguishes a recoverable soft-delete from an irreversible purge.
- **Remote/web** (`web/extensions/web-mode-gate.ts`): destructive ops are **hard-blocked** -- that gate has no confirmation UI. A remote-confirm flow is a follow-up.

The classifier reads two reliable, structured shapes exactly -- a direct tool call and the adapter's generic `mcp({tool, args})` proxy -- and adds best-effort guardrails for the free-form paths: a raw `curl`/`wget` DELETE against `/api/histories/`, and code mode's `run_galaxy_tool(code=...)` Python script. (Code mode isn't wired into this stack yet -- galaxy-mcp ships it behind `--discovery-mode code` and loom's adoption is separate -- so that branch is anticipatory.) The curl and code matchers are guardrails, not security boundaries: they catch the obvious reach-for-the-nearest-tool case, not deliberate obfuscation or a different HTTP client.

## Review

The diff went through an adversarial review (a cross-family pass plus several focused lenses). It confirmed end-to-end that the gate fires against the real emitted tool names and that the always-ask-even-weak / non-interactive-deny / uncacheable / honest-wording properties hold on the reliable paths. It also drove a round of hardening to the best-effort matchers, now in this PR: string-quoted booleans (`deleted='True'`, `{"purge":"true"}`), the code-mode kwargs / `galaxy_`-prefixed `call_tool` forms, purge carried in the DELETE body (not just the query), shell-variable history IDs, a whitespace-padded proxied tool name, and curl-regex over/under-matching (requires a curl/wget verb, excludes dataset-level `/contents/`, handles `wget --method=DELETE`).

## Scope / follow-ups

- Whole-history delete/purge only. Dataset/collection-level deletes need the missing per-dataset tool (#228).
- Other in-surface mutating tools (e.g. `delete_user_tool`) are not yet classified -- a small follow-up to extend the catalog.
- Remote/web interactive-confirm UX (today: hard-block).
- Upstream, a real `delete_dataset` op (#228) plus populating galaxy-ops `destructiveHint` metadata are the root-cause fixes the classifier can later defer to instead of a hand-maintained catalog.

## Tests

TDD throughout. `shared/galaxy-destructive` unit tests (direct / mcp-proxy / code-mode / curl vectors, including the review findings); `exec-guard-policy` (asks even weak, denies non-interactive, proxy + code-mode, curl); `exec-guard-gate` (uncacheable confirm, purge vs delete wording); `web-mode-gate` (hard-block incl. code-mode). Full suite green; root + app typecheck clean.
