### PR TITLE
Bump galaxy-mcp pin to >=1.9.0 for the Pages tools; cut 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Notable, user-facing changes to Loom and Orbit. Each release lists a short set o
 highlights; the full commit-level notes live on the GitHub release pages. Add a
 new `## [<version>] - <date>` block with a `### Highlights` list at release time.
 
+## [0.5.1] - 2026-06-20
+
+### Highlights
+
+- Destructive Galaxy deletes now ask first: deleting or purging a history, dataset, or collection prompts for confirmation before anything is removed (and the web shell blocks it outright)
+- Require the Galaxy MCP 1.9 server (up from 1.8): the agent can now work with Galaxy Pages -- creating, reading, and updating the notebook and report documents that pair an analysis with its narrative -- plus reliability fixes for workflow invocation and Galaxy auth
+- The text-selection Copy button stays put within the chat panel instead of drifting into the sidebar on wide or scrollable messages
+
 ## [0.5.0] - 2026-06-19
 
 ### Highlights

--- a/app/forge.config.ts
+++ b/app/forge.config.ts
@@ -206,7 +206,7 @@ function pruneNodeBundle(): void {
   }
 }
 
-// Bundle uv/uvx so Galaxy MCP (`uvx galaxy-mcp>=1.8.0`) doesn't need a
+// Bundle uv/uvx so Galaxy MCP (`uvx galaxy-mcp>=1.9.0`) doesn't need a
 // system-installed uv. Pulls the latest release tarball from astral-sh/uv.
 // "latest" resolves to a specific tag at fetch time -- the cached tarball
 // won't auto-refresh; remove `.loom-stage/cache/` to pick up newer uv.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orbit",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orbit",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "orbit",
   "productName": "Orbit",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Electron desktop shell for the Loom agent runtime (Galaxy bioinformatics)",
   "license": "MIT",
   "main": ".vite/build/main.js",

--- a/bin/loom.js
+++ b/bin/loom.js
@@ -318,7 +318,7 @@ if (!isInformationalCommand) {
   if (hasGalaxyCredentials) {
     mcpConfig.mcpServers.galaxy = {
       command: "uvx",
-      args: ["galaxy-mcp>=1.8.0"],
+      args: ["galaxy-mcp>=1.9.0"],
       directTools: true,
       // Local-path upload over MCP times out on large files (-32001); the
       // loom-native galaxy_upload_local_file tool handles those instead. URL

--- a/bin/uvx-check.js
+++ b/bin/uvx-check.js
@@ -1,5 +1,5 @@
 // Pre-flight helper: is `uvx` resolvable on PATH? Galaxy MCP launches via
-// `uvx galaxy-mcp>=1.8.0` (see bin/loom.js), so when Galaxy credentials are
+// `uvx galaxy-mcp>=1.9.0` (see bin/loom.js), so when Galaxy credentials are
 // configured but uv isn't installed, pi-mcp-adapter fails to start that one
 // server with a spawn error buried in the logs and Galaxy tools silently
 // vanish. We detect the gap up front and print an actionable notice. Orbit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@galaxyproject/loom",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@galaxyproject/loom",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "^0.0.52",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@galaxyproject/loom",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "description": "AI co-scientist for Galaxy bioinformatics, built on Pi.dev",
   "keywords": [


### PR DESCRIPTION
galaxy-mcp 1.9.0 is on PyPI now -- it's the release that adds the Pages (notebook/report) tools, fixes JSON-string `invoke_workflow` inputs, and lands an auth-replay fix. Loom launches the standalone server with `uvx galaxy-mcp>=1.8.0`, and with that floor uvx happily keeps resolving the cached 1.8.0 and never sees the new tools. Bumping the floor to `>=1.9.0` forces uvx to resolve the new release and sidesteps the uv cache staleness.

Kept it as a `>=` range (not a pin) so future patches still resolve. The functional change is the one line in `bin/loom.js`; the two doc comments in `bin/uvx-check.js` and `app/forge.config.ts` that quote the pin are bumped to match.

Also cuts the patch release -- 0.5.1 in both package.json/lockfiles (lockstep passes) plus a CHANGELOG highlight, same as the 0.4.1 entry did for the 1.6 -> 1.8 bump.

Verified: root + app typecheck clean, 1222 tests pass, prettier clean on touched files.

Note for after release: uvx may need a `uv cache` refresh to pick up the new resolve on machines that already cached 1.8.0.
