### PR TITLE
Stop the brain from coercing NA/missing padj to 0 when filtering stats tables

### DIFF
--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -726,6 +726,37 @@ unverified. Do **not** mark the step \`- [x]\` and do **not** say "done"
 or "complete" for that artifact. Say "created but not verified" and ask
 for the missing input or approval to change scope.
 
+### Filtering significance tables — never coerce missing values
+
+When you derive a filtered subset or a count from a statistics table by
+thresholding a p-value / \`padj\` / FDR column (or any column where a
+missing value is not the same as \`0\`), do not let a bare numeric
+coercion turn a missing or non-numeric value into a number. In awk,
+\`"NA"+0\` is \`0\`, so \`$7+0 < 0.05\` counts every \`NA\` row as
+passing — and the header row, blank fields, and \`.\` coerce to \`0\` the
+same way. A DESeq2 results table writes \`NA\` in \`padj\` for
+independent-filtered and outlier genes, so this trap silently inflates
+the "significant" count with no error to catch; the wrong number looks
+completely plausible and flows into downstream figures and tables.
+
+Exclude non-numeric/missing rows explicitly before comparing:
+
+- Prefer Python/R with real NA handling (pandas
+  \`dropna(subset=["padj"])\`, R \`!is.na()\` / \`na.rm\`) — the reliable
+  default for anything past a trivial one-column filter.
+- In awk, guard the column so non-numeric values can't reach the
+  comparison. \`awk '$7 != "NA" && $7+0 < 0.05'\` only excludes the
+  literal \`NA\`; the header, blanks, \`.\`, and \`NaN\` still coerce to
+  \`0\`, so validate the field is actually numeric (or skip the header
+  and the known sentinels) rather than trusting \`$7+0\` alone.
+
+Legitimate numeric filtering is fine, and a column with a deliberate
+zero-imputation convention is the user's call — the rule is only that a
+*missing* value must be dropped, not silently coerced to \`0\`, unless
+the user has defined how to impute it. After filtering, sanity-check the
+surviving row count against expectation (the row/object-count check
+above); an implausible jump usually means a sentinel slipped through.
+
 ### Notebook requirement
 
 Every new plan step should include a concrete \`Verification:\` sub-bullet

--- a/tests/verification-context.test.ts
+++ b/tests/verification-context.test.ts
@@ -27,6 +27,24 @@ describe("buildVerificationDisciplineBlock", () => {
     expect(ctx).toContain("element count");
   });
 
+  it("warns against coercing missing values when filtering significance tables", () => {
+    const ctx = buildVerificationDisciplineBlock();
+    // Normalize whitespace so these load-bearing phrases survive prose reflow.
+    const flat = ctx.replace(/\s+/g, " ");
+
+    expect(flat).toContain("Filtering significance tables — never coerce missing values");
+    expect(flat).toContain('`"NA"+0` is `0`');
+    expect(flat).toContain("$7+0 < 0.05");
+    expect(flat).toContain('writes `NA` in `padj`');
+    expect(flat).toContain('awk \'$7 != "NA" && $7+0 < 0.05\'');
+    // The awk example must flag its own limitation (it only catches literal NA).
+    expect(flat).toContain("only excludes the literal `NA`");
+    expect(flat).toContain('dropna(subset=["padj"])');
+    expect(flat).toContain("Legitimate numeric filtering is fine");
+    expect(flat).toContain("zero-imputation convention is the user's call");
+    expect(flat).toContain("sanity-check the surviving row count");
+  });
+
   it("is wired into the assembled system prompt", async () => {
     const handlers = new Map<string, (event: unknown, ctx: unknown) => Promise<unknown>>();
     const pi = {


### PR DESCRIPTION
Closes #355

DESeq2 writes `NA` in the `padj` column for genes dropped by independent filtering / outlier detection. A bare awk filter like `$7+0 < 0.05` coerces those `NA` rows to `0` (`"NA"+0 == 0` in awk), and `0 < 0.05` is true, so every NA-padj gene gets silently counted as significant. In the run that prompted this, one contrast was reported as 8,738 significant genes where the NA-aware count was ~1,560 -- and that wrong number flowed into downstream shared-DEG and TF analyses before anyone caught it. Same class of silent scientific-correctness gap as #318 and #220.

This adds a guidance subsection to the brain's verification-discipline prompt block (`buildVerificationDisciplineBlock` in `extensions/loom/context.ts`) -- the shipped system prompt, not the human-facing docs. The rule: when thresholding a p-value/padj/FDR column, drop non-numeric/missing rows explicitly (prefer Python/R with real NA handling, or guard the column in awk) and sanity-check the surviving count against expectation.

A few deliberate choices:

- **Prompt note, not a hard guardrail.** There's no in-scope way to intercept and parse arbitrary awk/bash; the precedent here (#171, #268, #320) is prompt-text guardrails in `context.ts`, each with a mechanical test. This follows that.
- **Narrowly scoped.** It's about *coercion of missing values*, not "don't use awk" -- legitimate numeric filtering still works, and a column with a deliberate zero-imputation convention is left as the user's call.
- **The awk example flags its own limitation.** `$7 != "NA"` only excludes the literal `NA`; the header row, blanks, and `.` coerce to `0` the same way, so the text says so and points at Python/R as the reliable default rather than handing over one incantation to cargo-cult.
- **Placement:** it's in the verification block because the closing count sanity-check is genuine verification and reuses that block's existing row/object-count check. Easy to move to a dedicated scientific-correctness block instead if we'd rather grow that family (#318/#220) somewhere of its own.

Ran a skeptical adversarial review pass over the diff; it caught the awk-example-too-narrow and scope-too-broad points above, which are folded in.

Tests: added a case to `tests/verification-context.test.ts` asserting the load-bearing strings ship in the prompt. Full root suite green (1238 passing), root + app typecheck clean. Not live-eyeballed in a running session.