### PR TITLE
Fix GCC feedback: symlinked files in files tab + sticky Copy button (#353)

### DIFF
--- a/app/src/main/files-handler.ts
+++ b/app/src/main/files-handler.ts
@@ -67,7 +67,7 @@ function toPosix(p: string): string {
   return p.split(path.sep).join("/");
 }
 
-async function walkDir(
+export async function walkDir(
   cwd: string,
   relDir: string,
   includeHidden: boolean,
@@ -92,24 +92,40 @@ async function walkDir(
     if (!includeHidden && e.name.startsWith(".") && e.name !== "notebook.md") continue;
 
     const childRel = toPosix(path.join(relDir, e.name));
-    if (e.isDirectory()) {
+    const absPath = path.join(absDir, e.name);
+
+    // Resolve symlinks to their target type so linked files/dirs still appear.
+    let isDir = e.isDirectory();
+    let isFile = e.isFile();
+    if (e.isSymbolicLink()) {
+      try {
+        const target = await fsp.stat(absPath);
+        isDir = target.isDirectory();
+        isFile = target.isFile();
+      } catch {
+        // Broken symlink -- surface it as a file so it stays visible.
+        isFile = true;
+      }
+    }
+
+    if (isDir) {
       out.push({
         name: e.name,
         relPath: childRel,
         type: "directory",
         children: await walkDir(cwd, childRel, includeHidden, depth + 1),
       });
-    } else if (e.isFile()) {
+    } else if (isFile) {
       let size: number | undefined;
       try {
-        const stat = await fsp.stat(path.join(absDir, e.name));
+        const stat = await fsp.stat(absPath);
         size = stat.size;
       } catch {
         size = undefined;
       }
       out.push({ name: e.name, relPath: childRel, type: "file", size });
     }
-    // Symlinks / sockets / etc. are ignored.
+    // Sockets / fifos / etc. are still ignored.
   }
 
   // Directories first, then files; alphabetical within each group.

--- a/app/src/main/files-handler.ts
+++ b/app/src/main/files-handler.ts
@@ -67,6 +67,19 @@ function toPosix(p: string): string {
   return p.split(path.sep).join("/");
 }
 
+// Whether p's real path stays inside cwd. Used to decide if a symlinked
+// directory is safe to descend into -- mirrors the file-protocol guard in
+// main.ts so symlinks can't expose content outside the working directory.
+async function isWithinCwd(cwd: string, p: string): Promise<boolean> {
+  try {
+    const cwdReal = await fsp.realpath(cwd);
+    const pReal = await fsp.realpath(p);
+    return pReal === cwdReal || pReal.startsWith(cwdReal + path.sep);
+  } catch {
+    return false;
+  }
+}
+
 export async function walkDir(
   cwd: string,
   relDir: string,
@@ -97,13 +110,18 @@ export async function walkDir(
     // Resolve symlinks to their target type so linked files/dirs still appear.
     let isDir = e.isDirectory();
     let isFile = e.isFile();
+    let recurse = isDir; // real directories always descend
     if (e.isSymbolicLink()) {
       try {
         const target = await fsp.stat(absPath);
         isDir = target.isDirectory();
         isFile = target.isFile();
+        // Only descend into a linked directory whose real path stays inside
+        // cwd, so a symlink can't expose content outside the working directory.
+        recurse = isDir && (await isWithinCwd(cwd, absPath));
       } catch {
         // Broken symlink -- surface it as a file so it stays visible.
+        isDir = false;
         isFile = true;
       }
     }
@@ -113,7 +131,7 @@ export async function walkDir(
         name: e.name,
         relPath: childRel,
         type: "directory",
-        children: await walkDir(cwd, childRel, includeHidden, depth + 1),
+        children: recurse ? await walkDir(cwd, childRel, includeHidden, depth + 1) : [],
       });
     } else if (isFile) {
       let size: number | undefined;

--- a/tests/files-walkdir-symlinks.test.ts
+++ b/tests/files-walkdir-symlinks.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { promises as fsp } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// files-handler.ts imports { ipcMain, BrowserWindow } from "electron" at module
+// top-level; stub them since walkDir never calls into electron.
+vi.mock("electron", () => ({ ipcMain: {}, BrowserWindow: {} }));
+
+import { walkDir, type FileNode } from "../app/src/main/files-handler.js";
+
+let root: string;
+
+beforeAll(async () => {
+  root = await fsp.mkdtemp(path.join(os.tmpdir(), "loom-walkdir-"));
+
+  // A real file and a real directory.
+  await fsp.writeFile(path.join(root, "real.txt"), "hello");
+  await fsp.mkdir(path.join(root, "realdir"));
+  await fsp.writeFile(path.join(root, "realdir", "inner.txt"), "x");
+
+  // A symlink to the file, a symlink to the directory, and a broken symlink.
+  await fsp.symlink(path.join(root, "real.txt"), path.join(root, "link-to-file"));
+  await fsp.symlink(path.join(root, "realdir"), path.join(root, "link-to-dir"));
+  await fsp.symlink(path.join(root, "missing-target"), path.join(root, "broken-link"));
+});
+
+afterAll(async () => {
+  await fsp.rm(root, { recursive: true, force: true });
+});
+
+function byName(nodes: FileNode[]): Map<string, FileNode> {
+  return new Map(nodes.map((n) => [n.name, n]));
+}
+
+describe("walkDir symlink handling", () => {
+  it("shows a symlink to a file as a file", async () => {
+    const nodes = byName(await walkDir(root, "", false, 0));
+    const link = nodes.get("link-to-file");
+    expect(link).toBeDefined();
+    expect(link?.type).toBe("file");
+  });
+
+  it("shows a symlink to a directory as a walkable directory", async () => {
+    const nodes = byName(await walkDir(root, "", false, 0));
+    const link = nodes.get("link-to-dir");
+    expect(link).toBeDefined();
+    expect(link?.type).toBe("directory");
+    expect(link?.children?.some((c) => c.name === "inner.txt")).toBe(true);
+  });
+
+  it("still surfaces a broken symlink as a file", async () => {
+    const nodes = byName(await walkDir(root, "", false, 0));
+    const link = nodes.get("broken-link");
+    expect(link).toBeDefined();
+    expect(link?.type).toBe("file");
+  });
+});

--- a/tests/files-walkdir-symlinks.test.ts
+++ b/tests/files-walkdir-symlinks.test.ts
@@ -10,6 +10,7 @@ vi.mock("electron", () => ({ ipcMain: {}, BrowserWindow: {} }));
 import { walkDir, type FileNode } from "../app/src/main/files-handler.js";
 
 let root: string;
+let outside: string;
 
 beforeAll(async () => {
   root = await fsp.mkdtemp(path.join(os.tmpdir(), "loom-walkdir-"));
@@ -23,10 +24,16 @@ beforeAll(async () => {
   await fsp.symlink(path.join(root, "real.txt"), path.join(root, "link-to-file"));
   await fsp.symlink(path.join(root, "realdir"), path.join(root, "link-to-dir"));
   await fsp.symlink(path.join(root, "missing-target"), path.join(root, "broken-link"));
+
+  // A symlink to a directory OUTSIDE cwd -- shown, but must not be descended.
+  outside = await fsp.mkdtemp(path.join(os.tmpdir(), "loom-outside-"));
+  await fsp.writeFile(path.join(outside, "secret.txt"), "nope");
+  await fsp.symlink(outside, path.join(root, "link-outside"));
 });
 
 afterAll(async () => {
   await fsp.rm(root, { recursive: true, force: true });
+  await fsp.rm(outside, { recursive: true, force: true });
 });
 
 function byName(nodes: FileNode[]): Map<string, FileNode> {
@@ -54,5 +61,14 @@ describe("walkDir symlink handling", () => {
     const link = nodes.get("broken-link");
     expect(link).toBeDefined();
     expect(link?.type).toBe("file");
+  });
+
+  it("shows a symlink to an outside-cwd directory but does not descend into it", async () => {
+    const nodes = byName(await walkDir(root, "", false, 0));
+    const link = nodes.get("link-outside");
+    expect(link).toBeDefined();
+    expect(link?.type).toBe("directory");
+    // Contents outside cwd must not leak into the tree.
+    expect(link?.children).toEqual([]);
   });
 });


### PR DESCRIPTION
Addresses both items from #353 (GCC user feedback session).

## 1. Show symlinked files in the files tab
`walkDir` dropped symlink entries because a symlink `Dirent` reports `false` for both `isFile()` and `isDirectory()`. It now resolves the target type via `stat`:
- symlink → file shows as a file (with target size)
- symlink → directory is walked **only when its real path stays inside cwd** (mirrors the `main.ts` file-protocol containment guard, so a symlink can't expose content outside the working directory); outside-cwd linked dirs still show but render empty
- broken symlinks surface as files so they stay visible

## 2. Copy button sticks around forever
The selection Copy button is `position:fixed` at coords captured when text was selected. Scrolling the chat with a trackpad (no mousedown) left it pinned in the viewport. It now repositions on scroll/resize and hides once the selection scrolls out of the chat's visible bounds. Placement math extracted to a pure `computeCopyButtonPlacement` for unit testing.

## Tests
New `tests/files-walkdir-symlinks.test.ts` (real tmpdir with file/dir/broken/outside-cwd links) and `computeCopyButtonPlacement` cases in `tests/chat-panel.test.ts`. Full suite: 924 passing; app `tsc --noEmit` clean.

> Note: the Copy-button report wording was garbled ("Highlight causes Copy button to hove … sticks around forever"); interpreted as the fixed-position button staying pinned during scroll. Not yet validated against the live UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)