### PR TITLE
Auto-load notebook on Orbit startup

### DIFF
--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -1197,8 +1197,11 @@ async function refreshCwd(): Promise<void> {
 // callers behave as before. `applyCwdChange` passes false so the source cwd's
 // per-cwd cost record survives the switch — otherwise the per-cwd keying is
 // pointless.
+let notebookLoadSeq = 0;
+
 function resetUiForFreshContext(opts: { clearPersistedCost?: boolean } = {}): void {
   const { clearPersistedCost = true } = opts;
+  notebookLoadSeq++;
   chat.clear();
   artifacts.clear();
   clearQueue();
@@ -1245,6 +1248,7 @@ function applyCwdChange(dir: string): void {
   filesPanel.reset();
   void filesPanel.refresh();
   void refreshGalaxyInvocations(window.orbit);
+  void loadNotebookFromDisk();
 }
 
 cwdChangeBtn.addEventListener("click", async () => {
@@ -1261,12 +1265,16 @@ window.orbit.onCwdChanged((dir) => {
 // Replay prior turns only if the chat is currently blank — otherwise the user
 // is mid-flow (e.g. prefs-save restart) and replay would clobber live UI.
 async function loadNotebookFromDisk(): Promise<void> {
+  const seq = ++notebookLoadSeq;
   const r = await window.orbit.loadNotebook();
+  if (seq !== notebookLoadSeq) return;
   if (r.ok && r.content) {
     artifacts.setNotebookMarkdown(`> \`${r.path}\`\n\n${r.content}`);
     setArtifactCollapsed(false);
   }
 }
+
+void loadNotebookFromDisk();
 
 // On wake-from-sleep, auto-restore blank chat, notebook, and streaming UI state.
 window.orbit.onDisplayResume(() => {
@@ -2703,6 +2711,7 @@ window.orbit.onUiRequest((request) => {
     // the brain-side activity.jsonl is still written for debug but no
     // longer pushed as a widget.
     if (key === LoomWidgetKey.Notebook && lines) {
+      notebookLoadSeq++;
       artifacts.setNotebookMarkdown(decodeMarkdownWidget(lines));
       setArtifactCollapsed(false);
     }

--- a/app/test/e2e/smoke.spec.ts
+++ b/app/test/e2e/smoke.spec.ts
@@ -48,9 +48,7 @@ function packagedExecutablePath(): string {
   throw new Error(`Unsupported platform: ${process.platform}`);
 }
 
-test("Orbit launches and the renderer initializes without errors", async () => {
-  const errors: string[] = [];
-
+async function launchIsolatedOrbit(opts: { notebook?: string } = {}) {
   // Per-test temp tree. HOME redirect covers ~/.loom and ~/.orbit; the
   // Electron --user-data-dir flag covers app.getPath("userData") which on
   // macOS lives outside HOME (~/Library/Application Support).
@@ -63,6 +61,9 @@ test("Orbit launches and the renderer initializes without errors", async () => {
     fs.mkdir(fakeCwd, { recursive: true }),
     fs.mkdir(userDataDir, { recursive: true }),
   ]);
+  if (opts.notebook !== undefined) {
+    await fs.writeFile(path.join(fakeCwd, "notebook.md"), opts.notebook, "utf-8");
+  }
 
   const isolatedEnv = {
     ...process.env,
@@ -95,6 +96,13 @@ test("Orbit launches and the renderer initializes without errors", async () => {
     cwd: fakeCwd,
   });
 
+  return { app, tmpRoot };
+}
+
+test("Orbit launches and the renderer initializes without errors", async () => {
+  const errors: string[] = [];
+  const { app, tmpRoot } = await launchIsolatedOrbit();
+
   try {
     const page = await app.firstWindow();
     page.on("pageerror", (err) => errors.push(`pageerror: ${err.message}`));
@@ -115,6 +123,24 @@ test("Orbit launches and the renderer initializes without errors", async () => {
 
     // No uncaught renderer errors during boot
     expect(errors).toEqual([]);
+  } finally {
+    await app.close();
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("Orbit loads notebook.md into the notebook pane on startup", async () => {
+  const uniqueNotebookLine = `Notebook autoload sentinel ${Date.now()}`;
+  const { app, tmpRoot } = await launchIsolatedOrbit({
+    notebook: `# Existing analysis\n\n${uniqueNotebookLine}\n`,
+  });
+
+  try {
+    const page = await app.firstWindow();
+    await expect(page.locator("#input")).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator("#notebook-view")).toContainText(uniqueNotebookLine, {
+      timeout: 30_000,
+    });
   } finally {
     await app.close();
     await fs.rm(tmpRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- automatically load `notebook.md` into the Orbit notebook pane on startup
- reload the notebook after switching analysis directories
- guard async notebook loads so stale reads cannot repaint the wrong notebook

## Tests
- `tsc --noEmit`
- Prettier check for touched files
- attempted Electron smoke spec; packaged app failed to launch before either test body ran, including the pre-existing smoke test