### PR TITLE
Surface the release URL when the update banner can't open a browser (#368)

### DIFF
--- a/app/src/main/ipc-handlers.ts
+++ b/app/src/main/ipc-handlers.ts
@@ -23,6 +23,7 @@ import { normalizeGalaxyUrl, validateGalaxyUrl } from "./galaxy-url.js";
 import { getProviders, getModels } from "@earendil-works/pi-ai";
 import { isDeprecatedModelId } from "./model-catalog.js";
 import { checkLatestVersion } from "./version-check.js";
+import { resolveReleasePageUrl } from "./release-page.js";
 import { postFeedback } from "./feedback.js";
 import type { FeedbackPayload } from "../../../shared/feedback-contract.js";
 import {
@@ -669,16 +670,21 @@ export function registerIpcHandlers(agent: AgentManager): void {
   }));
 
   // Opens the GitHub releases page in the user's default browser when they
-  // click the "update available" banner. Hard-coded URL — renderer never
-  // gets a generic openExternal capability.
+  // click the "update available" banner. The destination is pinned in
+  // resolveReleasePageUrl -- the renderer never gets a generic openExternal
+  // capability. Report the *real* outcome (and log failures): shell.openExternal
+  // can reject or no-op where there's no default browser / no xdg-open (WSLg,
+  // #368), and the old always-"opened:true" hid that from the caller, which
+  // then had no way to offer a copy-the-link fallback.
   ipc.handle("version:open-release", async (_e, url: unknown) => {
-    const releasesPage = "https://github.com/galaxyproject/loom/releases/latest";
-    const target =
-      typeof url === "string" && /^https:\/\/github\.com\/galaxyproject\/loom\/releases\//.test(url)
-        ? url
-        : releasesPage;
-    await shell.openExternal(target);
-    return { opened: true };
+    const target = resolveReleasePageUrl(url);
+    try {
+      await shell.openExternal(target);
+      return { opened: true, url: target };
+    } catch (err) {
+      log("version:open-release -- shell.openExternal failed:", target, err);
+      return { opened: false, url: target };
+    }
   });
 
   // Opens the bound Galaxy history in the user's default browser when the user

--- a/app/src/main/release-page.ts
+++ b/app/src/main/release-page.ts
@@ -1,0 +1,19 @@
+/**
+ * Release-page URL resolution for the "update available" banner.
+ *
+ * The renderer never gets a generic openExternal capability -- a compromised
+ * renderer could otherwise redirect the browser anywhere. So the URL handed to
+ * shell.openExternal is pinned here: anything that isn't an https loom releases
+ * URL collapses to the canonical /releases/latest page. Kept pure and free of
+ * electron imports so it can be unit-tested.
+ */
+
+const LATEST_RELEASES_PAGE = "https://github.com/galaxyproject/loom/releases/latest";
+
+// Anchored at the start so a look-alike host (github.com.evil.com) or a path
+// that merely *contains* the releases prefix can't satisfy the pin.
+const LOOM_RELEASE_URL = /^https:\/\/github\.com\/galaxyproject\/loom\/releases\//;
+
+export function resolveReleasePageUrl(url: unknown): string {
+  return typeof url === "string" && LOOM_RELEASE_URL.test(url) ? url : LATEST_RELEASES_PAGE;
+}

--- a/app/src/main/release-page.ts
+++ b/app/src/main/release-page.ts
@@ -3,17 +3,35 @@
  *
  * The renderer never gets a generic openExternal capability -- a compromised
  * renderer could otherwise redirect the browser anywhere. So the URL handed to
- * shell.openExternal is pinned here: anything that isn't an https loom releases
- * URL collapses to the canonical /releases/latest page. Kept pure and free of
- * electron imports so it can be unit-tested.
+ * shell.openExternal is pinned here: anything that isn't an https github.com
+ * loom releases URL collapses to the canonical /releases/latest page. Kept pure
+ * and free of electron imports so it can be unit-tested.
+ *
+ * The check parses with `new URL` and inspects the *normalized* protocol, host,
+ * and path rather than string-matching the raw input -- a raw prefix match lets
+ * `.../releases/../issues/1` (or its `%2e%2e` encoding) satisfy the pin while
+ * the browser resolves it back out of /releases/. Returning `parsed.href` means
+ * what we validated is exactly what gets opened.
  */
 
 const LATEST_RELEASES_PAGE = "https://github.com/galaxyproject/loom/releases/latest";
 
-// Anchored at the start so a look-alike host (github.com.evil.com) or a path
-// that merely *contains* the releases prefix can't satisfy the pin.
-const LOOM_RELEASE_URL = /^https:\/\/github\.com\/galaxyproject\/loom\/releases\//;
+const RELEASES_PATH_PREFIX = "/galaxyproject/loom/releases/";
 
 export function resolveReleasePageUrl(url: unknown): string {
-  return typeof url === "string" && LOOM_RELEASE_URL.test(url) ? url : LATEST_RELEASES_PAGE;
+  if (typeof url !== "string") return LATEST_RELEASES_PAGE;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return LATEST_RELEASES_PAGE;
+  }
+  if (
+    parsed.protocol === "https:" &&
+    parsed.hostname === "github.com" &&
+    parsed.pathname.startsWith(RELEASES_PATH_PREFIX)
+  ) {
+    return parsed.href;
+  }
+  return LATEST_RELEASES_PAGE;
 }

--- a/app/src/preload/preload.ts
+++ b/app/src/preload/preload.ts
@@ -156,7 +156,7 @@ export interface OrbitAPI {
     releaseUrl: string;
   } | null>;
   getVersion(): Promise<{ version: string; isPackaged: boolean }>;
-  openReleasePage(url?: string): Promise<{ opened: boolean }>;
+  openReleasePage(url?: string): Promise<{ opened: boolean; url: string }>;
   openGalaxyHistory(url: string): Promise<{ opened: boolean }>;
   getGalaxyStatus(): Promise<{ connected: boolean; url: string | null }>;
   restartToUpdate(): Promise<{ restarting: boolean }>;

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -26,6 +26,7 @@ import {
 import type { FeedbackPayload, FeedbackSysinfo } from "../../../shared/feedback-contract.js";
 import changelogRaw from "../../../CHANGELOG.md?raw";
 import { parseChangelog, decideWhatsNew, releaseUrlFor } from "../../../shared/whats-new.js";
+import { openReleaseWithFallback } from "./update-banner.js";
 
 declare global {
   interface Window {
@@ -3987,7 +3988,16 @@ window.orbit.onProcUpdate((procs) => {
 
   if (updateBanner && updateVersionEl && updateLinkBtn && updateDismissBtn) {
     updateLinkBtn.addEventListener("click", () => {
-      if (currentReleaseUrl) void window.orbit.openReleasePage(currentReleaseUrl);
+      if (!currentReleaseUrl) return;
+      // Reveal the copyable link on every click, not just on a detected failure:
+      // where there's no working default browser (WSLg, #368) shell.openExternal
+      // fails silently, and because it only resolves Promise<void> a stub
+      // xdg-open that exits 0 without opening anything still looks like success.
+      // Showing the URL up-front means the update is never a dead end regardless
+      // of how the open fails; the note escalates only on a confirmed failure.
+      void openReleaseWithFallback(updateBanner, currentReleaseUrl, (u) =>
+        window.orbit.openReleasePage(u),
+      );
     });
     updateDismissBtn.addEventListener("click", () => {
       updateBanner.classList.add("hidden");

--- a/app/src/renderer/app.ts
+++ b/app/src/renderer/app.ts
@@ -26,7 +26,7 @@ import {
 import type { FeedbackPayload, FeedbackSysinfo } from "../../../shared/feedback-contract.js";
 import changelogRaw from "../../../CHANGELOG.md?raw";
 import { parseChangelog, decideWhatsNew, releaseUrlFor } from "../../../shared/whats-new.js";
-import { openReleaseWithFallback } from "./update-banner.js";
+import { openReleaseWithFallback, clearReleaseFallback } from "./update-banner.js";
 
 declare global {
   interface Window {
@@ -4001,6 +4001,7 @@ window.orbit.onProcUpdate((procs) => {
     });
     updateDismissBtn.addEventListener("click", () => {
       updateBanner.classList.add("hidden");
+      clearReleaseFallback(updateBanner);
       const v = updateVersionEl.textContent || restartVersionEl?.textContent;
       if (v) {
         try {
@@ -4021,6 +4022,7 @@ window.orbit.onProcUpdate((procs) => {
         if (dismissed === info.latest) return;
         updateVersionEl.textContent = info.latest;
         currentReleaseUrl = info.releaseUrl;
+        clearReleaseFallback(updateBanner); // fresh link banner starts clean
         linkText?.classList.remove("hidden");
         updateLinkBtn.classList.remove("hidden");
         updateBanner.classList.remove("hidden");
@@ -4032,6 +4034,9 @@ window.orbit.onProcUpdate((procs) => {
     if (window.orbit.platform === "darwin") {
       window.orbit.onUpdateDownloaded((info) => {
         if (restartVersionEl) restartVersionEl.textContent = info.version;
+        // Drop any release-link fallback from a prior updater-error notify
+        // banner so the restart-to-install banner renders clean.
+        clearReleaseFallback(updateBanner);
         linkText?.classList.add("hidden");
         updateLinkBtn.classList.add("hidden");
         restartText?.classList.remove("hidden");

--- a/app/src/renderer/styles.css
+++ b/app/src/renderer/styles.css
@@ -123,6 +123,7 @@ a:visited {
 #update-banner {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 12px;
   padding: 6px 12px;
   background: var(--accent-bg);
@@ -131,6 +132,21 @@ a:visited {
   font-family: var(--font-sans);
   font-size: 12px;
   flex: 0 0 auto;
+}
+/* Copy-the-link fallback, revealed only when the browser couldn't be opened
+   (WSLg / no default browser). Wraps onto its own row under the banner text. */
+#update-banner .update-banner-fallback {
+  flex: 1 1 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-dim);
+}
+#update-banner .update-banner-fallback-url {
+  font-family: var(--font-mono, monospace);
+  color: var(--accent);
+  user-select: all;
+  word-break: break-all;
 }
 #update-banner.hidden {
   display: none;

--- a/app/src/renderer/update-banner.ts
+++ b/app/src/renderer/update-banner.ts
@@ -78,6 +78,11 @@ export function showReleaseFallback(
   return fallback;
 }
 
+/** Remove the fallback if present. No-op when it was never shown. */
+export function clearReleaseFallback(banner: HTMLElement): void {
+  banner.querySelector(".update-banner-fallback")?.remove();
+}
+
 /**
  * Orchestrates a "Open release page" click: reveal the copyable link up front
  * (so the update is never a dead end even when shell.openExternal resolves

--- a/app/src/renderer/update-banner.ts
+++ b/app/src/renderer/update-banner.ts
@@ -1,0 +1,115 @@
+/**
+ * Update-banner fallback for when the browser can't be launched.
+ *
+ * The "Open release page" button asks main to run shell.openExternal. On some
+ * environments that quietly fails -- notably WSLg, which often has no default
+ * browser / no working xdg-open (#368). Worse, shell.openExternal returns only
+ * Promise<void>, so a stub xdg-open that exits 0 without opening anything looks
+ * like success. We can't force a browser open, but we can always make the
+ * release URL reachable: reveal it as selectable text with a copy button so the
+ * user can open it themselves. Kept DOM-only (no electron import) so it can be
+ * unit-tested with happy-dom.
+ */
+
+export const NEUTRAL_FALLBACK_NOTE = "Release page:";
+export const OPEN_FAILED_FALLBACK_NOTE = "Couldn't open your browser automatically. Use this link:";
+
+/** Copy text via the async clipboard API. Never throws -- returns success. */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    const clip = navigator.clipboard;
+    if (!clip || typeof clip.writeText !== "function") return false;
+    await clip.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reveal (or update) the copy-the-link fallback inside the update banner.
+ * Idempotent: repeated calls reuse the one fallback element and just refresh
+ * the note + URL (so a stale "couldn't open" note is reset on a later success).
+ * Returns the fallback element.
+ */
+export function showReleaseFallback(
+  banner: HTMLElement,
+  url: string,
+  note: string = NEUTRAL_FALLBACK_NOTE,
+): HTMLElement {
+  const doc = banner.ownerDocument;
+  let fallback = banner.querySelector<HTMLElement>(".update-banner-fallback");
+  if (!fallback) {
+    fallback = doc.createElement("div");
+    fallback.className = "update-banner-fallback";
+    fallback.setAttribute("role", "note");
+
+    const noteEl = doc.createElement("span");
+    noteEl.className = "update-banner-fallback-note";
+
+    const urlEl = doc.createElement("span");
+    urlEl.className = "update-banner-fallback-url";
+    // Let the user select it directly, even if the copy button can't reach a
+    // clipboard (some sandboxed/headless environments).
+    urlEl.tabIndex = 0;
+
+    const copyBtn = doc.createElement("button");
+    copyBtn.className = "update-banner-fallback-copy update-banner-link";
+    copyBtn.type = "button";
+    copyBtn.textContent = "Copy";
+    copyBtn.addEventListener("click", () => {
+      const current = urlEl.textContent || "";
+      void copyToClipboard(current).then((ok) => {
+        copyBtn.textContent = ok ? "Copied" : "Copy failed";
+      });
+      selectElementText(urlEl);
+    });
+
+    fallback.append(noteEl, urlEl, copyBtn);
+    banner.appendChild(fallback);
+  }
+
+  const noteEl = fallback.querySelector<HTMLElement>(".update-banner-fallback-note");
+  if (noteEl) noteEl.textContent = note;
+  const urlEl = fallback.querySelector<HTMLElement>(".update-banner-fallback-url");
+  if (urlEl) urlEl.textContent = url;
+  const copyBtn = fallback.querySelector<HTMLElement>(".update-banner-fallback-copy");
+  if (copyBtn) copyBtn.textContent = "Copy";
+  return fallback;
+}
+
+/**
+ * Orchestrates a "Open release page" click: reveal the copyable link up front
+ * (so the update is never a dead end even when shell.openExternal resolves
+ * without actually opening a browser), attempt the open, and escalate the note
+ * to a failure message only when the open is a *confirmed* miss. Takes the open
+ * function as a parameter so the wiring is testable without electron.
+ */
+export async function openReleaseWithFallback(
+  banner: HTMLElement,
+  url: string,
+  open: (url: string) => Promise<{ opened: boolean; url?: string } | undefined>,
+): Promise<void> {
+  showReleaseFallback(banner, url);
+  try {
+    const result = await open(url);
+    if (!result?.opened) {
+      showReleaseFallback(banner, result?.url || url, OPEN_FAILED_FALLBACK_NOTE);
+    }
+  } catch {
+    showReleaseFallback(banner, url, OPEN_FAILED_FALLBACK_NOTE);
+  }
+}
+
+function selectElementText(el: HTMLElement): void {
+  try {
+    const selection = el.ownerDocument.defaultView?.getSelection();
+    if (!selection) return;
+    const range = el.ownerDocument.createRange();
+    range.selectNodeContents(el);
+    selection.removeAllRanges();
+    selection.addRange(range);
+  } catch {
+    // Selection is a best-effort nicety; ignore environments without it.
+  }
+}

--- a/tests/release-page.test.ts
+++ b/tests/release-page.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { resolveReleasePageUrl } from "../app/src/main/release-page.js";
+
+const LATEST = "https://github.com/galaxyproject/loom/releases/latest";
+
+describe("resolveReleasePageUrl", () => {
+  it("passes a valid loom releases URL through untouched", () => {
+    const url = "https://github.com/galaxyproject/loom/releases/tag/v0.5.2";
+    expect(resolveReleasePageUrl(url)).toBe(url);
+    expect(resolveReleasePageUrl(LATEST)).toBe(LATEST);
+  });
+
+  it("pins to the latest releases page for a non-releases loom URL", () => {
+    expect(resolveReleasePageUrl("https://github.com/galaxyproject/loom/issues/368")).toBe(LATEST);
+  });
+
+  it("pins to the latest releases page for a foreign host", () => {
+    expect(resolveReleasePageUrl("https://evil.example/galaxyproject/loom/releases/tag/x")).toBe(
+      LATEST,
+    );
+  });
+
+  it("pins to the latest releases page for a look-alike host prefix", () => {
+    // github.com.evil.com must not satisfy the pin.
+    expect(
+      resolveReleasePageUrl("https://github.com.evil.com/galaxyproject/loom/releases/tag/x"),
+    ).toBe(LATEST);
+  });
+
+  it("pins to the latest releases page for a javascript: URL", () => {
+    expect(resolveReleasePageUrl("javascript:alert(1)")).toBe(LATEST);
+  });
+
+  it("pins to the latest releases page for http (non-https) releases URL", () => {
+    expect(resolveReleasePageUrl("http://github.com/galaxyproject/loom/releases/tag/v1")).toBe(
+      LATEST,
+    );
+  });
+
+  it("pins to the latest releases page for non-string input", () => {
+    expect(resolveReleasePageUrl(undefined)).toBe(LATEST);
+    expect(resolveReleasePageUrl(null)).toBe(LATEST);
+    expect(resolveReleasePageUrl(42)).toBe(LATEST);
+    expect(resolveReleasePageUrl({})).toBe(LATEST);
+  });
+});

--- a/tests/release-page.test.ts
+++ b/tests/release-page.test.ts
@@ -31,6 +31,28 @@ describe("resolveReleasePageUrl", () => {
     expect(resolveReleasePageUrl("javascript:alert(1)")).toBe(LATEST);
   });
 
+  it("does not let path traversal escape the /releases/ pin", () => {
+    // These match a naive string prefix but normalize out of /releases/.
+    expect(
+      resolveReleasePageUrl("https://github.com/galaxyproject/loom/releases/../issues/1"),
+    ).toBe(LATEST);
+    expect(
+      resolveReleasePageUrl("https://github.com/galaxyproject/loom/releases/%2e%2e/issues/1"),
+    ).toBe(LATEST);
+  });
+
+  it("returns the normalized URL for traversal that stays within /releases/", () => {
+    expect(
+      resolveReleasePageUrl("https://github.com/galaxyproject/loom/releases/../releases/tag/v1"),
+    ).toBe("https://github.com/galaxyproject/loom/releases/tag/v1");
+  });
+
+  it("pins for a userinfo-bearing look-alike that is not github.com", () => {
+    expect(
+      resolveReleasePageUrl("https://github.com@evil.example/galaxyproject/loom/releases/tag/v1"),
+    ).toBe(LATEST);
+  });
+
   it("pins to the latest releases page for http (non-https) releases URL", () => {
     expect(resolveReleasePageUrl("http://github.com/galaxyproject/loom/releases/tag/v1")).toBe(
       LATEST,

--- a/tests/update-banner-fallback.test.ts
+++ b/tests/update-banner-fallback.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  showReleaseFallback,
+  openReleaseWithFallback,
+  copyToClipboard,
+  NEUTRAL_FALLBACK_NOTE,
+  OPEN_FAILED_FALLBACK_NOTE,
+} from "../app/src/renderer/update-banner.js";
+
+describe("showReleaseFallback", () => {
+  let banner: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = `<div id="update-banner"></div>`;
+    banner = document.getElementById("update-banner")!;
+  });
+
+  it("reveals the release URL as selectable text inside the banner", () => {
+    const url = "https://github.com/galaxyproject/loom/releases/tag/v0.5.2";
+    showReleaseFallback(banner, url);
+    const fallback = banner.querySelector(".update-banner-fallback");
+    expect(fallback).not.toBeNull();
+    expect(fallback!.textContent).toContain(url);
+  });
+
+  it("puts the exact URL in a dedicated selectable element", () => {
+    const url = "https://github.com/galaxyproject/loom/releases/latest";
+    showReleaseFallback(banner, url);
+    const urlEl = banner.querySelector(".update-banner-fallback-url");
+    expect(urlEl).not.toBeNull();
+    expect(urlEl!.textContent).toBe(url);
+  });
+
+  it("uses a neutral note by default (no failure is asserted on a plain reveal)", () => {
+    showReleaseFallback(banner, "https://github.com/galaxyproject/loom/releases/latest");
+    expect(banner.querySelector(".update-banner-fallback-note")!.textContent).toBe(
+      NEUTRAL_FALLBACK_NOTE,
+    );
+  });
+
+  it("shows the given note when the open is a confirmed failure", () => {
+    showReleaseFallback(
+      banner,
+      "https://github.com/galaxyproject/loom/releases/latest",
+      OPEN_FAILED_FALLBACK_NOTE,
+    );
+    expect(banner.querySelector(".update-banner-fallback-note")!.textContent).toBe(
+      OPEN_FAILED_FALLBACK_NOTE,
+    );
+  });
+
+  it("resets a stale failure note back to neutral on a later success", () => {
+    const url = "https://github.com/galaxyproject/loom/releases/latest";
+    showReleaseFallback(banner, url, OPEN_FAILED_FALLBACK_NOTE);
+    showReleaseFallback(banner, url); // e.g. a retry that opened successfully
+    expect(banner.querySelector(".update-banner-fallback-note")!.textContent).toBe(
+      NEUTRAL_FALLBACK_NOTE,
+    );
+  });
+
+  it("is idempotent -- a second call reuses the element and updates the URL", () => {
+    showReleaseFallback(banner, "https://github.com/galaxyproject/loom/releases/tag/v1");
+    showReleaseFallback(banner, "https://github.com/galaxyproject/loom/releases/tag/v2");
+    expect(banner.querySelectorAll(".update-banner-fallback").length).toBe(1);
+    expect(banner.querySelector(".update-banner-fallback-url")!.textContent).toBe(
+      "https://github.com/galaxyproject/loom/releases/tag/v2",
+    );
+  });
+
+  it("offers a copy button that copies the URL to the clipboard", async () => {
+    const url = "https://github.com/galaxyproject/loom/releases/latest";
+    let copied: string | null = null;
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (t: string) => {
+          copied = t;
+        },
+      },
+    });
+    showReleaseFallback(banner, url);
+    const copyBtn = banner.querySelector<HTMLButtonElement>(".update-banner-fallback-copy")!;
+    expect(copyBtn).not.toBeNull();
+    copyBtn.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(copied).toBe(url);
+  });
+});
+
+describe("openReleaseWithFallback", () => {
+  let banner: HTMLElement;
+  const url = "https://github.com/galaxyproject/loom/releases/tag/v0.5.2";
+
+  beforeEach(() => {
+    document.body.innerHTML = `<div id="update-banner"></div>`;
+    banner = document.getElementById("update-banner")!;
+  });
+
+  const noteText = () => banner.querySelector(".update-banner-fallback-note")!.textContent;
+
+  it("keeps the copyable link visible with a neutral note when the open reports success", async () => {
+    // The WSLg regression: shell.openExternal can resolve { opened: true }
+    // without a browser ever appearing. The link must still be reachable and
+    // must NOT claim a failure.
+    await openReleaseWithFallback(banner, url, async () => ({ opened: true, url }));
+    expect(banner.querySelector(".update-banner-fallback-url")!.textContent).toBe(url);
+    expect(noteText()).toBe(NEUTRAL_FALLBACK_NOTE);
+  });
+
+  it("escalates the note to the failure message when the open reports it didn't open", async () => {
+    await openReleaseWithFallback(banner, url, async () => ({ opened: false, url }));
+    expect(banner.querySelector(".update-banner-fallback-url")!.textContent).toBe(url);
+    expect(noteText()).toBe(OPEN_FAILED_FALLBACK_NOTE);
+  });
+
+  it("escalates the note to the failure message when the open call rejects", async () => {
+    await openReleaseWithFallback(banner, url, async () => {
+      throw new Error("no browser");
+    });
+    expect(banner.querySelector(".update-banner-fallback-url")!.textContent).toBe(url);
+    expect(noteText()).toBe(OPEN_FAILED_FALLBACK_NOTE);
+  });
+
+  it("reveals the link before awaiting the open, so a hung open still isn't a dead end", () => {
+    let resolveOpen: (v: { opened: boolean }) => void = () => {};
+    const pending = openReleaseWithFallback(
+      banner,
+      url,
+      () => new Promise((res) => (resolveOpen = res)),
+    );
+    // Synchronously after the call, before the open settles, the URL is shown.
+    expect(banner.querySelector(".update-banner-fallback-url")!.textContent).toBe(url);
+    resolveOpen({ opened: true });
+    return pending;
+  });
+});
+
+describe("copyToClipboard", () => {
+  it("writes the text through the async clipboard API and reports success", async () => {
+    let copied: string | null = null;
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (t: string) => {
+          copied = t;
+        },
+      },
+    });
+    const ok = await copyToClipboard("hello");
+    expect(ok).toBe(true);
+    expect(copied).toBe("hello");
+  });
+
+  it("reports failure instead of throwing when the clipboard API is unavailable", async () => {
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    await expect(copyToClipboard("hello")).resolves.toBe(false);
+  });
+
+  it("reports failure instead of throwing when writeText rejects", async () => {
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async () => {
+          throw new Error("denied");
+        },
+      },
+    });
+    await expect(copyToClipboard("hello")).resolves.toBe(false);
+  });
+});

--- a/tests/update-banner-fallback.test.ts
+++ b/tests/update-banner-fallback.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import {
   showReleaseFallback,
+  clearReleaseFallback,
   openReleaseWithFallback,
   copyToClipboard,
   NEUTRAL_FALLBACK_NOTE,
@@ -66,6 +67,14 @@ describe("showReleaseFallback", () => {
     expect(banner.querySelector(".update-banner-fallback-url")!.textContent).toBe(
       "https://github.com/galaxyproject/loom/releases/tag/v2",
     );
+  });
+
+  it("clearReleaseFallback removes a shown fallback and is a no-op when absent", () => {
+    clearReleaseFallback(banner); // absent: must not throw
+    showReleaseFallback(banner, "https://github.com/galaxyproject/loom/releases/latest");
+    expect(banner.querySelector(".update-banner-fallback")).not.toBeNull();
+    clearReleaseFallback(banner);
+    expect(banner.querySelector(".update-banner-fallback")).toBeNull();
   });
 
   it("offers a copy button that copies the URL to the clipboard", async () => {


### PR DESCRIPTION
Closes #368.

## What was wrong

Under WSLg (and anywhere there's no default browser or working `xdg-open`), the update-available banner's **"Open release page"** button did nothing -- no browser, and no log/error to explain it. The click routes renderer -> `version:open-release` IPC -> `shell.openExternal`, and the outcome was swallowed at both ends:

- the main handler `await`ed `shell.openExternal` but always returned `{ opened: true }` and never try/caught, so a failure propagated back over IPC unseen and nothing was logged;
- the renderer discarded the result with `void window.orbit.openReleasePage(...)`.

## The subtlety

`shell.openExternal` only resolves `Promise<void>` -- there's no positive "a browser actually opened" signal. On Linux a stub `xdg-open` that exits 0 without opening anything makes the promise *resolve*, so a purely reactive "show a fallback only when it failed" approach would still miss that WSLg variant.

## The fix

Don't depend on detecting the failure. Clicking "Open release page" now **always** reveals the release URL as selectable text with a copy button, then attempts the open, and only escalates the note to "Couldn't open your browser automatically" on a *confirmed* failure (`opened: false` or a thrown error). So the update is never a dead end regardless of how the open fails or misreports. The main handler also reports the real `{ opened, url }` and logs failures.

That button only appears on the non-darwin / updater-error notify banner (macOS's happy-path auto-update shows "Restart to install" instead), so this lands exactly on the population that can hit the bug and leaves the macOS flow untouched.

Details:
- New pure `resolveReleasePageUrl` holds the security URL pin (https loom `/releases/` only, else `/releases/latest`), now unit-tested -- the renderer still never gets a generic `openExternal`.
- New DOM-only `update-banner` helper (`showReleaseFallback` / `openReleaseWithFallback` / `copyToClipboard`); the URL is rendered via `textContent` (no HTML/`href`), so no injection risk.

## Tests / checks

- Root `npm test`: 1271 passed, 1 skipped. Root `tsc` + app `tsc` clean. Prettier clean.
- New tests cover the URL pin (incl. look-alike host, non-https, non-string) and the fallback/orchestration -- including the resolve-but-nothing case where the IPC resolves `{ opened: true }` yet the link must stay visible with a neutral note.

## Needs a human eyeball on WSLg

This is WSLg-specific and can't be verified on macOS/CI. Someone on WSLg should confirm the button now surfaces the copyable release URL (and the "couldn't open" note when the browser genuinely can't launch); the new `log(...)` line will also record the `openExternal` failure in the `orbit` CLI output.

Left out of scope: the what's-new modal's "Full release notes" link uses the same IPC and has the same underlying limitation -- it picks up the main-side logging but not the fallback UI here, since #368 is specifically the update banner. Easy follow-up if wanted.
