### PR TITLE
Make Enter accept the highlighted slash command (fixes picker Enter)

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -16,6 +16,7 @@ import { formatGalaxyTooltip } from "./galaxy-tooltip.js";
 import { PromptQueue, queuedPreview } from "./prompt-queue.js";
 import { FeedbackDraftStore } from "./feedback-draft.js";
 import { caretVisualLineFlags, shouldRecallOnArrow } from "./input-history-nav.js";
+import { shouldAcceptSlashCommandOnEnter } from "./slash-popup-nav.js";
 import { LoomWidgetKey, decodeMarkdownWidget } from "../../../shared/loom-shell-contract.js";
 import { ALLOWED_SKILLS_PREFIX, isAllowedSkillUrl } from "../../../shared/loom-config.js";
 import {
@@ -2217,9 +2218,15 @@ function acceptSlashPopup(index: number): void {
 }
 
 inputEl.addEventListener("keydown", (e) => {
+  // An Enter that commits an IME composition isn't a submit -- let the browser
+  // handle it and bail before any accept/submit logic (covers both Enter paths).
+  if (e.key === "Enter" && e.isComposing) return;
+
   // Slash popup is a hint, not a modal: Tab completes, ↑/↓ navigate
-  // within it, Esc dismisses. Enter still submits whatever the user
-  // typed — the popup auto-closes as a side effect of submit.
+  // within it, Esc dismisses. Enter accepts the highlighted command and
+  // runs it -- Tab+Enter in one keystroke (#287). A fully-typed command is
+  // itself the highlighted row, so it still runs; Shift+Enter inserts a
+  // newline and falls through to the regular submit path.
   if (isSlashPopupOpen()) {
     if (e.key === "ArrowUp") {
       e.preventDefault();
@@ -2241,7 +2248,22 @@ inputEl.addEventListener("keydown", (e) => {
       closeSlashPopup();
       return;
     }
-    // Enter falls through to the regular submit path below.
+    if (
+      e.key === "Enter" &&
+      !e.shiftKey &&
+      shouldAcceptSlashCommandOnEnter(slashPopupActive, slashPopupItems.length)
+    ) {
+      // Complete the highlighted command, then submit it. acceptSlashPopup
+      // dispatches an input event that can re-open the popup for a no-arg
+      // command, so close it again before submit -- matching the raw path.
+      e.preventDefault();
+      acceptSlashPopup(slashPopupActive);
+      closeSlashPopup();
+      submit();
+      return;
+    }
+    // Shift+Enter (newline) or a popup with no valid highlighted row fall
+    // through to the regular submit path below.
   }
 
   if (e.key === "ArrowUp" && shouldRecallOnArrow("up", caretVisualLineFlags(inputEl))) {

--- a/app/src/renderer/slash-popup-nav.ts
+++ b/app/src/renderer/slash-popup-nav.ts
@@ -1,0 +1,12 @@
+// Decision helper for the slash-command autocomplete popup's keyboard flow.
+
+/** Pure decision: when the slash popup is open and Enter is pressed, should we
+ *  accept the highlighted command (complete + run, like Tab+Enter) instead of
+ *  submitting the raw typed text? Yes whenever a real row is highlighted
+ *  (issue #287) -- the normal case, since opening the popup always highlights
+ *  row 0 (and a fully-typed command is itself that highlighted row, so it still
+ *  runs). Returns false only defensively (no items, or active index out of
+ *  range); Enter then falls back to the normal submit path. */
+export function shouldAcceptSlashCommandOnEnter(activeIndex: number, itemCount: number): boolean {
+  return activeIndex >= 0 && activeIndex < itemCount;
+}

--- a/tests/slash-popup-nav.test.ts
+++ b/tests/slash-popup-nav.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { shouldAcceptSlashCommandOnEnter } from "../app/src/renderer/slash-popup-nav.js";
+
+// When the slash-command popup is open, Enter should accept the highlighted
+// command and run it (Tab+Enter in one keystroke, issue #287). Opening the
+// popup always highlights row 0, so the accept path is the normal case; the
+// false cases below are the defensive guard (no items / out-of-range index)
+// that lets Enter fall back to the normal submit path.
+describe("shouldAcceptSlashCommandOnEnter", () => {
+  test("accepts when the first row is highlighted", () => {
+    expect(shouldAcceptSlashCommandOnEnter(0, 3)).toBe(true);
+  });
+
+  test("accepts when a later in-range row is highlighted", () => {
+    expect(shouldAcceptSlashCommandOnEnter(2, 3)).toBe(true);
+  });
+
+  test("does not accept when nothing is highlighted (active -1)", () => {
+    expect(shouldAcceptSlashCommandOnEnter(-1, 3)).toBe(false);
+  });
+
+  test("does not accept when there are no items", () => {
+    expect(shouldAcceptSlashCommandOnEnter(0, 0)).toBe(false);
+  });
+
+  test("does not accept when the active index is past the last item", () => {
+    expect(shouldAcceptSlashCommandOnEnter(3, 3)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #287.

Opening the slash-command picker and pressing Enter submitted the raw typed text (e.g. the literal `/`) instead of running the highlighted command -- you had to Tab to complete first, then Enter. This makes Enter behave like Tab+Enter: it completes the highlighted command and runs it, matching standard autocomplete (VS Code palette, shell completion).

### What changed
- In the chat input's keydown handler, the open-popup branch now handles Enter: on a highlighted row it calls `acceptSlashPopup(...)`, closes the popup, then submits, instead of falling through to the raw-submit path. `acceptSlashPopup` dispatches an `input` event that can transiently re-open the popup for a no-arg command, so we close it again before `submit()` -- mirroring the existing raw path.
- Pulled the accept-on-Enter decision into a small pure helper (`shouldAcceptSlashCommandOnEnter`) with unit tests, following the existing `input-history-nav` pattern.
- Updated the now-stale comments that documented the old "Tab completes / Enter submits raw" design.

### Behavior / scope
- **Fully-typed command + Enter still runs.** When the popup is open it always highlights row 0 (`maybeOpenSlashPopup` sets it), and a fully-typed command is itself that highlighted row, so accept+submit re-runs the same command (`submit()` trims the trailing space `acceptSlashPopup` may add for arg-bearing commands).
- **Arg-bearing commands.** Per the issue ("select + run"), Enter on a highlighted command runs it; one that needs an argument surfaces its usage, same as submitting a bare command does today. Use Tab to complete-without-running and then type args.
- **Shift+Enter** still inserts a newline (both Enter paths require `!e.shiftKey`), so multi-line input and the #314 ArrowUp recall behavior are untouched.
- **IME composition.** An Enter that commits an IME composition now bails early (a single guard at the top of the handler), so it's never treated as a submit on either Enter path.

### Testing
- `npm test`: green (1255 passed); new `tests/slash-popup-nav.test.ts` pins the helper contract.
- `cd app && npx tsc --noEmit`: no new errors (renderer files clean; the pre-existing main/preload electron-type errors are unchanged by this diff).
- Not yet live-eyeballed in Orbit. Manual check to run: type `/`, arrow to a command, press Enter -> the highlighted command should run (previously submitted the raw `/`); confirm Shift+Enter still inserts a newline and a fully-typed command + Enter still runs.

Note: the pure-helper test covers the accept/skip decision but not the DOM keydown flow itself (the renderer handler isn't reachable from the node test harness) -- the close-ordering, Shift+Enter, and IME behavior are covered by the manual check above.

Reviewed adversarially over two passes; the only flagged correctness issue (Enter during IME composition still hitting the raw submit path) is fixed here.