### PR TITLE
Add inline HTML previews to Orbit

### DIFF
--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -625,6 +625,12 @@ export function registerIpcHandlers(agent: AgentManager): void {
           webSecurity: true,
         },
       });
+      win.webContents.on("before-input-event", (event, input) => {
+        if (input.type === "keyDown" && input.key === "Escape" && !win.isDestroyed()) {
+          event.preventDefault();
+          win.close();
+        }
+      });
       await win.loadFile(absPath);
       return { opened: true };
     }

--- a/app/src/renderer/files/file-viewer.ts
+++ b/app/src/renderer/files/file-viewer.ts
@@ -8,10 +8,11 @@
 
 import type { Marked } from "marked";
 import { renderMarkdown } from "../chat/markdown.js";
+import { buildHtmlPreviewDocument } from "./html-preview.js";
 import { extOf, imagePreviewBlob } from "./image-preview.js";
 import { buildPreviewMarked, previewImageBaseDir } from "./markdown-preview.js";
 
-type FileKind = "text" | "image" | "pdf" | "binary";
+type FileKind = "text" | "html" | "image" | "pdf" | "binary";
 
 const TEXT_EXTS = new Set([
   // generic
@@ -40,8 +41,6 @@ const TEXT_EXTS = new Set([
   ".cfg",
   ".conf",
   ".xml",
-  ".html",
-  ".htm",
   ".css",
   // tabular
   ".csv",
@@ -80,11 +79,14 @@ const TEXT_EXTS = new Set([
 
 const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"]);
 
+const HTML_EXTS = new Set([".html", ".htm"]);
+
 const PDF_EXTS = new Set([".pdf"]);
 
 export function kindOf(path: string): FileKind {
   const ext = extOf(path);
   if (!ext) return "text"; // no extension → treat as text
+  if (HTML_EXTS.has(ext)) return "html";
   if (TEXT_EXTS.has(ext)) return "text";
   if (IMAGE_EXTS.has(ext)) return "image";
   if (PDF_EXTS.has(ext)) return "pdf";
@@ -115,6 +117,7 @@ export class FileViewer {
   private previewBtn: HTMLButtonElement | null = null;
   private currentImageUrl: string | null = null;
   private currentPdfUrl: string | null = null;
+  private currentHtmlUrl: string | null = null;
 
   constructor(container: HTMLElement) {
     this.container = container;
@@ -162,7 +165,9 @@ export class FileViewer {
     const root = document.createElement("div");
     root.className = "file-viewer-root";
 
-    if (this.currentKind === "text") {
+    if (this.currentKind === "html") {
+      this.renderHtml(root, relPath, bytes, preview, size);
+    } else if (this.currentKind === "text") {
       this.renderText(root, relPath, bytes, preview, size);
     } else if (this.currentKind === "image") {
       this.renderImage(root, relPath, bytes, size);
@@ -197,7 +202,10 @@ export class FileViewer {
     }
     if (!res.ok) return;
 
-    if (this.currentKind === "text") {
+    if (this.currentKind === "html") {
+      const newText = new TextDecoder("utf-8").decode(res.bytes);
+      this.renderHtmlPreview(newText);
+    } else if (this.currentKind === "text") {
       if (!this.editor) return;
       const newText = new TextDecoder("utf-8").decode(res.bytes);
       if (this.editor.value === newText) return;
@@ -213,7 +221,7 @@ export class FileViewer {
         this.editor.setSelectionRange(Math.min(selStart, cap), Math.min(selEnd, cap));
         // Re-render markdown preview if it's the currently visible pane.
         if (this.preview && !this.preview.classList.contains("hidden")) {
-          this.preview.innerHTML = renderMarkdown(newText, this.previewMarked);
+          this.renderPreview(newText);
         }
       }
     } else if (this.currentKind === "image") {
@@ -248,7 +256,7 @@ export class FileViewer {
         this.statusEl.className = "file-viewer-status saved";
       }
       if (this.preview && !this.preview.classList.contains("hidden")) {
-        this.preview.innerHTML = renderMarkdown(newText, this.previewMarked);
+        this.renderPreview(newText);
       }
       banner.remove();
     });
@@ -307,6 +315,10 @@ export class FileViewer {
       URL.revokeObjectURL(this.currentPdfUrl);
       this.currentPdfUrl = null;
     }
+    if (this.currentHtmlUrl) {
+      URL.revokeObjectURL(this.currentHtmlUrl);
+      this.currentHtmlUrl = null;
+    }
   }
 
   private renderText(
@@ -330,31 +342,7 @@ export class FileViewer {
     // editor + Save toolbar + markdown preview toggle entirely — the
     // user can't usefully edit a 200 MB file's first 10 lines.
     if (headPreview) {
-      const toolbar = document.createElement("div");
-      toolbar.className = "file-viewer-toolbar";
-      const filename = document.createElement("span");
-      filename.className = "file-viewer-filename";
-      filename.textContent = relPath;
-      filename.title = relPath;
-      toolbar.appendChild(filename);
-      const sizeLabel = document.createElement("span");
-      sizeLabel.className = "file-viewer-status";
-      sizeLabel.textContent = typeof size === "number" ? formatBytes(size) : "";
-      toolbar.appendChild(sizeLabel);
-      root.appendChild(toolbar);
-
-      const banner = document.createElement("div");
-      banner.className = "file-viewer-preview-banner";
-      const truncated = headPreview.byteBudgetHit
-        ? `Preview only — first ${headPreview.lineCount} lines (truncated mid-line: lines longer than 64 KB are clipped).`
-        : `Preview only — first ${headPreview.lineCount} lines.`;
-      banner.textContent = `${truncated} Open externally to see the full file.`;
-      root.appendChild(banner);
-
-      const pre = document.createElement("pre");
-      pre.className = "file-viewer-preview-text";
-      pre.textContent = text;
-      root.appendChild(pre);
+      this.renderHeadPreview(root, relPath, text, headPreview, size);
       return;
     }
 
@@ -432,12 +420,89 @@ export class FileViewer {
     this.setMode(isMarkdown ? "preview" : "edit");
   }
 
+  private renderHeadPreview(
+    root: HTMLElement,
+    relPath: string,
+    text: string,
+    headPreview: { kind: "head"; lineCount: number; byteBudgetHit: boolean },
+    size?: number,
+  ): void {
+    const toolbar = document.createElement("div");
+    toolbar.className = "file-viewer-toolbar";
+    const filename = document.createElement("span");
+    filename.className = "file-viewer-filename";
+    filename.textContent = relPath;
+    filename.title = relPath;
+    toolbar.appendChild(filename);
+    const sizeLabel = document.createElement("span");
+    sizeLabel.className = "file-viewer-status";
+    sizeLabel.textContent = typeof size === "number" ? formatBytes(size) : "";
+    toolbar.appendChild(sizeLabel);
+    root.appendChild(toolbar);
+
+    const banner = document.createElement("div");
+    banner.className = "file-viewer-preview-banner";
+    const truncated = headPreview.byteBudgetHit
+      ? `Preview only — first ${headPreview.lineCount} lines (truncated mid-line: lines longer than 64 KB are clipped).`
+      : `Preview only — first ${headPreview.lineCount} lines.`;
+    banner.textContent = `${truncated} Open externally to see the full file.`;
+    root.appendChild(banner);
+
+    const pre = document.createElement("pre");
+    pre.className = "file-viewer-preview-text";
+    pre.textContent = text;
+    root.appendChild(pre);
+  }
+
+  private renderHtml(
+    root: HTMLElement,
+    relPath: string,
+    bytes: Uint8Array,
+    headPreview?: { kind: "head"; lineCount: number; byteBudgetHit: boolean },
+    size?: number,
+  ): void {
+    const text = new TextDecoder("utf-8").decode(bytes);
+    if (headPreview) {
+      this.renderHeadPreview(root, relPath, text, headPreview, size);
+      return;
+    }
+
+    const toolbar = document.createElement("div");
+    toolbar.className = "file-viewer-toolbar";
+
+    const filename = document.createElement("span");
+    filename.className = "file-viewer-filename";
+    filename.textContent = relPath;
+    filename.title = relPath;
+    toolbar.appendChild(filename);
+
+    const openBtn = document.createElement("button");
+    openBtn.className = "file-viewer-btn";
+    openBtn.textContent = "Open Externally";
+    openBtn.addEventListener("click", () => {
+      void window.orbit.openFile(relPath);
+    });
+    toolbar.appendChild(openBtn);
+
+    const sizeLabel = document.createElement("span");
+    sizeLabel.className = "file-viewer-status";
+    sizeLabel.textContent = typeof size === "number" ? formatBytes(size) : "";
+    toolbar.appendChild(sizeLabel);
+
+    root.appendChild(toolbar);
+
+    const preview = document.createElement("div");
+    preview.className = "file-viewer-preview file-viewer-html-preview";
+    this.preview = preview;
+    root.appendChild(preview);
+    this.renderHtmlPreview(text);
+  }
+
   private setMode(mode: "edit" | "preview"): void {
     if (!this.editor || !this.preview) return;
     if (mode === "preview") {
       // Render preview from current (possibly dirty) editor contents.
-      const html = renderMarkdown(this.editor.value, this.previewMarked);
-      this.preview.innerHTML = html;
+      this.renderPreview(this.editor.value);
       this.editor.classList.add("hidden");
       this.preview.classList.remove("hidden");
       if (this.editBtn) this.editBtn.classList.remove("active");
@@ -448,6 +513,35 @@ export class FileViewer {
       if (this.editBtn) this.editBtn.classList.add("active");
       if (this.previewBtn) this.previewBtn.classList.remove("active");
     }
+  }
+
+  private renderPreview(text: string): void {
+    if (!this.preview) return;
+    this.preview.innerHTML = renderMarkdown(text, this.previewMarked);
+  }
+
+  private renderHtmlPreview(text: string): void {
+    if (!this.preview || this.currentKind !== "html" || !this.currentPath) return;
+    this.preview.replaceChildren(this.buildHtmlIframe(this.currentPath, text));
+  }
+
+  private buildHtmlIframe(relPath: string, html: string): HTMLIFrameElement {
+    if (this.currentHtmlUrl) {
+      URL.revokeObjectURL(this.currentHtmlUrl);
+      this.currentHtmlUrl = null;
+    }
+    const doc = buildHtmlPreviewDocument(relPath, html);
+    const blob = new Blob([doc], { type: "text/html" });
+    const url = URL.createObjectURL(blob);
+    this.currentHtmlUrl = url;
+
+    const iframe = document.createElement("iframe");
+    iframe.className = "file-viewer-html-frame";
+    iframe.setAttribute("sandbox", "allow-scripts");
+    iframe.referrerPolicy = "no-referrer";
+    iframe.src = url;
+    iframe.title = relPath;
+    return iframe;
   }
 
   private markDirty(): void {

--- a/app/src/renderer/files/html-preview.ts
+++ b/app/src/renderer/files/html-preview.ts
@@ -1,0 +1,46 @@
+import { previewImageBaseDir } from "./markdown-preview.js";
+
+const HTML_PREVIEW_CSP = [
+  "default-src 'none'",
+  "script-src 'unsafe-inline' blob:",
+  "object-src 'none'",
+  "frame-src 'none'",
+  "child-src 'none'",
+  "connect-src 'none'",
+  "form-action 'none'",
+  "base-uri orbit-artifact:",
+  "img-src orbit-artifact: data: blob:",
+  "style-src orbit-artifact: 'unsafe-inline'",
+  "font-src orbit-artifact: data:",
+  "media-src orbit-artifact: data: blob:",
+].join("; ");
+
+function escapeAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function encodeArtifactPath(p: string): string {
+  if (!p) return "";
+  return p.split("/").map(encodeURIComponent).join("/") + "/";
+}
+
+export function htmlPreviewBaseHref(relPath: string): string {
+  return `orbit-artifact://cwd/${encodeArtifactPath(previewImageBaseDir(relPath))}`;
+}
+
+export function buildHtmlPreviewDocument(relPath: string, html: string): string {
+  const tags = [
+    `<meta http-equiv="Content-Security-Policy" content="${escapeAttr(HTML_PREVIEW_CSP)}">`,
+    `<base href="${escapeAttr(htmlPreviewBaseHref(relPath))}">`,
+  ].join("");
+
+  if (/<head(?:\s[^>]*)?>/i.test(html)) {
+    return html.replace(/<head(?:\s[^>]*)?>/i, (m) => `${m}${tags}`);
+  }
+
+  return `<!doctype html><html><head>${tags}</head><body>${html}</body></html>`;
+}

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -631,6 +631,18 @@ body:not(.artifact-collapsed) #artifact-toggle {
 .file-viewer-preview.hidden {
   display: none;
 }
+.file-viewer-html-preview {
+  padding: 0;
+  overflow: hidden;
+  background: #fff;
+}
+.file-viewer-html-frame {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #fff;
+  display: block;
+}
 
 .file-viewer-image-wrap {
   flex: 1;

--- a/tests/file-preview-classification.test.ts
+++ b/tests/file-preview-classification.test.ts
@@ -34,6 +34,11 @@ describe("kindOf (renderer file viewer)", () => {
     expect(kindOf("a.tab")).toBe("text");
   });
 
+  it("classifies HTML as its own renderable kind", () => {
+    expect(kindOf("report.html")).toBe("html");
+    expect(kindOf("report.htm")).toBe("html");
+  });
+
   it("keeps real binaries out of the text path", () => {
     expect(kindOf("reads.bam")).toBe("binary");
     expect(kindOf("index.bai")).toBe("binary");
@@ -62,6 +67,11 @@ describe("isTextLikeForPreview (main-process head-preview gate)", () => {
     expect(isTextLikeForPreview("reads.bam")).toBe(false);
     expect(isTextLikeForPreview("archive.gz")).toBe(false);
     expect(isTextLikeForPreview("photo.png")).toBe(false);
+  });
+
+  it("keeps HTML text-like for large-file head previews", () => {
+    expect(isTextLikeForPreview("report.html")).toBe(true);
+    expect(isTextLikeForPreview("report.htm")).toBe(true);
   });
 
   it("keeps the gzipped Galaxy variant binary -- only the last extension counts", () => {

--- a/tests/file-viewer-html.test.ts
+++ b/tests/file-viewer-html.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FileViewer } from "../app/src/renderer/files/file-viewer.js";
+
+function bytes(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+function button(root: HTMLElement, label: string): HTMLButtonElement {
+  const found = Array.from(root.querySelectorAll("button")).find((b) => b.textContent === label);
+  if (!found) throw new Error(`missing button: ${label}`);
+  return found;
+}
+
+describe("FileViewer HTML preview", () => {
+  let container: HTMLDivElement;
+  let createObjectURL: ReturnType<typeof vi.fn>;
+  let revokeObjectURL: ReturnType<typeof vi.fn>;
+  let openFile: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    container = document.createElement("div");
+
+    let nextBlobId = 0;
+    createObjectURL = vi.fn(() => `blob:html-${++nextBlobId}`);
+    revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: createObjectURL,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: revokeObjectURL,
+    });
+
+    openFile = vi.fn(async () => ({ opened: true }));
+    Object.defineProperty(window, "orbit", {
+      configurable: true,
+      value: {
+        openFile,
+        readFile: vi.fn(),
+        writeFile: vi.fn(async () => ({ ok: true })),
+      },
+    });
+    Object.defineProperty(window, "confirm", {
+      configurable: true,
+      value: vi.fn(() => true),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("opens HTML in preview mode by default", () => {
+    const viewer = new FileViewer(container);
+
+    expect(viewer.open("report.html", bytes("<h1>Report</h1>"), 15)).toBe(true);
+
+    const editor = container.querySelector<HTMLTextAreaElement>(".file-viewer-editor");
+    const preview = container.querySelector<HTMLElement>(".file-viewer-html-preview");
+    const iframe = container.querySelector<HTMLIFrameElement>(".file-viewer-html-frame");
+    expect(editor).toBeNull();
+    expect(preview?.classList.contains("hidden")).toBe(false);
+    expect(iframe?.src).toBe("blob:html-1");
+    expect(iframe?.getAttribute("sandbox")).toBe("allow-scripts");
+    expect(iframe?.title).toBe("report.html");
+  });
+
+  it("does not render editing controls for HTML", () => {
+    const viewer = new FileViewer(container);
+    viewer.open("report.html", bytes("<h1>Report</h1>"), 15);
+
+    const labels = Array.from(container.querySelectorAll("button")).map((b) => b.textContent);
+    expect(labels).not.toContain("Edit");
+    expect(labels).not.toContain("Preview");
+    expect(labels).not.toContain("Save");
+    expect(container.querySelector(".file-viewer-editor")).toBeNull();
+  });
+
+  it("opens HTML externally through the existing Orbit IPC", () => {
+    const viewer = new FileViewer(container);
+    viewer.open("reports/report.html", bytes("<h1>Report</h1>"), 15);
+
+    button(container, "Open Externally").click();
+
+    expect(openFile).toHaveBeenCalledWith("reports/report.html");
+  });
+
+  it("revokes HTML blob URLs when closing and reopening", () => {
+    const viewer = new FileViewer(container);
+    viewer.open("one.html", bytes("<h1>One</h1>"), 12);
+
+    viewer.open("two.html", bytes("<h1>Two</h1>"), 12);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:html-1");
+
+    viewer.close();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:html-2");
+  });
+
+  it("renders oversized HTML head previews as read-only source excerpts", () => {
+    const viewer = new FileViewer(container);
+    viewer.open("large.html", bytes("<h1>Partial"), 2_000_000, {
+      kind: "head",
+      lineCount: 1,
+      byteBudgetHit: false,
+    });
+
+    expect(container.querySelector(".file-viewer-html-frame")).toBeNull();
+    expect(container.querySelector(".file-viewer-editor")).toBeNull();
+    expect(container.querySelector(".file-viewer-preview-text")?.textContent).toBe("<h1>Partial");
+    expect(container.textContent).toContain("Preview only");
+  });
+});

--- a/tests/html-preview.test.ts
+++ b/tests/html-preview.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from "vitest";
+
+import {
+  buildHtmlPreviewDocument,
+  htmlPreviewBaseHref,
+} from "../app/src/renderer/files/html-preview.js";
+
+describe("htmlPreviewBaseHref", () => {
+  it("points root-level HTML at the cwd artifact root", () => {
+    expect(htmlPreviewBaseHref("report.html")).toBe("orbit-artifact://cwd/");
+  });
+
+  it("points nested HTML at its containing directory", () => {
+    expect(htmlPreviewBaseHref("reports/run-1/report.html")).toBe(
+      "orbit-artifact://cwd/reports/run-1/",
+    );
+  });
+
+  it("encodes path segments", () => {
+    expect(htmlPreviewBaseHref("my reports/café run/report.html")).toBe(
+      "orbit-artifact://cwd/my%20reports/caf%C3%A9%20run/",
+    );
+  });
+});
+
+describe("buildHtmlPreviewDocument", () => {
+  it("injects a restrictive CSP and base href into an existing head", () => {
+    const html = buildHtmlPreviewDocument(
+      "reports/report.html",
+      "<!doctype html><html><head><title>R</title></head><body><h1>Report</h1></body></html>",
+    );
+
+    expect(html).toContain('<base href="orbit-artifact://cwd/reports/">');
+    expect(html).toContain('http-equiv="Content-Security-Policy"');
+    expect(html).toContain("script-src 'unsafe-inline' blob:");
+    expect(html).toContain("object-src 'none'");
+    expect(html).toContain("form-action 'none'");
+    expect(html).toContain("connect-src 'none'");
+    expect(html.indexOf("Content-Security-Policy")).toBeLessThan(html.indexOf("<title>R</title>"));
+  });
+
+  it("wraps an HTML fragment with a safe document shell", () => {
+    const html = buildHtmlPreviewDocument("report.html", "<h1>Report</h1>");
+
+    expect(html).toMatch(/^<!doctype html><html><head>/);
+    expect(html).toContain('<base href="orbit-artifact://cwd/">');
+    expect(html).toContain("<body><h1>Report</h1></body>");
+  });
+
+  it("escapes generated attributes", () => {
+    const html = buildHtmlPreviewDocument('a "quoted"/report.html', "<p>x</p>");
+
+    expect(html).toContain('href="orbit-artifact://cwd/a%20%22quoted%22/"');
+    expect(html).not.toContain('href="orbit-artifact://cwd/a "quoted"/"');
+  });
+});


### PR DESCRIPTION
Adds inline HTML preview support to Orbit’s File tab. HTML files now render in a sandboxed iframe with local assets resolved through the cwd-jailed orbit-artifact:// protocol, remain preview-only in the editor, and can still be opened in a hardened external window with Escape-to-close support.