### PR TITLE
fix(orbit): cap footer status pill at 25% width; scroll long text within it

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -2771,7 +2771,10 @@ function setStatusBadge(status: string, msg?: string): void {
   statusBadge.className = ("footer-control status-badge " + (status || "")).trim();
   statusBadgeIsStuck = STUCK_STATUS.has(status);
   statusBadge.style.cursor = statusBadgeIsStuck ? "pointer" : "default";
-  statusBadge.title = statusBadgeIsStuck ? "Click to open Preferences" : "";
+  // The pill is width-capped and scrolls when long (see #agent-status CSS), so
+  // expose the full status on hover — "Click to open Preferences" still wins
+  // when the badge is stuck/clickable.
+  statusBadge.title = statusBadgeIsStuck ? "Click to open Preferences" : lastBadgeBaseText;
   renderBadgeText();
 }
 

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -895,6 +895,19 @@ body.platform-darwin #files-title {
    collects on the right. */
 #agent-status {
   margin-right: auto;
+  /* Cap the status pill at a quarter of the footer so a long status message
+     can't grow the pill and crowd the other footer controls. min-width:0 lets
+     it shrink below its content; the text stays on one line (nowrap, inherited
+     from .footer-control) and scrolls horizontally within the pill when it
+     overflows. The scrollbar is hidden for aesthetics — the full text is still
+     available on hover via the title attribute (set in setStatusBadge). */
+  max-width: 25%;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+#agent-status::-webkit-scrollbar {
+  display: none;
 }
 #usage-tokens {
   white-space: nowrap;


### PR DESCRIPTION
## Problem

The footer status pill (`#agent-status`) grows with its message. Since it's a `.footer-control` (`inline-flex`, `white-space: nowrap`) with no width cap, a long agent status (e.g. a long tool label / "responding…" with detail) expands the pill and **crowds the other footer controls** (Galaxy indicator, model, usage, cwd).

## Fix

Constrain `#agent-status`:
- `max-width: 25%` — never wider than a quarter of the footer, so it can't push the other controls.
- `min-width: 0` — lets it shrink below its content (flex items otherwise won't).
- `overflow-x: auto` + inherited `white-space: nowrap` — long text **scrolls horizontally within the pill** instead of growing it. The scrollbar is hidden (`scrollbar-width: none` + `::-webkit-scrollbar { display: none }`) so it doesn't eat the ~20px pill height; horizontal trackpad/shift-wheel still scrolls.
- The full status is available on **hover** — `setStatusBadge` now sets the pill's `title` to the full status text (still yields to "Click to open Preferences" when the badge is in a stuck/clickable state).

Renderer-only, no behavior change beyond layout. `app` `tsc --noEmit` clean; root typecheck clean; 1250 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)