### PR TITLE
Re-sync the Notebook panel after notebook.md writes that bypass the watcher

### DIFF
--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -31,7 +31,13 @@ import { registerSandbox } from "./sandbox";
 import { isLocalExecDisabled } from "./local-exec";
 import { registerSecretRedaction } from "./secret-redaction";
 import * as fs from "fs";
-import { getState, getNotebookPath, getNotebookWidgetMode, setNotebookWidgetMode } from "./state";
+import {
+  getState,
+  getNotebookPath,
+  getNotebookWidgetMode,
+  setNotebookWidgetMode,
+  reemitNotebookIfChanged,
+} from "./state";
 import {
   loadProfiles,
   saveProfile,
@@ -366,6 +372,13 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
   });
 
   pi.on("tool_execution_end", async (event, ctx) => {
+    // Re-sync the Notebook panel after any tool. A bash write to notebook.md
+    // can slip past the single-file watcher -- an atomic temp-and-rename save
+    // (`sed -i`, editors) swaps the inode, and a plain truncate can race the
+    // watcher's awaitWriteFinish window. This is content-guarded so it only
+    // emits on a real change and is a no-op otherwise. #253
+    reemitNotebookIfChanged();
+
     if (event.toolName?.startsWith("galaxy_")) {
       const startTime = toolStartTimes.get(event.toolName);
       if (startTime) {

--- a/extensions/loom/state.ts
+++ b/extensions/loom/state.ts
@@ -48,6 +48,8 @@ export function setNotebookWidgetMode(mode: NotebookWidgetMode): void {
 export function resetState(): void {
   stopWatchingNotebook();
   notebookWidgetMode = "auto";
+  lastEmittedNotebookContent = null;
+  lastInspectedFingerprint = null;
   state = {
     galaxyConnected: false,
     currentHistoryId: null,
@@ -63,6 +65,12 @@ export function resetState(): void {
 type NotebookChangeListener = (markdown: string) => void;
 const notebookChangeListeners: NotebookChangeListener[] = [];
 
+// Content last handed to listeners, plus a cheap stat fingerprint of the file
+// state we last inspected. Both feed reemitNotebookIfChanged() so a re-sync
+// trigger only emits when notebook.md actually changed.
+let lastEmittedNotebookContent: string | null = null;
+let lastInspectedFingerprint: string | null = null;
+
 /** Register a callback that fires on every notebook write. Returns unsubscribe. */
 export function onNotebookChange(listener: NotebookChangeListener): () => void {
   notebookChangeListeners.push(listener);
@@ -73,9 +81,65 @@ export function onNotebookChange(listener: NotebookChangeListener): () => void {
 }
 
 function notifyNotebookChange(markdown: string): void {
+  lastEmittedNotebookContent = markdown;
   for (const listener of notebookChangeListeners) {
-    listener(markdown);
+    try {
+      listener(markdown);
+    } catch (err) {
+      // Isolate subscribers: one throwing listener must not starve the others
+      // or break the caller (e.g. the tool_execution_end hook, which is no
+      // longer wrapped the way the watcher path is). #253
+      console.error("notebook change listener failed:", err);
+    }
   }
+}
+
+/**
+ * Re-read notebook.md and emit a change if its content differs from what was
+ * last emitted; returns whether it emitted.
+ *
+ * The chokidar watcher tracks a single file path and can miss a bash write
+ * that replaces the inode (an atomic temp-and-rename save, e.g. `sed -i` or an
+ * editor) or one that races its awaitWriteFinish window, leaving the Notebook
+ * panel stale until the next `/notebook`. The tool_execution_end hook calls
+ * this after every tool so the panel re-syncs. A cheap stat fingerprint skips
+ * the read when the file is untouched, and a content compare suppresses emits
+ * when nothing actually changed, so calling this on every tool end is not
+ * churn. #253
+ */
+export function reemitNotebookIfChanged(): boolean {
+  const filePath = state.notebookPath;
+  if (!filePath) return false;
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(filePath);
+  } catch {
+    // Missing/unreadable right now (e.g. mid-rename); the watcher and the next
+    // real write recover. Don't advance the fingerprint so the follow-up is seen.
+    return false;
+  }
+
+  // Include dev/ino and ctimeMs, not just mtime+size: an atomic temp-and-rename
+  // save swaps the inode (changing ino), and ctime moves on any write -- so an
+  // inode-replacing or same-size rewrite with a preserved/coarse mtime is still
+  // seen as changed, which is the whole point of #253.
+  const fingerprint = `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}:${stat.ctimeMs}`;
+  if (fingerprint === lastInspectedFingerprint) return false;
+
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return false;
+  }
+  lastInspectedFingerprint = fingerprint;
+
+  // mtime/size moved but the bytes are identical (e.g. a rewrite) -> no churn.
+  if (content === lastEmittedNotebookContent) return false;
+
+  notifyNotebookChange(content);
+  return true;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -141,6 +205,11 @@ export function getNotebookPath(): string | null {
 export function setNotebookPath(notebookFile: string | null): void {
   state.notebookPath = notebookFile;
   state.notebookLoaded = notebookFile !== null;
+  // Switching notebooks must not inherit the prior file's emit baselines, or a
+  // new notebook that shares the old one's content/fingerprint would be wrongly
+  // suppressed and leave the panel stale. #253
+  lastEmittedNotebookContent = null;
+  lastInspectedFingerprint = null;
   if (notebookFile) {
     startWatchingNotebook(notebookFile, false);
     loadActivityLog(path.dirname(notebookFile));
@@ -169,6 +238,9 @@ export function initSessionArtifacts(cwd: string): void {
   const sessionDir = cwd;
   // Fresh session: Pi has cleared extension widgets, so reset the mode too.
   notebookWidgetMode = "auto";
+  // New session may point at a different notebook.md; force the next re-sync
+  // check to re-inspect rather than trust a stale fingerprint. #253
+  lastInspectedFingerprint = null;
 
   try {
     const autoCommit = ensureGitRepo(cwd);

--- a/tests/notebook-reemit.test.ts
+++ b/tests/notebook-reemit.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, renameSync, rmSync, statSync, utimesSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  initSessionArtifacts,
+  onNotebookChange,
+  reemitNotebookIfChanged,
+  resetState,
+  setNotebookPath,
+  stopWatchingNotebook,
+} from "../extensions/loom/state";
+
+// #253: a bash write to notebook.md is missed by the single-file chokidar
+// watcher -- an atomic temp-and-rename save (`sed -i`, editors) swaps the
+// inode, and even a plain truncate can race the watcher's awaitWriteFinish
+// window -- so the Notebook panel goes stale until the next `/notebook`. The
+// tool_execution_end hook re-syncs by calling reemitNotebookIfChanged(), which
+// must emit once when the file's content actually changed and stay quiet
+// otherwise.
+describe("reemitNotebookIfChanged (#253 notebook panel re-sync)", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    resetState();
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function freshSession(): { dir: string; seen: string[]; unsub: () => void } {
+    const dir = mkdtempSync(join(tmpdir(), "loom-reemit-"));
+    dirs.push(dir);
+    initSessionArtifacts(dir); // creates notebook.md, emits the initial "" once
+    // These tests exercise reemitNotebookIfChanged() in isolation; drop the real
+    // chokidar watcher so a late awaitWriteFinish callback can't append to `seen`
+    // and make exact-array assertions flaky. reemit reads state.notebookPath
+    // directly, so it still works with the watcher stopped.
+    stopWatchingNotebook();
+    const seen: string[] = [];
+    const unsub = onNotebookChange((content) => seen.push(content));
+    return { dir, seen, unsub };
+  }
+
+  it("emits once when notebook.md changed out of band", () => {
+    const { dir, seen, unsub } = freshSession();
+
+    writeFileSync(join(dir, "notebook.md"), "# Results\n", "utf-8");
+    expect(reemitNotebookIfChanged()).toBe(true);
+
+    expect(seen).toEqual(["# Results\n"]);
+    unsub();
+  });
+
+  it("does not emit when notebook.md is unchanged", () => {
+    const { seen, unsub } = freshSession();
+
+    expect(reemitNotebookIfChanged()).toBe(false);
+    expect(seen).toEqual([]);
+    unsub();
+  });
+
+  it("does not re-emit the same change on a second call", () => {
+    const { dir, seen, unsub } = freshSession();
+
+    writeFileSync(join(dir, "notebook.md"), "# Results\n", "utf-8");
+    expect(reemitNotebookIfChanged()).toBe(true);
+    expect(reemitNotebookIfChanged()).toBe(false);
+
+    expect(seen).toEqual(["# Results\n"]);
+    unsub();
+  });
+
+  it("returns false when there is no active notebook", () => {
+    resetState();
+    expect(reemitNotebookIfChanged()).toBe(false);
+  });
+
+  it("emits on an inode-replacing write even when size and mtime are unchanged", () => {
+    const { dir, seen, unsub } = freshSession();
+    const nb = join(dir, "notebook.md");
+    // Pin a fixed mtime so a mtime+size-only guard would treat the replacement
+    // as identical -- this is the watcher-evading write #253 is really about.
+    const fixed = new Date(1700000000000);
+
+    writeFileSync(nb, "AAAA", "utf-8");
+    utimesSync(nb, fixed, fixed);
+    expect(reemitNotebookIfChanged()).toBe(true);
+    expect(seen).toEqual(["AAAA"]);
+
+    // Atomic temp-and-rename: new inode, same byte length, restored mtime.
+    const tmp = join(dir, ".notebook.md.tmp");
+    writeFileSync(tmp, "BBBB", "utf-8");
+    renameSync(tmp, nb);
+    utimesSync(nb, fixed, fixed);
+    expect(statSync(nb).size).toBe(4); // same size as before
+
+    seen.length = 0;
+    expect(reemitNotebookIfChanged()).toBe(true);
+    expect(seen).toEqual(["BBBB"]);
+    unsub();
+  });
+
+  it("does not let a throwing listener break the caller or starve other listeners", () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const { dir, unsub } = freshSession();
+      const unsubBad = onNotebookChange(() => {
+        throw new Error("listener boom");
+      });
+      const seen: string[] = [];
+      const unsubGood = onNotebookChange((content) => seen.push(content));
+
+      writeFileSync(join(dir, "notebook.md"), "# After throw\n", "utf-8");
+
+      // The tool_execution_end hook calls reemit; a misbehaving subscriber must
+      // not throw out of it, and the well-behaved subscriber must still fire.
+      expect(() => reemitNotebookIfChanged()).not.toThrow();
+      expect(seen).toEqual(["# After throw\n"]);
+      expect(errSpy).toHaveBeenCalled();
+
+      unsubBad();
+      unsubGood();
+      unsub();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("re-emits when the notebook path switches to a same-content file", () => {
+    const { unsub } = freshSession(); // notebook.md == ""
+    unsub();
+
+    const dir2 = mkdtempSync(join(tmpdir(), "loom-reemit-alt-"));
+    dirs.push(dir2);
+    const nb2 = join(dir2, "notebook.md");
+    writeFileSync(nb2, "", "utf-8"); // identical content ("") to the first notebook
+
+    setNotebookPath(nb2);
+    stopWatchingNotebook();
+    const seen: string[] = [];
+    const unsub2 = onNotebookChange((content) => seen.push(content));
+
+    // A new notebook that happens to share the old one's content must still
+    // emit so the panel/header re-sync to the new file.
+    expect(reemitNotebookIfChanged()).toBe(true);
+    expect(seen).toEqual([""]);
+    unsub2();
+  });
+});


### PR DESCRIPTION
Closes #253

The Notebook panel only refreshed when the chokidar watcher caught a change to `notebook.md`, but the watcher tracks a single file path. An atomic temp-and-rename save (`sed -i`, an editor) swaps the inode out from under it, and a plain truncate can race its `awaitWriteFinish` window -- so when the agent wrote the notebook through bash instead of `/notebook`, the panel went stale. The `tool_execution_end` hook also only re-emitted for `galaxy_` tools.

## What this does

`tool_execution_end` now calls a new `reemitNotebookIfChanged()` (in `state.ts`) after every tool. It re-reads `notebook.md` and emits through the existing `notifyNotebookChange` path **only when the content actually changed**:

- a `dev:ino:size:mtimeMs:ctimeMs` stat fingerprint skips the read when the file is untouched, so it isn't I/O churn on every tool end, and
- a content comparison suppresses no-op emits.

Including `ino`/`ctime` in the fingerprint (not just `mtime`+`size`) is deliberate: an inode-replacing or same-size rewrite with a preserved/coarse mtime is exactly the watcher-evading write this is meant to catch.

Two small hardening changes fell out of review of the new emit path:

- `notifyNotebookChange` now isolates per-listener exceptions (logged, not rethrown), so one misbehaving subscriber can't break the `tool_execution_end` hook or starve other listeners.
- `setNotebookPath` resets the emit baselines, so switching to a new notebook that happens to share the old one's content/fingerprint still re-syncs the panel instead of being suppressed.

## Scope

This is the contained UI re-sync fix only -- the watcher itself is unchanged (parent-dir watching / a watcher rewrite is a separate, larger change). Two deliberately out-of-scope notes:

- **Duplicate emit in the race window:** if `reemit` fires before the watcher's 500ms `awaitWriteFinish` settles, the watcher later emits the same content again. The only `onNotebookChange` listener (the UI bridge) dedups on content, so there's no visible double-render.
- **Auto-commit:** a write the watcher truly misses refreshes the panel but isn't auto-committed (the watcher owns commits). That's a durability concern for the watcher work, not this UI fix, and it's not a regression -- previously such a write neither refreshed nor committed.

## Tests

New `tests/notebook-reemit.test.ts` (7 cases): changed -> emit once, unchanged -> no emit, no re-emit on a second call, no-op without an active notebook, an inode-replacing write with pinned size+mtime still emits (fails on a mtime+size-only guard), a throwing listener neither breaks the caller nor starves other listeners, and a path switch to a same-content notebook still re-emits. The cases run with the real watcher stopped so they're deterministic. Full root suite green (1257 passing); root and Orbit typechecks clean.
