### PR TITLE
Orbit: Add light and dark appearance themes

### DIFF
--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -105,6 +105,15 @@ function reconcileIncomingConfig(incoming: Record<string, unknown>): LoomConfig 
     out.guardian = { ...current.guardian, sandbox: incomingGuardian.sandbox === true };
   }
 
+  const incomingUi = (incoming as { ui?: { theme?: unknown } }).ui;
+  if (incomingUi && typeof incomingUi === "object" && !Array.isArray(incomingUi)) {
+    const theme = incomingUi.theme;
+    out.ui = {
+      ...current.ui,
+      theme: theme === "light" || theme === "dark" ? theme : "dark",
+    };
+  }
+
   // LLM multi-provider reconciliation. The renderer sends:
   //   { active, providers: { [name]: { apiKey?, model? } } }
   // where apiKey may be UNCHANGED_SECRET (preserve), "" (clear), or a new value.
@@ -376,6 +385,7 @@ export function registerIpcHandlers(agent: AgentManager): void {
     "condaBin",
     "experiments",
     "guardian",
+    "ui",
     "updateCheck",
   ]);
 
@@ -400,6 +410,12 @@ export function registerIpcHandlers(agent: AgentManager): void {
     // XSS that reached config:save still can't enable the bypass.
     if (out.guardian && typeof out.guardian === "object" && !Array.isArray(out.guardian)) {
       out.guardian = { sandbox: (out.guardian as Record<string, unknown>).sandbox === true };
+    }
+    if (out.ui && typeof out.ui === "object" && !Array.isArray(out.ui)) {
+      const theme = (out.ui as Record<string, unknown>).theme;
+      out.ui = {
+        theme: theme === "light" || theme === "dark" ? theme : "dark",
+      };
     }
     return out as LoomConfig;
   }

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -15,6 +15,7 @@ import { refreshGalaxyHistory } from "./galaxy-history.js";
 import { formatGalaxyTooltip } from "./galaxy-tooltip.js";
 import { PromptQueue, queuedPreview } from "./prompt-queue.js";
 import { FeedbackDraftStore } from "./feedback-draft.js";
+import { applyOrbitTheme } from "./theme.js";
 import { caretVisualLineFlags, shouldRecallOnArrow } from "./input-history-nav.js";
 import { LoomWidgetKey, decodeMarkdownWidget } from "../../../shared/loom-shell-contract.js";
 import { ALLOWED_SKILLS_PREFIX, isAllowedSkillUrl } from "../../../shared/loom-config.js";
@@ -33,10 +34,18 @@ declare global {
   }
 }
 
+let cleanupThemeListener: (() => void) | null = null;
+
+function setOrbitThemePreference(preference: unknown): void {
+  cleanupThemeListener?.();
+  cleanupThemeListener = applyOrbitTheme(preference);
+}
+
 // Apply remote-mode class as early as possible so CSS rules hit before paint.
 // The web shell's config:get response carries `_mode: "remote" | "desktop"`;
 // Electron's main-process config has no such field, so this is a no-op there.
 void window.orbit.getConfig().then((cfg: Record<string, unknown>) => {
+  setOrbitThemePreference((cfg as { ui?: { theme?: unknown } })?.ui?.theme);
   if ((cfg as { _mode?: string })?._mode === "remote") {
     document.body.classList.add("remote-mode");
   }
@@ -2878,6 +2887,8 @@ const prefsBypass = document.getElementById("prefs-bypass") as HTMLInputElement;
 const bypassBanner = document.getElementById("bypass-banner")!;
 const prefsSandbox = document.getElementById("prefs-sandbox") as HTMLInputElement;
 const sandboxBanner = document.getElementById("sandbox-banner")!;
+const prefsTheme = document.getElementById("prefs-theme") as HTMLSelectElement;
+let prefsSavedThemePreference: "light" | "dark" = "dark";
 
 function refreshBypassBanner(active: boolean): void {
   bypassBanner.classList.toggle("hidden", !active);
@@ -3255,6 +3266,7 @@ async function openPreferences(): Promise<void> {
     condaBin?: string;
     skills?: { repos?: Array<{ name?: string; url?: string; branch?: string; enabled?: boolean }> };
     guardian?: { dangerouslyBypassPermissions?: boolean; sandbox?: boolean };
+    ui?: { theme?: "light" | "dark" };
   };
 
   // Build per-provider in-memory state from masked config.
@@ -3287,6 +3299,8 @@ async function openPreferences(): Promise<void> {
 
   prefsDefaultCwd.value = config.defaultCwd || "";
   prefsCondaBin.value = config.condaBin || "auto";
+  prefsSavedThemePreference = config.ui?.theme === "light" ? "light" : "dark";
+  prefsTheme.value = prefsSavedThemePreference;
   prefsBypass.checked = config.guardian?.dangerouslyBypassPermissions === true;
   prefsSandbox.checked = config.guardian?.sandbox === true;
 
@@ -3305,8 +3319,9 @@ async function openPreferences(): Promise<void> {
   prefsOverlay.classList.remove("hidden");
 }
 
-function closePreferences(): void {
+function closePreferences({ revertTheme = true }: { revertTheme?: boolean } = {}): void {
   prefsOverlay.classList.add("hidden");
+  if (revertTheme) setOrbitThemePreference(prefsSavedThemePreference);
 }
 
 async function savePreferences(): Promise<void> {
@@ -3398,6 +3413,7 @@ async function savePreferences(): Promise<void> {
 
   config.defaultCwd = prefsDefaultCwd.value.trim() || undefined;
   config.condaBin = (prefsCondaBin.value as "auto" | "mamba" | "conda") || undefined;
+  config.ui = { theme: prefsTheme.value };
   // The bash sandbox toggle rides the normal Save path (which restarts the brain, so
   // the sandbox engages at the next session_start). Main narrows this to the sandbox
   // field only and merges it onto the stored guardian block, so it can't disturb the
@@ -3440,7 +3456,8 @@ async function savePreferences(): Promise<void> {
 
   const result = await window.orbit.saveConfig(config as Record<string, unknown>);
   if (result.success) {
-    closePreferences();
+    closePreferences({ revertTheme: false });
+    setOrbitThemePreference(prefsTheme.value);
     void refreshGalaxyStatus();
     refreshSandboxBanner(prefsSandbox.checked);
     if (selectedModel) {
@@ -3470,9 +3487,12 @@ async function savePreferences(): Promise<void> {
   }
 }
 
-prefsClose.addEventListener("click", closePreferences);
-prefsCancel.addEventListener("click", closePreferences);
+prefsClose.addEventListener("click", () => closePreferences());
+prefsCancel.addEventListener("click", () => closePreferences());
 prefsSave.addEventListener("click", savePreferences);
+prefsTheme.addEventListener("change", () => {
+  setOrbitThemePreference(prefsTheme.value);
+});
 prefsOverlay.addEventListener("click", (e) => {
   if (e.target === prefsOverlay) closePreferences();
 });

--- a/app/src/renderer/index.html
+++ b/app/src/renderer/index.html
@@ -444,6 +444,17 @@
           <button id="prefs-close" class="modal-close" title="Close">×</button>
         </div>
         <div class="modal-body">
+          <section class="prefs-section" id="prefs-section-appearance">
+            <h3>Appearance</h3>
+            <div class="prefs-row">
+              <label for="prefs-theme">Theme</label>
+              <select id="prefs-theme">
+                <option value="dark">Dark</option>
+                <option value="light">Light</option>
+              </select>
+            </div>
+          </section>
+
           <section class="prefs-section" id="prefs-section-llm">
             <h3>LLM Providers</h3>
             <div class="prefs-row">

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -83,6 +83,13 @@
   --footer-ctrl-padding-x: 10px;
   --footer-ctrl-radius: var(--radius);
   --footer-ctrl-font-size: 11px;
+  --footer-control-text: var(--text-dim);
+  --footer-control-hover-text: var(--text);
+  --footer-control-hover-bg: var(--bg-subtle-hover);
+  --footer-highlight: var(--accent);
+  --footer-highlight-border: var(--accent);
+  --footer-highlight-bg: var(--accent-bg);
+  --footer-highlight-text: var(--galaxy-dark);
 }
 
 :root[data-theme="light"] {
@@ -142,6 +149,14 @@
   --danger-bg: #c03434;
   --danger-bg-hover: #a82d2d;
   --danger-border: #9f2a2a;
+
+  --footer-control-text: rgba(255, 255, 255, 0.82);
+  --footer-control-hover-text: #ffffff;
+  --footer-control-hover-bg: rgba(219, 234, 254, 0.16);
+  --footer-highlight: #60a5fa;
+  --footer-highlight-border: rgba(147, 197, 253, 0.85);
+  --footer-highlight-bg: rgba(96, 165, 250, 0.24);
+  --footer-highlight-text: #ffffff;
 }
 
 * {
@@ -595,6 +610,12 @@ body:not(.artifact-collapsed) #artifact-toggle {
   background: var(--accent-bg);
 }
 
+:root[data-theme="light"] body:not(.files-collapsed) #files-toggle,
+:root[data-theme="light"] body:not(.artifact-collapsed) #artifact-toggle {
+  color: #ffffff;
+  border-color: #ffffff;
+}
+
 /* ── File viewer (in artifact pane) ───────────────────────────────────────── */
 
 .file-viewer-root {
@@ -892,7 +913,7 @@ body.platform-darwin #files-title {
   border-radius: var(--footer-ctrl-radius);
   border: 1px solid var(--border);
   background: var(--bg-subtle);
-  color: var(--text-dim);
+  color: var(--footer-control-text);
   font-family: var(--font);
   font-size: var(--footer-ctrl-font-size);
   font-weight: 500;
@@ -907,16 +928,16 @@ body.platform-darwin #files-title {
   cursor: pointer;
 }
 .footer-control.is-interactive:hover {
-  background: var(--bg-subtle-hover);
-  color: var(--text);
+  background: var(--footer-control-hover-bg);
+  color: var(--footer-control-hover-text);
   border-color: var(--border-strong);
 }
 
 /* Status badge — agent state. Color-only variants atop the base. */
 .status-badge.running {
-  color: var(--accent);
-  border-color: var(--accent);
-  background: var(--accent-bg);
+  color: var(--footer-highlight-text);
+  border-color: var(--footer-highlight-border);
+  background: var(--footer-highlight-bg);
 }
 .status-badge.error {
   color: #ff817b;
@@ -924,9 +945,9 @@ body.platform-darwin #files-title {
   background: rgba(227, 26, 30, 0.2);
 }
 .status-badge.thinking {
-  color: var(--galaxy-gold-dark);
-  border-color: rgba(255, 215, 0, 0.3);
-  background: rgba(255, 215, 0, 0.15);
+  color: var(--footer-highlight-text);
+  border-color: var(--footer-highlight-border);
+  background: var(--footer-highlight-bg);
   animation: blink 1.5s step-end infinite;
 }
 
@@ -947,14 +968,14 @@ body.platform-darwin #files-title {
   transition: background 0.4s;
 }
 .agent-heartbeat.pulse {
-  background: var(--accent);
+  background: var(--footer-highlight);
   animation: heartbeat-pulse 0.8s ease-out;
 }
 @keyframes heartbeat-pulse {
   0% {
-    background: var(--accent);
+    background: var(--footer-highlight);
     transform: scale(1.6);
-    box-shadow: 0 0 4px var(--accent);
+    box-shadow: 0 0 4px var(--footer-highlight);
   }
   100% {
     background: var(--text-dim);
@@ -967,14 +988,14 @@ body.platform-darwin #files-title {
   font-family: var(--font);
 }
 #model-indicator:hover {
-  color: var(--masthead-hover);
-  border-color: var(--masthead-hover);
+  color: var(--footer-highlight);
+  border-color: var(--footer-highlight-border);
 }
 
 /* Galaxy status pill: same dimensions as other footer-controls; the dot is
    a ::before pseudo-element. Color states defined above near .status-dot. */
 .status-dot-connected {
-  color: var(--text);
+  color: var(--footer-control-hover-text);
 }
 
 /* Push the agent-status pill to the left edge; everything after it
@@ -988,7 +1009,7 @@ body.platform-darwin #files-title {
 #usage-cost {
   padding-left: 6px;
   border-left: 1px solid var(--border-strong);
-  color: var(--accent);
+  color: var(--footer-highlight);
   white-space: nowrap;
 }
 #usage-cost.hidden {
@@ -1015,7 +1036,7 @@ body.platform-darwin #files-title {
   height: 100%;
   width: 0%;
   border-radius: 3px;
-  background: var(--accent);
+  background: var(--footer-highlight);
   transition: width 0.2s;
 }
 #context-fill-pct {
@@ -1035,7 +1056,7 @@ body.platform-darwin #files-title {
 }
 
 /* Segmented Local|Cloud control — single rounded-rect container with two
-   inner buttons, the active one filled with var(--accent). */
+   inner buttons, the active one filled with the footer highlight. */
 .footer-control-segmented {
   padding: 0;
   gap: 0;
@@ -1045,7 +1066,7 @@ body.platform-darwin #files-title {
   appearance: none;
   background: transparent;
   border: 0;
-  color: var(--text-dim);
+  color: var(--footer-control-text);
   font: inherit;
   height: 100%;
   padding: 0 10px;
@@ -1055,12 +1076,12 @@ body.platform-darwin #files-title {
     color 0.15s;
 }
 .footer-control-segmented .exec-mode-btn:hover:not(.active) {
-  color: var(--text);
-  background: var(--bg-inset);
+  color: var(--footer-control-hover-text);
+  background: var(--footer-control-hover-bg);
 }
 .footer-control-segmented .exec-mode-btn.active {
-  background: var(--accent);
-  color: var(--galaxy-dark);
+  background: var(--footer-highlight);
+  color: var(--footer-highlight-text);
   font-weight: 600;
 }
 
@@ -1081,7 +1102,7 @@ body.platform-darwin #files-title {
   appearance: none;
   background: transparent;
   border: 0;
-  color: var(--text-dim);
+  color: var(--footer-control-text);
   padding: 0;
   margin-left: 2px;
   cursor: pointer;
@@ -1091,7 +1112,7 @@ body.platform-darwin #files-title {
   transition: color 0.15s;
 }
 .cwd-change-btn:hover {
-  color: var(--masthead-hover);
+  color: var(--footer-highlight);
 }
 
 /* ── Messages ──────────────────────────────────────────────────────────────── */
@@ -2073,7 +2094,7 @@ body.platform-darwin #files-title {
 #abort-btn {
   background: var(--accent);
   color: var(--galaxy-dark);
-  border: none;
+  border: 1px solid transparent;
   border-radius: var(--radius);
   width: 36px;
   height: 36px;
@@ -2085,9 +2106,22 @@ body.platform-darwin #files-title {
   flex-shrink: 0;
 }
 
+#send-btn {
+  align-self: stretch;
+  width: auto;
+  height: auto;
+  aspect-ratio: 1;
+}
+
 #send-btn:hover,
 #abort-btn:hover {
   opacity: 0.85;
+}
+
+:root[data-theme="light"] #send-btn {
+  background: #ffffff;
+  color: var(--galaxy-primary);
+  border-color: var(--accent);
 }
 
 /* Stop carries a visible label (not just an icon) so it's unmistakable while a

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -5,6 +5,8 @@
 @import url("./assets/fonts/fonts.css");
 
 :root {
+  color-scheme: dark;
+
   /* Galaxy brand palette */
   --galaxy-primary: #25537b;
   --galaxy-dark: #2c3143;
@@ -24,15 +26,32 @@
   --bg-hover: #3c435c;
   --bg-chat: #2c3143;
   --bg-artifact: #2c3143;
+  --bg-inset: rgba(255, 255, 255, 0.06);
+  --bg-base: rgba(0, 0, 0, 0.03);
+  --bg-subtle: rgba(255, 255, 255, 0.04);
+  --bg-subtle-hover: rgba(255, 255, 255, 0.1);
+  --bg-selected: rgba(255, 255, 255, 0.15);
 
   --text: #f0f2f8;
   --text-dim: rgba(248, 250, 252, 0.45);
   --text-bright: #f8fafc;
+  --text-muted-on-masthead: rgba(255, 255, 255, 0.7);
+  --text-subtle-on-masthead: rgba(255, 255, 255, 0.6);
 
+  --accent-surface: var(--galaxy-primary);
+  --accent-surface-border: rgba(255, 255, 255, 0.08);
+  --accent-surface-text: var(--text-bright);
   --accent: #ffd700;
   --accent-light: #ffd700;
   --accent-bg: rgba(255, 215, 0, 0.15);
   --accent-hover: #d19e00;
+
+  --user-message-bg: var(--accent-surface);
+  --user-message-border: var(--accent-surface-border);
+  --user-message-text: var(--accent-surface-text);
+  --activity-bg: var(--masthead);
+  --activity-border: var(--border-strong);
+  --activity-shell-text: var(--masthead-text);
 
   --success: #4ade80;
   --success-bg: rgba(74, 222, 128, 0.15);
@@ -42,7 +61,14 @@
 
   --border: rgba(255, 255, 255, 0.08);
   --border-strong: rgba(255, 255, 255, 0.15);
+  --border-subtle: rgba(255, 255, 255, 0.04);
   --bg-stripe: rgba(255, 255, 255, 0.02);
+  --shadow: rgba(0, 0, 0, 0.4);
+  --shadow-soft: rgba(0, 0, 0, 0.3);
+  --modal-scrim: rgba(20, 25, 40, 0.6);
+  --danger-bg: #7a2027;
+  --danger-bg-hover: #8d2731;
+  --danger-border: #a13038;
   --radius: 6px;
   --font: "JetBrains Mono", Monaco, Menlo, Consolas, "Courier New", monospace;
   --font-sans:
@@ -56,6 +82,64 @@
   --footer-ctrl-padding-x: 10px;
   --footer-ctrl-radius: var(--radius);
   --footer-ctrl-font-size: 11px;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+
+  --masthead: #25537b;
+  --masthead-text: #f8fafc;
+  --masthead-hover: #ffd700;
+
+  --bg: #f6f8fb;
+  --bg-surface: #ffffff;
+  --bg-deep: #e8edf5;
+  --bg-hover: #e1e8f2;
+  --bg-chat: #f6f8fb;
+  --bg-artifact: #ffffff;
+  --bg-inset: rgba(31, 41, 55, 0.06);
+  --bg-base: rgba(31, 41, 55, 0.035);
+  --bg-subtle: rgba(31, 41, 55, 0.055);
+  --bg-subtle-hover: rgba(31, 41, 55, 0.1);
+  --bg-selected: rgba(31, 41, 55, 0.14);
+
+  --text: #1f2937;
+  --text-dim: rgba(31, 41, 55, 0.62);
+  --text-bright: #111827;
+  --text-muted-on-masthead: rgba(248, 250, 252, 0.78);
+  --text-subtle-on-masthead: rgba(248, 250, 252, 0.68);
+
+  --accent-surface: #dbeafe;
+  --accent-surface-border: #bfdbfe;
+  --accent-surface-text: #1e3a5f;
+  --accent: #b77900;
+  --accent-light: #d19e00;
+  --accent-bg: rgba(209, 158, 0, 0.14);
+  --accent-hover: #8a5a00;
+
+  --user-message-bg: var(--accent-surface);
+  --user-message-border: var(--accent-surface-border);
+  --user-message-text: var(--accent-surface-text);
+  --activity-bg: var(--accent-surface);
+  --activity-border: var(--accent-surface-border);
+  --activity-shell-text: var(--accent-surface-text);
+
+  --success: #17803d;
+  --success-bg: rgba(23, 128, 61, 0.12);
+  --warning: #b77900;
+  --error: #c03434;
+  --error-bg: rgba(192, 52, 52, 0.1);
+
+  --border: rgba(31, 41, 55, 0.12);
+  --border-strong: rgba(31, 41, 55, 0.22);
+  --border-subtle: rgba(31, 41, 55, 0.08);
+  --bg-stripe: rgba(31, 41, 55, 0.035);
+  --shadow: rgba(31, 41, 55, 0.18);
+  --shadow-soft: rgba(31, 41, 55, 0.16);
+  --modal-scrim: rgba(15, 23, 42, 0.28);
+  --danger-bg: #c03434;
+  --danger-bg-hover: #a82d2d;
+  --danger-border: #9f2a2a;
 }
 
 * {
@@ -340,7 +424,7 @@ body.files-collapsed #files-divider {
 }
 .files-header-btn:hover {
   opacity: 1;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--bg-subtle-hover);
 }
 .files-header-btn.active {
   opacity: 1;
@@ -423,7 +507,7 @@ body.files-collapsed #files-divider {
   background: var(--bg-surface);
   border: 1px solid var(--border-strong);
   border-radius: 4px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 16px var(--shadow);
   padding: 4px 0;
   font-family: var(--font-sans);
   font-size: 12px;
@@ -467,7 +551,7 @@ body.files-collapsed #files-divider {
   border: 1px solid var(--border-strong);
   border-radius: var(--radius);
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 2px 8px var(--shadow);
   transition:
     background 0.1s,
     color 0.1s;
@@ -499,7 +583,7 @@ body.files-collapsed #files-divider {
 }
 .pane-title-btn:hover {
   opacity: 1;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--bg-subtle-hover);
 }
 body:not(.files-collapsed) #files-toggle,
 body:not(.artifact-collapsed) #artifact-toggle {
@@ -805,7 +889,7 @@ body.platform-darwin #files-title {
   padding: 0 var(--footer-ctrl-padding-x);
   border-radius: var(--footer-ctrl-radius);
   border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--bg-subtle);
   color: var(--text-dim);
   font-family: var(--font);
   font-size: var(--footer-ctrl-font-size);
@@ -821,7 +905,7 @@ body.platform-darwin #files-title {
   cursor: pointer;
 }
 .footer-control.is-interactive:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--bg-subtle-hover);
   color: var(--text);
   border-color: var(--border-strong);
 }
@@ -901,7 +985,7 @@ body.platform-darwin #files-title {
 }
 #usage-cost {
   padding-left: 6px;
-  border-left: 1px solid rgba(255, 255, 255, 0.15);
+  border-left: 1px solid var(--border-strong);
   color: var(--accent);
   white-space: nowrap;
 }
@@ -921,7 +1005,7 @@ body.platform-darwin #files-title {
   width: 42px;
   height: 6px;
   border-radius: 3px;
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--bg-selected);
   overflow: hidden;
 }
 #context-fill-bar {
@@ -970,7 +1054,7 @@ body.platform-darwin #files-title {
 }
 .footer-control-segmented .exec-mode-btn:hover:not(.active) {
   color: var(--text);
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--bg-inset);
 }
 .footer-control-segmented .exec-mode-btn.active {
   background: var(--accent);
@@ -1040,11 +1124,11 @@ body.platform-darwin #files-title {
 }
 
 .message.user {
-  background: var(--galaxy-primary);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--user-message-bg);
+  border: 1px solid var(--user-message-border);
   align-self: flex-end;
   max-width: 85%;
-  color: var(--text-bright);
+  color: var(--user-message-text);
   white-space: pre-wrap;
   word-break: break-word;
 }
@@ -1570,7 +1654,7 @@ body.platform-darwin #files-title {
   background: var(--bg-surface);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 16px var(--shadow);
   font-size: 12px;
   z-index: 50;
 }
@@ -1586,7 +1670,7 @@ body.platform-darwin #files-title {
   padding: 6px 12px;
   cursor: pointer;
   color: var(--text);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .slash-popup-item:last-child {
@@ -1666,6 +1750,7 @@ body.platform-darwin #files-title {
   flex-direction: column;
   height: 100%;
   padding: 0;
+  background: var(--activity-bg);
   overflow: hidden;
 }
 
@@ -1674,9 +1759,9 @@ body.platform-darwin #files-title {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  border-bottom: 2px solid var(--border-strong);
-  background: var(--masthead);
-  color: #d4d4d4;
+  border-bottom: 2px solid var(--activity-border);
+  background: var(--activity-bg);
+  color: var(--activity-shell-text);
   overflow: hidden;
 }
 
@@ -1685,7 +1770,7 @@ body.platform-darwin #files-title {
   display: flex;
   flex-direction: column;
   min-height: 0;
-  background: var(--masthead);
+  background: var(--activity-bg);
   color: var(--text);
   overflow: hidden;
 }
@@ -1694,7 +1779,7 @@ body.platform-darwin #files-title {
   flex: 0 0 auto;
   display: flex;
   flex-direction: column;
-  background: var(--masthead);
+  background: var(--activity-bg);
   color: var(--text);
   overflow: hidden;
   max-height: 40%;
@@ -1712,7 +1797,7 @@ body.platform-darwin #files-title {
   flex: 0 0 auto;
   display: flex;
   flex-direction: column;
-  background: var(--masthead);
+  background: var(--activity-bg);
   color: var(--text);
   overflow: hidden;
 }
@@ -1778,7 +1863,7 @@ body.platform-darwin #files-title {
 .galaxy-invocation-bar {
   margin-top: 4px;
   height: 4px;
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--bg-subtle-hover);
   border-radius: 2px;
   overflow: hidden;
 }
@@ -1818,8 +1903,8 @@ body.platform-darwin #files-title {
   align-items: center;
   gap: 8px;
   padding: 4px 12px;
-  background: rgba(0, 0, 0, 0.2);
-  color: rgba(255, 255, 255, 0.7);
+  background: var(--bg-subtle);
+  color: var(--text-muted-on-masthead);
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
@@ -1830,8 +1915,8 @@ body.platform-darwin #files-title {
 }
 .activity-section-header button {
   background: none;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  color: rgba(255, 255, 255, 0.6);
+  border: 1px solid var(--border-strong);
+  color: var(--text-subtle-on-masthead);
   font-family: var(--font-sans);
   font-size: 10px;
   padding: 1px 6px;
@@ -1839,7 +1924,7 @@ body.platform-darwin #files-title {
   cursor: pointer;
 }
 .activity-section-header button:hover {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--bg-subtle-hover);
   color: var(--masthead-hover);
   border-color: var(--masthead-hover);
 }
@@ -1882,10 +1967,10 @@ body.platform-darwin #files-title {
 }
 #proc-monitor-table td {
   padding: 3px 8px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid var(--border-subtle);
 }
 #proc-monitor-table tr:hover td {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--bg-subtle);
 }
 #proc-monitor-table .col-cmd {
   color: var(--text);
@@ -1925,7 +2010,7 @@ body.platform-darwin #files-title {
 }
 
 #agent-shell-body::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.2);
+  background: var(--bg-selected);
   border-radius: 3px;
 }
 
@@ -1942,17 +2027,17 @@ body.platform-darwin #files-title {
   padding-left: 16px;
 }
 .shell-line.shell-tool-error {
-  color: #ff817b;
+  color: var(--error);
   padding-left: 16px;
 }
 .shell-line.shell-status {
   color: var(--galaxy-gold-dark);
 }
 .shell-line.shell-info {
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-dim);
 }
 .shell-line.shell-stdout {
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-muted-on-masthead);
   padding-left: 16px;
   font-size: 10px;
 }
@@ -2081,7 +2166,7 @@ body.platform-darwin #files-title {
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(20, 25, 40, 0.6);
+  background: var(--modal-scrim);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2093,7 +2178,7 @@ body.platform-darwin #files-title {
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 8px;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 10px 40px var(--shadow-soft);
   width: 560px;
   max-width: 90vw;
   max-height: 85vh;
@@ -2442,13 +2527,13 @@ body.platform-darwin #files-title {
 }
 
 .modal-actions .plan-btn.danger {
-  background: #7a2027;
-  color: var(--text-bright, #fff);
-  border-color: #a13038;
+  background: var(--danger-bg);
+  color: #fff;
+  border-color: var(--danger-border);
 }
 
 .modal-actions .plan-btn.danger:hover {
-  background: #8d2731;
+  background: var(--danger-bg-hover);
 }
 
 /* Base button used across modals, prefs, plan-draft cards, file viewer.
@@ -2595,7 +2680,7 @@ body.platform-darwin #files-title {
   font-size: 16px;
   line-height: 1;
   font-weight: 400;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-subtle-on-masthead);
   cursor: pointer;
   transition:
     background 0.15s,
@@ -2603,8 +2688,8 @@ body.platform-darwin #files-title {
 }
 
 .pane-tab-close:hover {
-  background: rgba(255, 255, 255, 0.15);
-  color: #fff;
+  background: var(--bg-selected);
+  color: var(--masthead-text);
 }
 
 /* Activity timeline entries. */
@@ -2651,7 +2736,7 @@ body.platform-darwin #files-title {
 .activity-event-body {
   margin: 6px 0 0;
   padding: 6px 8px;
-  background: var(--bg-base, rgba(0, 0, 0, 0.03));
+  background: var(--bg-base);
   border-radius: 4px;
   white-space: pre-wrap;
   word-break: break-word;
@@ -2688,7 +2773,7 @@ body.platform-darwin #files-title {
 }
 
 .empty-state code {
-  background: var(--bg-inset, rgba(255, 255, 255, 0.06));
+  background: var(--bg-inset);
   padding: 1px 5px;
   border-radius: 3px;
   font-family: "JetBrains Mono", monospace;
@@ -2759,8 +2844,8 @@ body.platform-darwin #files-title {
   width: 100%;
   padding: 8px 10px;
   font: inherit;
-  background: var(--bg-inset, rgba(255, 255, 255, 0.06));
-  border: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
   border-radius: 4px;
   color: var(--text, inherit);
   box-sizing: border-box;
@@ -2784,7 +2869,7 @@ body.platform-darwin #files-title {
   border-radius: 4px;
   cursor: pointer;
   border: 1px solid transparent;
-  background: var(--bg-inset, rgba(255, 255, 255, 0.04));
+  background: var(--bg-inset);
 }
 
 .ext-option:hover,

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -52,6 +52,7 @@
   --activity-bg: var(--masthead);
   --activity-border: var(--border-strong);
   --activity-shell-text: var(--masthead-text);
+  --activity-header-button-text: var(--text-subtle-on-masthead);
 
   --success: #4ade80;
   --success-bg: rgba(74, 222, 128, 0.15);
@@ -123,6 +124,7 @@
   --activity-bg: var(--accent-surface);
   --activity-border: var(--accent-surface-border);
   --activity-shell-text: var(--accent-surface-text);
+  --activity-header-button-text: var(--text-dim);
 
   --success: #17803d;
   --success-bg: rgba(23, 128, 61, 0.12);
@@ -1916,7 +1918,7 @@ body.platform-darwin #files-title {
 .activity-section-header button {
   background: none;
   border: 1px solid var(--border-strong);
-  color: var(--text-subtle-on-masthead);
+  color: var(--activity-header-button-text);
   font-family: var(--font-sans);
   font-size: 10px;
   padding: 1px 6px;

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -53,6 +53,9 @@
   --activity-border: var(--border-strong);
   --activity-shell-text: var(--masthead-text);
   --activity-header-button-text: var(--text-subtle-on-masthead);
+  --shell-tool-start-text: #80c3ea;
+  --shell-status-text: var(--galaxy-gold-dark);
+  --shell-stdout-text: var(--text-muted-on-masthead);
 
   --success: #4ade80;
   --success-bg: rgba(74, 222, 128, 0.15);
@@ -132,6 +135,10 @@
   --activity-border: var(--accent-surface-border);
   --activity-shell-text: var(--accent-surface-text);
   --activity-header-button-text: var(--text-dim);
+  /* Shell-line colors readable on the pale --activity-bg (AA on #dbeafe). */
+  --shell-tool-start-text: #155e8c;
+  --shell-status-text: #7a5c00;
+  --shell-stdout-text: #3d5678;
 
   --success: #17803d;
   --success-bg: rgba(23, 128, 61, 0.12);
@@ -2043,7 +2050,7 @@ body.platform-darwin #files-title {
 }
 
 .shell-line.shell-tool-start {
-  color: #80c3ea;
+  color: var(--shell-tool-start-text);
 }
 .shell-line.shell-tool-end {
   color: var(--success);
@@ -2054,13 +2061,13 @@ body.platform-darwin #files-title {
   padding-left: 16px;
 }
 .shell-line.shell-status {
-  color: var(--galaxy-gold-dark);
+  color: var(--shell-status-text);
 }
 .shell-line.shell-info {
   color: var(--text-dim);
 }
 .shell-line.shell-stdout {
-  color: var(--text-muted-on-masthead);
+  color: var(--shell-stdout-text);
   padding-left: 16px;
   font-size: 10px;
 }
@@ -3320,6 +3327,7 @@ body.remote-mode #update-banner,
 body.remote-mode #report-issue-btn,
 body.remote-mode #exec-mode-toggle,
 body.remote-mode #cwd-bar,
+body.remote-mode #prefs-section-appearance,
 body.remote-mode #prefs-section-llm,
 body.remote-mode #prefs-section-skills,
 body.remote-mode #prefs-section-safety {

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -1904,7 +1904,7 @@ body.platform-darwin #files-title {
   gap: 8px;
   padding: 4px 12px;
   background: var(--bg-subtle);
-  color: var(--text-muted-on-masthead);
+  color: var(--text-dim);
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.5px;

--- a/app/src/renderer/theme.ts
+++ b/app/src/renderer/theme.ts
@@ -1,0 +1,26 @@
+export type OrbitThemePreference = "light" | "dark";
+export type AppliedOrbitTheme = "light" | "dark";
+
+export const DEFAULT_ORBIT_THEME: OrbitThemePreference = "dark";
+
+export function normalizeOrbitThemePreference(value: unknown): OrbitThemePreference {
+  return value === "light" || value === "dark" ? value : DEFAULT_ORBIT_THEME;
+}
+
+export function resolveAppliedOrbitTheme(preference: unknown): AppliedOrbitTheme {
+  return normalizeOrbitThemePreference(preference);
+}
+
+export function applyOrbitTheme(
+  preference: unknown,
+  target: HTMLElement = document.documentElement,
+): () => void {
+  const normalized = normalizeOrbitThemePreference(preference);
+  const applied = resolveAppliedOrbitTheme(normalized);
+  target.dataset.themePreference = normalized;
+  target.dataset.theme = applied;
+  target.style.colorScheme = applied;
+  return () => {
+    // Kept as a no-op cleanup so callers can replace themes uniformly.
+  };
+}

--- a/shared/loom-config.d.ts
+++ b/shared/loom-config.d.ts
@@ -82,6 +82,11 @@ export interface LoomConfig {
    */
   ui?: {
     /**
+     * Orbit visual theme. Missing or invalid values resolve to "dark" so
+     * existing installs keep the pre-theme appearance.
+     */
+    theme?: "light" | "dark";
+    /**
      * Show the model's "thinking" blocks in the interactive terminal. Off by
      * default -- loom hides them (writes pi's `hideThinkingBlock`) to keep the
      * chat readable. Set true to restore pi's reasoning stream persistently.

--- a/shared/loom-config.js
+++ b/shared/loom-config.js
@@ -20,6 +20,7 @@ export const DEFAULT_SKILLS = [
  * isAllowedSkillUrl() with a more permissive predicate.
  */
 export const ALLOWED_SKILLS_PREFIX = "https://github.com/galaxyproject/";
+const VALID_UI_THEMES = new Set(["light", "dark"]);
 
 export function isAllowedSkillUrl(url) {
   if (typeof url !== "string") return false;
@@ -119,6 +120,11 @@ export function loadConfig() {
   if (typeof raw.updateCheck !== "boolean") {
     raw.updateCheck = true;
   }
+  const ui = raw.ui && typeof raw.ui === "object" && !Array.isArray(raw.ui) ? raw.ui : {};
+  raw.ui = {
+    ...ui,
+    theme: VALID_UI_THEMES.has(ui.theme) ? ui.theme : "dark",
+  };
   return raw;
 }
 

--- a/tests/loom-config-ui-theme.test.ts
+++ b/tests/loom-config-ui-theme.test.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("loadConfig ui theme defaults", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "loom-config-theme-"));
+    vi.spyOn(os, "homedir").mockReturnValue(tmp);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  async function loadFreshConfig() {
+    vi.resetModules();
+    return import("../shared/loom-config.js");
+  }
+
+  it("defaults missing ui.theme to dark for existing and new configs", async () => {
+    const { loadConfig } = await loadFreshConfig();
+    expect(loadConfig().ui?.theme).toBe("dark");
+  });
+
+  it("preserves other ui preferences while normalizing invalid theme values", async () => {
+    fs.mkdirSync(path.join(tmp, ".loom"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, ".loom", "config.json"),
+      JSON.stringify({ ui: { theme: "sepia", showThinking: true } }),
+    );
+
+    const { loadConfig } = await loadFreshConfig();
+    expect(loadConfig().ui).toMatchObject({ theme: "dark", showThinking: true });
+  });
+
+  it("normalizes the removed system theme preference to dark", async () => {
+    fs.mkdirSync(path.join(tmp, ".loom"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, ".loom", "config.json"),
+      JSON.stringify({ ui: { theme: "system" } }),
+    );
+
+    const { loadConfig } = await loadFreshConfig();
+    expect(loadConfig().ui?.theme).toBe("dark");
+  });
+});

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from "vitest";
+import {
+  applyOrbitTheme,
+  normalizeOrbitThemePreference,
+  resolveAppliedOrbitTheme,
+} from "../app/src/renderer/theme.js";
+
+describe("Orbit theme resolution", () => {
+  it("defaults missing and invalid values to dark", () => {
+    expect(normalizeOrbitThemePreference(undefined)).toBe("dark");
+    expect(normalizeOrbitThemePreference("sepia")).toBe("dark");
+    expect(normalizeOrbitThemePreference("system")).toBe("dark");
+    expect(resolveAppliedOrbitTheme(undefined)).toBe("dark");
+  });
+
+  it("applies explicit light and dark", () => {
+    expect(resolveAppliedOrbitTheme("light")).toBe("light");
+    expect(resolveAppliedOrbitTheme("dark")).toBe("dark");
+  });
+
+  it("applies data attributes and color-scheme to the target", () => {
+    const target = document.createElement("div");
+    const cleanup = applyOrbitTheme("light", target);
+    expect(target.dataset.themePreference).toBe("light");
+    expect(target.dataset.theme).toBe("light");
+    expect(target.style.colorScheme).toBe("light");
+    cleanup();
+  });
+});


### PR DESCRIPTION
Adds Light/Dark appearance modes for Orbit, including a Preferences theme selector with live preview. The update introduces reusable theme tokens, improves light-mode contrast across chat and Activity surfaces, and persists the selected theme in Loom config.