### PR TITLE
Allowlist the Galaxy host in the bash sandbox when GALAXY_URL is scheme-less

### DIFF
--- a/extensions/loom/sandbox/sandbox-config.ts
+++ b/extensions/loom/sandbox/sandbox-config.ts
@@ -47,9 +47,8 @@ export function hostFromUrl(url?: string): string | undefined {
     // scheme-less GALAXY_URL ("usegalaxy.org") still resolves to a host.
     const parsed = new URL(normalizeGalaxyUrl(url));
     // Galaxy speaks http(s) only (validateGalaxyUrl enforces this on connect),
-    // so keep the host only for those schemes -- an ftp://x.org or
-    // file://host/... GALAXY_URL must not seed the bash network allowlist. The
-    // allowlisted host is therefore the Galaxy connection's, never broader.
+    // so keep the host only for those schemes -- an ftp:// or file:// GALAXY_URL
+    // must not seed the bash network allowlist.
     if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return undefined;
     return parsed.hostname || undefined;
   } catch {

--- a/extensions/loom/sandbox/sandbox-config.ts
+++ b/extensions/loom/sandbox/sandbox-config.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
+import { normalizeGalaxyUrl } from "../profiles";
 
 /**
  * Inputs for deriving the OS-sandbox profile. Pure: no I/O, fully testable.
@@ -42,7 +43,15 @@ const DENY_WRITE = [".env", ".env.*", "*.pem", "*.key"];
 export function hostFromUrl(url?: string): string | undefined {
   if (!url) return undefined;
   try {
-    return new URL(url).hostname || undefined;
+    // Normalize via the same helper /connect and the profile system use, so a
+    // scheme-less GALAXY_URL ("usegalaxy.org") still resolves to a host.
+    const parsed = new URL(normalizeGalaxyUrl(url));
+    // Galaxy speaks http(s) only (validateGalaxyUrl enforces this on connect),
+    // so keep the host only for those schemes -- an ftp://x.org or
+    // file://host/... GALAXY_URL must not seed the bash network allowlist. The
+    // allowlisted host is therefore the Galaxy connection's, never broader.
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return undefined;
+    return parsed.hostname || undefined;
   } catch {
     return undefined;
   }

--- a/tests/sandbox-config.test.ts
+++ b/tests/sandbox-config.test.ts
@@ -9,6 +9,27 @@ describe("hostFromUrl", () => {
     expect(hostFromUrl(undefined)).toBeUndefined();
     expect(hostFromUrl("not a url")).toBeUndefined();
   });
+
+  it("extracts the host from a scheme-less URL (the form config/env often supply)", () => {
+    expect(hostFromUrl("usegalaxy.org")).toBe("usegalaxy.org");
+    expect(hostFromUrl("test.galaxyproject.org/")).toBe("test.galaxyproject.org");
+    expect(hostFromUrl("my.galaxy.example:8080/x")).toBe("my.galaxy.example");
+  });
+
+  it("keeps a loopback http host (the one non-https scheme Galaxy permits)", () => {
+    expect(hostFromUrl("http://127.0.0.1:8080")).toBe("127.0.0.1");
+  });
+
+  it("ignores non-http(s) schemes so they can't seed the network allowlist", () => {
+    // Galaxy speaks http(s); ftp:// / file:// (even with a host) must not allowlist one.
+    expect(hostFromUrl("ftp://x.org")).toBeUndefined();
+    expect(hostFromUrl("file://evil.example/etc/passwd")).toBeUndefined();
+  });
+
+  it("yields no host for empty or unparseable input", () => {
+    expect(hostFromUrl("")).toBeUndefined();
+    expect(hostFromUrl("   ")).toBeUndefined();
+  });
 });
 
 describe("buildSandboxConfig", () => {
@@ -38,6 +59,11 @@ describe("buildSandboxConfig", () => {
   it("network: deny-all bash by default, allowlisting the Galaxy host when known", () => {
     expect(buildSandboxConfig(base).network!.allowedDomains).toEqual([]);
     const c = buildSandboxConfig({ ...base, galaxyUrl: "https://usegalaxy.org" });
+    expect(c.network!.allowedDomains).toContain("usegalaxy.org");
+  });
+
+  it("allowlists the Galaxy host even when the configured URL is scheme-less", () => {
+    const c = buildSandboxConfig({ ...base, galaxyUrl: "usegalaxy.org" });
     expect(c.network!.allowedDomains).toContain("usegalaxy.org");
   });
 

--- a/tests/sandbox-config.test.ts
+++ b/tests/sandbox-config.test.ts
@@ -8,6 +8,7 @@ describe("hostFromUrl", () => {
     expect(hostFromUrl("https://my.galaxy.example:8080/x")).toBe("my.galaxy.example");
     expect(hostFromUrl(undefined)).toBeUndefined();
     expect(hostFromUrl("not a url")).toBeUndefined();
+    expect(hostFromUrl("   ")).toBeUndefined();
   });
 
   it("extracts the host from a scheme-less URL (the form config/env often supply)", () => {
@@ -24,11 +25,6 @@ describe("hostFromUrl", () => {
     // Galaxy speaks http(s); ftp:// / file:// (even with a host) must not allowlist one.
     expect(hostFromUrl("ftp://x.org")).toBeUndefined();
     expect(hostFromUrl("file://evil.example/etc/passwd")).toBeUndefined();
-  });
-
-  it("yields no host for empty or unparseable input", () => {
-    expect(hostFromUrl("")).toBeUndefined();
-    expect(hostFromUrl("   ")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Closes #297.

`buildSandboxConfig` derives the bash sandbox's network allowlist from the Galaxy host, but `hostFromUrl` fed `process.env.GALAXY_URL` straight into `new URL()`. A scheme-less configured URL like `usegalaxy.org` throws there, the error is swallowed, and the Galaxy host never lands in the allowlist -- the same scheme-less-URL class that bit the REST path in #264/#290.

The fix runs the URL through `normalizeGalaxyUrl` first -- the existing helper `/connect` and the profile system already use -- so a bare host resolves to `https://usegalaxy.org` exactly the way the connection does. The allowlisted host is therefore the one Galaxy actually talks to, never broader.

While in here, an adversarial review of the diff pointed out that a non-http(s) `GALAXY_URL` (`ftp://x.org`, `file://host/...`) would still hand a host to the allowlist. Galaxy speaks http(s) only (`validateGalaxyUrl` enforces this on connect), so the host is now kept only for `http:`/`https:`. That tightens the allowlist relative to the old behavior rather than broadening it.

Low impact in practice -- Galaxy work flows over MCP, not bash, so the tight default was mostly fine -- but it closes the gap consistently.

Test-first: extended `tests/sandbox-config.test.ts` with the scheme-less case (the host gets allowlisted) alongside the existing scheme-ful case, plus loopback-http, non-http(s)-scheme, and empty-input coverage. Root `npm test` (1255 pass) and the app typecheck are green.