### PR TITLE
Match weak-tier model-id markers as whole tokens (fixes Gemini misclassification)

### DIFF
--- a/extensions/loom/exec-guard/model-tier.ts
+++ b/extensions/loom/exec-guard/model-tier.ts
@@ -6,8 +6,9 @@ export interface TierInput {
   cost?: { input: number; output: number };
 }
 
-// Substrings that mark a model as weak/cheap regardless of cost. Matched
-// case-insensitively against the model id. Conservative: when unsure -> weak.
+// Tokens that mark a model as weak/cheap regardless of cost. Matched as whole
+// dash/dot-delimited tokens of the lowercased id (NOT substrings) so "mini"
+// flags gpt-4o-mini but not gemini. Conservative: when unsure -> weak.
 const WEAK_ID_MARKERS = ["haiku", "mini", "flash", "small", "lite", "8b", "7b", "1b", "3b", "nano"];
 
 // Frontier id markers that are trusted even if a custom price table is wrong.
@@ -25,7 +26,8 @@ const TRUSTED_ID_MARKERS = [
 export function classifyModelTier(model: TierInput | undefined): ModelTier {
   if (!model || !model.id) return "weak";
   const id = model.id.toLowerCase();
-  if (WEAK_ID_MARKERS.some((m) => id.includes(m))) return "weak";
+  const idTokens = id.split(/[^a-z0-9]+/);
+  if (idTokens.some((tok) => WEAK_ID_MARKERS.includes(tok))) return "weak";
   if (TRUSTED_ID_MARKERS.some((m) => id.includes(m))) return "trusted";
   // Fall back to price: frontier output pricing is well above cheap tiers.
   // Threshold chosen so Haiku ($5 out) is weak and Sonnet ($15 out) is trusted.

--- a/tests/exec-guard-model-tier.test.ts
+++ b/tests/exec-guard-model-tier.test.ts
@@ -20,6 +20,23 @@ describe("classifyModelTier", () => {
     expect(
       classifyModelTier({ id: "gpt-5.4", provider: "openai", cost: { input: 5, output: 20 } }),
     ).toBe("trusted");
+    // Regression: "gemini" contains "mini"; a gemini-pro id must not match the weak marker.
+    // gemini-2.5-pro is trusted by its marker (a sub-$10 price proves it, not the price fallback);
+    // gemini-3.1-pro-preview has no marker and is trusted via the price fallback.
+    expect(
+      classifyModelTier({
+        id: "gemini-2.5-pro",
+        provider: "google",
+        cost: { input: 1.25, output: 5 },
+      }),
+    ).toBe("trusted");
+    expect(
+      classifyModelTier({
+        id: "gemini-3.1-pro-preview",
+        provider: "google",
+        cost: { input: 2, output: 12 },
+      }),
+    ).toBe("trusted");
   });
   it("cheap/small models are weak", () => {
     expect(


### PR DESCRIPTION
## The problem

The brain exec-guard classifies a model as weak- or trusted-tier in
`extensions/loom/exec-guard/model-tier.ts`, and the weak-tier check matched its markers as
substrings of the model id:

```ts
if (WEAK_ID_MARKERS.some((m) => id.includes(m))) return "weak";
```

`WEAK_ID_MARKERS` includes `"mini"`, and `"gemini"` contains it -- so
`"gemini-3.1-pro-preview".includes("mini")` is `true` and every Gemini model classifies as weak.
That check runs before the trusted-marker list and the price fallback, so it short-circuits: even
`gemini-2.5-pro` and `gemini-1.5-pro`, which are listed in `TRUSTED_ID_MARKERS`, come out weak, and
those two entries are unreachable dead code.

The user-visible effect: a weak-tier model never gets the trusted-workspace auto-allow (`policy.ts`),
so on any Gemini model "Trust this workspace" does nothing -- routine `unknown` commands
(`curl ... | jq`, or a script the agent just wrote) re-prompt on every call even in a trusted
workspace.

## The fix

Match each weak marker as a whole, delimiter-separated token instead of a substring:

```ts
const idTokens = id.split(/[^a-z0-9]+/);
if (idTokens.some((tok) => WEAK_ID_MARKERS.includes(tok))) return "weak";
```

Every weak marker is a single token, so genuinely weak ids still match (`gpt-4o-mini`,
`claude-3-5-haiku`, `gemini-2.0-flash`, `llama-3.1-8b`), while `"mini"` no longer matches inside
`"gemini"`. Gemini ids fall through to the trusted list and price fallback as intended, and the
`gemini-2.5-pro` / `gemini-1.5-pro` trusted markers are reachable again. The trusted-marker check is
left as a substring match -- those markers are longer, version-specific strings -- so there's no
behavior change for non-Gemini ids.

## Tests

Extends `tests/exec-guard-model-tier.test.ts` with two assertions in the existing "frontier models
are trusted" block: `gemini-2.5-pro` and `gemini-3.1-pro-preview` must be `trusted`. Both fail on the
current substring check and pass with the token match (watched them go red, then green). Full suite
green (1237 passed / 1 skipped), `npm run typecheck` clean, prettier and eslint clean.
