### PR TITLE
Gate dataset-level Galaxy delete/purge (follow-up to #338)

### DIFF
--- a/shared/galaxy-destructive.d.ts
+++ b/shared/galaxy-destructive.d.ts
@@ -1,7 +1,15 @@
+export type GalaxyDestructiveKind =
+  | "history-delete"
+  | "history-purge"
+  | "dataset-delete"
+  | "dataset-purge"
+  | "collection-delete"
+  | "collection-purge";
 export interface GalaxyDestructiveOp {
-  kind: "history-delete" | "history-purge" | "dataset-delete" | "dataset-purge";
+  kind: GalaxyDestructiveKind;
   historyId?: string;
   datasetId?: string;
+  collectionId?: string;
   irreversible: boolean;
 }
 export function classifyGalaxyDestructive(

--- a/shared/galaxy-destructive.d.ts
+++ b/shared/galaxy-destructive.d.ts
@@ -1,6 +1,7 @@
 export interface GalaxyDestructiveOp {
-  kind: "history-delete" | "history-purge";
+  kind: "history-delete" | "history-purge" | "dataset-delete" | "dataset-purge";
   historyId?: string;
+  datasetId?: string;
   irreversible: boolean;
 }
 export function classifyGalaxyDestructive(

--- a/shared/galaxy-destructive.js
+++ b/shared/galaxy-destructive.js
@@ -16,7 +16,8 @@
 // `destructiveHint` metadata (galaxy-mcp PR #61) instead of being hand-maintained here.
 
 /**
- * @typedef {{ kind: "history-delete" | "history-purge" | "dataset-delete" | "dataset-purge", historyId?: string, datasetId?: string, irreversible: boolean }} GalaxyDestructiveOp
+ * @typedef {"history-delete" | "history-purge" | "dataset-delete" | "dataset-purge" | "collection-delete" | "collection-purge"} GalaxyDestructiveKind
+ * @typedef {{ kind: GalaxyDestructiveKind, historyId?: string, datasetId?: string, collectionId?: string, irreversible: boolean }} GalaxyDestructiveOp
  */
 
 // Op-name -> predicate over its input args, returning the destructive shape or null.
@@ -106,6 +107,19 @@ export function classifyGalaxyDestructive(toolName, input) {
  * @param {GalaxyDestructiveOp} op @returns {{ headline: string }}
  */
 export function describeGalaxyDestructive(op) {
+  if (op.kind === "collection-delete" || op.kind === "collection-purge") {
+    const target = op.collectionId ? `collection ${op.collectionId}` : "this collection";
+    if (op.irreversible) {
+      return {
+        headline: `Permanently PURGE ${target} -- this deletes all of its datasets and cannot be undone.`,
+      };
+    }
+    return {
+      headline:
+        `Mark ${target} (and all of its datasets) as deleted. ` +
+        `Recoverable via Undelete on most Galaxy servers.`,
+    };
+  }
   const dataset = op.kind === "dataset-delete" || op.kind === "dataset-purge";
   if (dataset) {
     const target = op.datasetId ? `dataset ${op.datasetId}` : "this dataset";
@@ -131,12 +145,22 @@ export function describeGalaxyDestructive(op) {
   };
 }
 
-// A `purge`/`purged` flag set true, in a URL query (?purge=true) or a JSON/body/kwarg field
-// ("purge": true / purge=true / 'purged': True / "purge": "true"). Case-insensitive (so
-// Python `True` matches) and tolerant of a quoted boolean value (JSON-string / coerced bool).
+// Whether a `purge`/`purged` flag is set to a non-falsy value -- in a URL query
+// (?purge=true|1|yes|on), a JSON/body/kwarg field ("purge": true / 'purged': True / purge=1),
+// or carried in a request-body file we can't read (-d @file). Galaxy treats true/1/yes/on as
+// truthy; only an explicit false/0/no/off (or no purge token at all) is a recoverable soft
+// delete. An UNKNOWABLE value (shell variable, file body) is treated as a purge -- the safe,
+// honest direction: over-warn rather than mislabel an irreversible purge as recoverable.
 /** @param {string} s @returns {boolean} */
 function hasPurge(s) {
-  return /[?&]purged?=true\b/i.test(s) || /["']?purged?["']?\s*[:=]\s*["']?true\b/i.test(s);
+  const falsy = /^(false|0|no|off)$/i;
+  const q = s.match(/[?&]purged?=([^&\s"']*)/i);
+  if (q) return !falsy.test(q[1]);
+  const b = s.match(/["']?purged?["']?\s*[:=]\s*["']?([\w$.{}]+)/i);
+  if (b) return !falsy.test(b[1]);
+  // A DELETE whose body comes from a file we can't inspect could carry {"purge": true}.
+  if (/(?:-d|--data(?:-raw|-binary|-urlencode)?|--json)[=\s]+@/i.test(s)) return true;
+  return false;
 }
 
 // A clean literal id only -- never surface a shell variable / interpolation as the "id".
@@ -147,11 +171,14 @@ function literalId(raw) {
 
 /**
  * BEST-EFFORT guardrail for the raw-bash path: an HTTP DELETE issued by curl/wget against a
- * Galaxy history or a dataset within one. A dataset-level `/contents/{dsid}` sub-path is
- * reported as a dataset op (with dataset-scoped wording); the bare `/api/histories/{id}` is
- * the whole-history op. Reversibility is read from a purge flag in the query or the request
- * body. Requires an actual curl/wget verb so a stray URL in `echo`/text doesn't trip it; ids
- * are surfaced only when literal (a `$VAR` is matched but not echoed as a fake id).
+ * Galaxy history, a dataset, or a dataset collection. Targets are checked most-severe first
+ * so a less-severe URL in the same command can't conceal a worse one (a whole-history delete
+ * wins over a dataset URL). Covers the history (`/api/histories/{id}`), contents
+ * (`/contents[/datasets|/dataset_collections]/{id}`), and singleton/batch dataset
+ * (`/api/datasets[/{id}]`) routes. Reversibility is read from a purge flag (query, body, or
+ * an unreadable body file). Requires an actual curl/wget verb so a stray URL in `echo`/text
+ * doesn't trip it; ids are surfaced only when literal (a `$VAR` is matched but not echoed as
+ * a fake id).
  * @param {string} command @returns {GalaxyDestructiveOp | null}
  */
 export function isGalaxyDestructiveCurl(command) {
@@ -163,25 +190,46 @@ export function isGalaxyDestructiveCurl(command) {
     /--method[=\s]+["']?DELETE\b/i.test(cmd);
   if (!isDelete) return null;
   const irreversible = hasPurge(cmd);
-  // Dataset-level delete first (more specific): /api/histories/{hid}/contents/{dsid}.
-  const ds = cmd.match(/\/api\/histories\/([^/\s"'?]+)\/contents\/([^/\s"'?]+)/);
-  if (ds) {
+
+  // Whole-history delete wins (most severe): a bare /api/histories/{id} -- one NOT followed
+  // by a sub-resource path. The lookahead requires a query/space/quote/end after the id, so
+  // the history prefix of a /contents/... URL does not match here.
+  const wholeHistory = cmd.match(/\/api\/histories\/([^/\s"'?]+)(?=[?\s"']|$)/);
+  if (wholeHistory) {
     /** @type {GalaxyDestructiveOp} */
-    const op = { kind: irreversible ? "dataset-purge" : "dataset-delete", irreversible };
-    const hid = literalId(ds[1]);
-    const dsid = literalId(ds[2]);
-    if (hid) op.historyId = hid;
-    if (dsid) op.datasetId = dsid;
+    const op = { kind: irreversible ? "history-purge" : "history-delete", irreversible };
+    const id = literalId(wholeHistory[1]);
+    if (id) op.historyId = id;
     return op;
   }
-  // Whole-history delete: /api/histories/{id} (no /contents/ sub-path).
-  const m = cmd.match(/\/api\/histories\/([^/\s"'?]+)/);
-  if (!m) return null;
-  /** @type {GalaxyDestructiveOp} */
-  const op = { kind: irreversible ? "history-purge" : "history-delete", irreversible };
-  const id = literalId(m[1]);
-  if (id) op.historyId = id;
-  return op;
+
+  // A dataset COLLECTION (a recursive container -- understating it would be dishonest):
+  // /api/histories/{hid}/contents/dataset_collections/{cid}.
+  const coll = cmd.match(
+    /\/api\/histories\/[^/\s"'?]+\/contents\/dataset_collections\/([^/\s"'?]+)/,
+  );
+  if (coll) {
+    /** @type {GalaxyDestructiveOp} */
+    const op = { kind: irreversible ? "collection-purge" : "collection-delete", irreversible };
+    const id = literalId(coll[1]);
+    if (id) op.collectionId = id;
+    return op;
+  }
+
+  // A single dataset: in-history contents (legacy /contents/{id} or typed
+  // /contents/datasets/{id}) or the top-level singleton/batch /api/datasets[/{id}] routes.
+  const inHistory = cmd.match(/\/api\/histories\/[^/\s"'?]+\/contents\/(?:datasets\/)?([^/\s"'?]+)/);
+  const singleton = inHistory ? null : cmd.match(/\/api\/datasets\/([^/\s"'?]+)/);
+  const batch = inHistory || singleton ? false : /\/api\/datasets(?=[?\s"']|$)/.test(cmd);
+  if (inHistory || singleton || batch) {
+    /** @type {GalaxyDestructiveOp} */
+    const op = { kind: irreversible ? "dataset-purge" : "dataset-delete", irreversible };
+    const id = literalId(inHistory ? inHistory[1] : singleton ? singleton[1] : undefined);
+    if (id) op.datasetId = id;
+    return op;
+  }
+
+  return null;
 }
 
 /**

--- a/shared/galaxy-destructive.js
+++ b/shared/galaxy-destructive.js
@@ -16,7 +16,7 @@
 // `destructiveHint` metadata (galaxy-mcp PR #61) instead of being hand-maintained here.
 
 /**
- * @typedef {{ kind: "history-delete" | "history-purge", historyId?: string, irreversible: boolean }} GalaxyDestructiveOp
+ * @typedef {{ kind: "history-delete" | "history-purge" | "dataset-delete" | "dataset-purge", historyId?: string, datasetId?: string, irreversible: boolean }} GalaxyDestructiveOp
  */
 
 // Op-name -> predicate over its input args, returning the destructive shape or null.
@@ -106,6 +106,17 @@ export function classifyGalaxyDestructive(toolName, input) {
  * @param {GalaxyDestructiveOp} op @returns {{ headline: string }}
  */
 export function describeGalaxyDestructive(op) {
+  const dataset = op.kind === "dataset-delete" || op.kind === "dataset-purge";
+  if (dataset) {
+    const target = op.datasetId ? `dataset ${op.datasetId}` : "this dataset";
+    if (op.irreversible) {
+      return { headline: `Permanently PURGE ${target} -- this cannot be undone.` };
+    }
+    return {
+      headline:
+        `Mark ${target} as deleted. Recoverable via Undelete on most Galaxy servers.`,
+    };
+  }
   if (op.irreversible) {
     const target = op.historyId ? `history ${op.historyId}` : "the entire history";
     return {
@@ -136,10 +147,11 @@ function literalId(raw) {
 
 /**
  * BEST-EFFORT guardrail for the raw-bash path: an HTTP DELETE issued by curl/wget against a
- * whole Galaxy history (`/api/histories/{id}`, NOT a dataset-level `/contents/` sub-path).
- * Reversibility is read from a purge flag in the query or the request body. Requires an
- * actual curl/wget verb so a stray URL in `echo`/text doesn't trip it; the history id is
- * surfaced only when it's a literal (a `$VAR` is matched but not echoed as a fake id).
+ * Galaxy history or a dataset within one. A dataset-level `/contents/{dsid}` sub-path is
+ * reported as a dataset op (with dataset-scoped wording); the bare `/api/histories/{id}` is
+ * the whole-history op. Reversibility is read from a purge flag in the query or the request
+ * body. Requires an actual curl/wget verb so a stray URL in `echo`/text doesn't trip it; ids
+ * are surfaced only when literal (a `$VAR` is matched but not echoed as a fake id).
  * @param {string} command @returns {GalaxyDestructiveOp | null}
  */
 export function isGalaxyDestructiveCurl(command) {
@@ -150,12 +162,21 @@ export function isGalaxyDestructiveCurl(command) {
     /-X["']?DELETE\b/i.test(cmd) ||
     /--method[=\s]+["']?DELETE\b/i.test(cmd);
   if (!isDelete) return null;
-  // Dataset-level deletes (/api/histories/{id}/contents/{dsid}) are out of v1 scope --
-  // do not claim "entire history" for them.
-  if (/\/api\/histories\/[^/\s"'?]+\/contents\//.test(cmd)) return null;
+  const irreversible = hasPurge(cmd);
+  // Dataset-level delete first (more specific): /api/histories/{hid}/contents/{dsid}.
+  const ds = cmd.match(/\/api\/histories\/([^/\s"'?]+)\/contents\/([^/\s"'?]+)/);
+  if (ds) {
+    /** @type {GalaxyDestructiveOp} */
+    const op = { kind: irreversible ? "dataset-purge" : "dataset-delete", irreversible };
+    const hid = literalId(ds[1]);
+    const dsid = literalId(ds[2]);
+    if (hid) op.historyId = hid;
+    if (dsid) op.datasetId = dsid;
+    return op;
+  }
+  // Whole-history delete: /api/histories/{id} (no /contents/ sub-path).
   const m = cmd.match(/\/api\/histories\/([^/\s"'?]+)/);
   if (!m) return null;
-  const irreversible = hasPurge(cmd);
   /** @type {GalaxyDestructiveOp} */
   const op = { kind: irreversible ? "history-purge" : "history-delete", irreversible };
   const id = literalId(m[1]);

--- a/tests/galaxy-destructive.test.ts
+++ b/tests/galaxy-destructive.test.ts
@@ -296,3 +296,78 @@ describe("isGalaxyDestructiveCurl", () => {
     expect(isGalaxyDestructiveCurl("curl https://g/api/histories/abc")).toBeNull();
   });
 });
+
+describe("isGalaxyDestructiveCurl -- post-codex hardening (#345)", () => {
+  it("flags the singleton DELETE /api/datasets/{id} route", () => {
+    expect(
+      isGalaxyDestructiveCurl("curl -X DELETE 'https://g/api/datasets/d1?purge=true'"),
+    ).toMatchObject({ kind: "dataset-purge", datasetId: "d1", irreversible: true });
+  });
+
+  it("flags the batch DELETE /api/datasets route (ids in body, no literal id)", () => {
+    const op = isGalaxyDestructiveCurl(`curl -X DELETE https://g/api/datasets -d '{"purge":true}'`);
+    expect(op?.kind).toBe("dataset-purge");
+  });
+
+  it("treats purge=1 / yes / on as an irreversible purge", () => {
+    for (const v of ["1", "yes", "on"]) {
+      expect(
+        isGalaxyDestructiveCurl(`curl -X DELETE https://g/api/datasets/d1?purge=${v}`),
+        v,
+      ).toMatchObject({ kind: "dataset-purge", irreversible: true });
+    }
+  });
+
+  it("treats an unverifiable purge value (shell variable) as irreversible, not recoverable", () => {
+    expect(
+      isGalaxyDestructiveCurl(`curl -X DELETE "https://g/api/datasets/d1?purge=$DOPURGE"`),
+    ).toMatchObject({ kind: "dataset-purge", irreversible: true });
+  });
+
+  it("treats a file-ref request body on a delete as purge-ambiguous (irreversible)", () => {
+    expect(
+      isGalaxyDestructiveCurl(`curl -X DELETE https://g/api/datasets/d1 --data @payload.json`),
+    ).toMatchObject({ kind: "dataset-purge", irreversible: true });
+  });
+
+  it("respects an explicit purge=false as a recoverable soft delete", () => {
+    expect(
+      isGalaxyDestructiveCurl("curl -X DELETE 'https://g/api/datasets/d1?purge=false'"),
+    ).toMatchObject({ kind: "dataset-delete", irreversible: false });
+  });
+
+  it("prefers the whole-history op when a command also contains a dataset URL", () => {
+    expect(
+      isGalaxyDestructiveCurl(
+        "curl -X DELETE https://g/api/histories/H https://g/api/histories/H/contents/D",
+      ),
+    ).toMatchObject({ kind: "history-delete", historyId: "H" });
+  });
+
+  it("extracts the real id from a typed /contents/datasets/{id} route", () => {
+    expect(
+      isGalaxyDestructiveCurl("curl -X DELETE https://g/api/histories/H/contents/datasets/D"),
+    ).toMatchObject({ kind: "dataset-delete", datasetId: "D" });
+  });
+
+  it("classifies a dataset_collection delete as a collection, not a single dataset", () => {
+    const op = isGalaxyDestructiveCurl(
+      "curl -X DELETE 'https://g/api/histories/H/contents/dataset_collections/C?purge=true'",
+    );
+    expect(op).toMatchObject({ kind: "collection-purge", collectionId: "C", irreversible: true });
+  });
+});
+
+describe("describeGalaxyDestructive -- collection wording", () => {
+  it("collection purge names the collection and flags all its datasets, irreversibly", () => {
+    const { headline } = describeGalaxyDestructive({
+      kind: "collection-purge",
+      collectionId: "C",
+      irreversible: true,
+    });
+    expect(headline).toMatch(/collection/i);
+    expect(headline).toMatch(/all|every|its datasets/i);
+    expect(headline).toMatch(/cannot be undone|permanent/i);
+    expect(headline).toContain("C");
+  });
+});

--- a/tests/galaxy-destructive.test.ts
+++ b/tests/galaxy-destructive.test.ts
@@ -188,6 +188,29 @@ describe("describeGalaxyDestructive", () => {
     expect(typeof headline).toBe("string");
     expect(headline.length).toBeGreaterThan(0);
   });
+
+  it("dataset purge wording names the dataset and says it cannot be undone", () => {
+    const { headline } = describeGalaxyDestructive({
+      kind: "dataset-purge",
+      datasetId: "d1",
+      irreversible: true,
+    });
+    expect(headline).toMatch(/dataset/i);
+    expect(headline).toMatch(/cannot be undone|permanent/i);
+    expect(headline).toContain("d1");
+    expect(headline).not.toMatch(/entire history/i);
+  });
+
+  it("dataset delete wording is dataset-scoped and recoverable (not 'entire history')", () => {
+    const { headline } = describeGalaxyDestructive({
+      kind: "dataset-delete",
+      datasetId: "d1",
+      irreversible: false,
+    });
+    expect(headline).toMatch(/dataset/i);
+    expect(headline).toMatch(/undelete|recoverable/i);
+    expect(headline).not.toMatch(/entire history/i);
+  });
 });
 
 describe("isGalaxyDestructiveCurl", () => {
@@ -237,10 +260,28 @@ describe("isGalaxyDestructiveCurl", () => {
     expect(isGalaxyDestructiveCurl("http DELETE https://g/api/histories/abc")).toBeNull();
   });
 
-  it("does NOT flag dataset-level /contents/ deletes (out of v1 scope) (#338 F5)", () => {
+  it("flags a dataset-level /contents/ DELETE as a dataset delete (soft)", () => {
     expect(
       isGalaxyDestructiveCurl("curl -X DELETE https://g/api/histories/abc/contents/d1"),
-    ).toBeNull();
+    ).toMatchObject({ kind: "dataset-delete", datasetId: "d1", irreversible: false });
+  });
+
+  it("flags a dataset purge (?purge=true on /contents/) as irreversible", () => {
+    expect(
+      isGalaxyDestructiveCurl("curl -X DELETE 'https://g/api/histories/abc/contents/d1?purge=true'"),
+    ).toMatchObject({ kind: "dataset-purge", datasetId: "d1", irreversible: true });
+  });
+
+  it("flags a dataset purge carried in the request body", () => {
+    expect(
+      isGalaxyDestructiveCurl(`curl -X DELETE https://g/api/histories/abc/contents/d1 -d '{"purge":true}'`),
+    ).toMatchObject({ kind: "dataset-purge", irreversible: true });
+  });
+
+  it("still flags a dataset delete with a shell-variable id (no fake literal)", () => {
+    const op = isGalaxyDestructiveCurl(`curl -X DELETE "$URL/api/histories/$H/contents/$DS?purge=true"`);
+    expect(op).toMatchObject({ kind: "dataset-purge", irreversible: true });
+    expect(op?.datasetId).toBeUndefined();
   });
 
   it("does NOT flag a GET", () => {


### PR DESCRIPTION
Follow-up to #338 (merged in #344).

#344 gated whole-history delete/purge but deliberately scoped dataset-level deletes out -- the raw-curl guardrail skipped the `/contents/` sub-path so it couldn't mislabel a dataset delete as "entire history". A dataset **purge** is still irreversible data loss, just a smaller blast radius, so this extends the same classifier to it.

## What changed

`isGalaxyDestructiveCurl` now classifies a `curl`/`wget` DELETE against `/api/histories/{id}/contents/{dsid}`: a plain delete reads as `dataset-delete` (recoverable soft-delete), and a purge (`?purge=true` in the query or the request body) as `dataset-purge` (irreversible), each with honest dataset-scoped wording. IDs are surfaced only when literal (a `$VAR` still matches but isn't echoed as a fake id).

## No gate/policy/web changes

Both `tool_call` gates already route any destructive op to the same confirmation by category (`galaxy:destructive`), so this is just a new shape + wording in the shared classifier -- the classifier was built for exactly this kind of extension.

## Scope

Covers the raw-curl path, which is the only dataset-delete vector today -- there's no MCP dataset-delete tool yet (#228). When one ships, it should get a single entry in the same catalog. Collection deletes and `/api/datasets/{id}` are not covered here.

## Tests

Classifier unit tests for dataset delete/purge (query + body forms), shell-variable ids, and dataset-scoped wording (asserting it does NOT say "entire history" for a dataset). Full suite green; root + app typecheck clean.
