### PR TITLE
Dismiss the floating chat copy button on click-elsewhere and after copying

### DIFF
--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -1,6 +1,11 @@
 import { renderMarkdown } from "./markdown.js";
 import { joinTextBlocks } from "./block-spacing.js";
-import { computeCopyButtonPlacement } from "./copy-button.js";
+import {
+  computeCopyButtonPlacement,
+  CopyButtonDismissal,
+  type SelectionSignature,
+} from "./copy-button.js";
+import { copyToClipboard } from "../update-banner.js";
 import {
   TEAM_DISPATCH_KIND,
   type TeamDispatchDetails,
@@ -453,16 +458,33 @@ export class ChatPanel {
   }
 
   private initCopyButton(): HTMLElement {
+    const COPY_LABEL = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy`;
     const btn = document.createElement("button");
     btn.className = "chat-copy-btn";
     btn.hidden = true;
-    btn.innerHTML = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy`;
+    btn.innerHTML = COPY_LABEL;
     document.body.appendChild(btn);
 
     // selectionchange fires while a mousedown is still in progress and the old
     // selection is still live, which would immediately re-show the button we
     // just hid. Track mousedown state so selectionchange can't re-show it.
     let mouseIsDown = false;
+
+    // #377: many clicks never collapse the selection (non-selectable chrome,
+    // the chat input, scrollbars), so hiding on mousedown isn't enough -- the
+    // mouseup/selectionchange re-validation would bring the button right back.
+    const dismissal = new CopyButtonDismissal();
+
+    const currentSignature = (): SelectionSignature | null => {
+      const sel = window.getSelection();
+      if (!sel || sel.isCollapsed || sel.rangeCount === 0) return null;
+      return {
+        anchorNode: sel.anchorNode,
+        anchorOffset: sel.anchorOffset,
+        focusNode: sel.focusNode,
+        focusOffset: sel.focusOffset,
+      };
+    };
 
     btn.addEventListener("mousedown", (e) => e.preventDefault()); // keep selection alive on button click
 
@@ -472,6 +494,7 @@ export class ChatPanel {
       if (!btn.contains(e.target as Node)) {
         btn.hidden = true;
         mouseIsDown = true;
+        dismissal.suppress(currentSignature());
       }
     });
     document.addEventListener("mouseup", () => {
@@ -484,17 +507,32 @@ export class ChatPanel {
 
     btn.addEventListener("click", () => {
       const sel = window.getSelection();
-      if (!sel || sel.rangeCount === 0) return;
+      if (!sel || sel.rangeCount === 0) {
+        btn.hidden = true;
+        return;
+      }
       const frag = sel.getRangeAt(0).cloneContents();
       const tmp = document.createElement("div");
       tmp.appendChild(frag);
       const md = fragmentToMarkdown(tmp);
-      navigator.clipboard.writeText(md).then(() => {
-        btn.textContent = "✓ Copied";
+      void copyToClipboard(md).then((ok) => {
+        if (ok) {
+          btn.textContent = "✓ Copied";
+          setTimeout(() => {
+            btn.innerHTML = COPY_LABEL;
+            btn.hidden = true;
+            sel.removeAllRanges();
+          }, 1200);
+          return;
+        }
+        // Clipboard unavailable/refused: don't claim success, and keep the
+        // selection so Cmd/Ctrl+C still works. Suppress right away so the
+        // confirmation beat can't be re-shown by scroll/selectionchange.
+        dismissal.suppress(currentSignature());
+        btn.textContent = "✗ Copy failed";
         setTimeout(() => {
-          btn.innerHTML = `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg> Copy`;
+          btn.innerHTML = COPY_LABEL;
           btn.hidden = true;
-          sel.removeAllRanges();
         }, 1200);
       });
     });
@@ -502,6 +540,7 @@ export class ChatPanel {
     // Keyboard selection (Shift+arrow, Ctrl+A, etc.) — selectionchange is safe
     // here because there's no mousedown race.
     document.addEventListener("selectionchange", () => {
+      dismissal.noteSelectionChange(currentSignature());
       if (mouseIsDown) return;
       updateBtn();
     });
@@ -526,6 +565,11 @@ export class ChatPanel {
     const updateBtn = () => {
       const sel = window.getSelection();
       if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
+        btn.hidden = true;
+        return;
+      }
+      // A dismissed-but-surviving selection stays dismissed (#377).
+      if (dismissal.suppresses(currentSignature())) {
         btn.hidden = true;
         return;
       }

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -476,6 +476,11 @@ export class ChatPanel {
     // mouseup/selectionchange re-validation would bring the button right back.
     const dismissal = new CopyButtonDismissal();
 
+    // Bumped whenever the document selection collapses/empties: a later
+    // selection with an identical signature is then a NEW selection (the user
+    // re-selected the same text), not the one a pending copy acted on.
+    let selectionEpoch = 0;
+
     const currentSignature = (): SelectionSignature | null => {
       const sel = window.getSelection();
       if (!sel || sel.isCollapsed || sel.rangeCount === 0) return null;
@@ -520,6 +525,12 @@ export class ChatPanel {
       // confirmation beat ends, the user may have selected something else,
       // and that newer selection must be neither cleared nor suppressed.
       const copied = currentSignature();
+      const epoch = selectionEpoch;
+      // The copied selection is still the live one: same signature, and no
+      // collapse in between (which would make an identical signature a new,
+      // re-selected range rather than this one).
+      const copiedSelectionIsLive = () =>
+        epoch === selectionEpoch && selectionSignaturesEqual(currentSignature(), copied);
       void copyToClipboard(md).then((ok) => {
         if (ok) {
           btn.textContent = "✓ Copied";
@@ -527,12 +538,12 @@ export class ChatPanel {
           // Clipboard unavailable/refused: don't claim success, and keep the
           // selection so Cmd/Ctrl+C still works -- just stop showing the
           // button for it.
-          dismissal.suppress(copied);
+          if (copiedSelectionIsLive()) dismissal.suppress(copied);
           btn.textContent = "✗ Copy failed";
         }
         setTimeout(() => {
           btn.innerHTML = COPY_LABEL;
-          if (ok && selectionSignaturesEqual(currentSignature(), copied)) {
+          if (ok && copiedSelectionIsLive()) {
             btn.hidden = true;
             window.getSelection()?.removeAllRanges();
           } else {
@@ -547,7 +558,9 @@ export class ChatPanel {
     // Keyboard selection (Shift+arrow, Ctrl+A, etc.) — selectionchange is safe
     // here because there's no mousedown race.
     document.addEventListener("selectionchange", () => {
-      dismissal.noteSelectionChange(currentSignature());
+      const sig = currentSignature();
+      if (sig === null) selectionEpoch++;
+      dismissal.noteSelectionChange(sig);
       if (mouseIsDown) return;
       updateBtn();
     });

--- a/app/src/renderer/chat/chat-panel.ts
+++ b/app/src/renderer/chat/chat-panel.ts
@@ -3,6 +3,7 @@ import { joinTextBlocks } from "./block-spacing.js";
 import {
   computeCopyButtonPlacement,
   CopyButtonDismissal,
+  selectionSignaturesEqual,
   type SelectionSignature,
 } from "./copy-button.js";
 import { copyToClipboard } from "../update-banner.js";
@@ -515,24 +516,30 @@ export class ChatPanel {
       const tmp = document.createElement("div");
       tmp.appendChild(frag);
       const md = fragmentToMarkdown(tmp);
+      // Snapshot what was copied: by the time the clipboard settles or the
+      // confirmation beat ends, the user may have selected something else,
+      // and that newer selection must be neither cleared nor suppressed.
+      const copied = currentSignature();
       void copyToClipboard(md).then((ok) => {
         if (ok) {
           btn.textContent = "✓ Copied";
-          setTimeout(() => {
-            btn.innerHTML = COPY_LABEL;
-            btn.hidden = true;
-            sel.removeAllRanges();
-          }, 1200);
-          return;
+        } else {
+          // Clipboard unavailable/refused: don't claim success, and keep the
+          // selection so Cmd/Ctrl+C still works -- just stop showing the
+          // button for it.
+          dismissal.suppress(copied);
+          btn.textContent = "✗ Copy failed";
         }
-        // Clipboard unavailable/refused: don't claim success, and keep the
-        // selection so Cmd/Ctrl+C still works. Suppress right away so the
-        // confirmation beat can't be re-shown by scroll/selectionchange.
-        dismissal.suppress(currentSignature());
-        btn.textContent = "✗ Copy failed";
         setTimeout(() => {
           btn.innerHTML = COPY_LABEL;
-          btn.hidden = true;
+          if (ok && selectionSignaturesEqual(currentSignature(), copied)) {
+            btn.hidden = true;
+            window.getSelection()?.removeAllRanges();
+          } else {
+            // The user moved on (or the copy failed): leave the selection
+            // alone and let the usual rules decide visibility.
+            updateBtn();
+          }
         }, 1200);
       });
     });

--- a/app/src/renderer/chat/copy-button.ts
+++ b/app/src/renderer/chat/copy-button.ts
@@ -71,3 +71,59 @@ export function computeCopyButtonPlacement(input: CopyButtonInput): CopyButtonPl
 
   return { hidden: false, top, left };
 }
+
+/**
+ * Identity of a document selection, compared by node reference + offsets.
+ * `null` stands for "no usable selection" (none, empty, or collapsed).
+ */
+export interface SelectionSignature {
+  anchorNode: unknown;
+  anchorOffset: number;
+  focusNode: unknown;
+  focusOffset: number;
+}
+
+export function selectionSignaturesEqual(
+  a: SelectionSignature | null,
+  b: SelectionSignature | null,
+): boolean {
+  if (a === null || b === null) return a === b;
+  return (
+    a.anchorNode === b.anchorNode &&
+    a.anchorOffset === b.anchorOffset &&
+    a.focusNode === b.focusNode &&
+    a.focusOffset === b.focusOffset
+  );
+}
+
+/**
+ * Click-to-dismiss state for the floating Copy button (#377).
+ *
+ * A click outside the button hides it, but many clicks never collapse the
+ * document selection (non-selectable UI chrome, the chat input's internal
+ * caret, scrollbars), so re-validating on mouseup used to bring the button
+ * straight back. Dismissal therefore records the selection it dismissed:
+ * as long as the document selection is still that exact range the button
+ * stays hidden, and any real change -- including the collapse at the start
+ * of a drag, so re-selecting the same text works -- lifts the suppression.
+ */
+export class CopyButtonDismissal {
+  private suppressed: SelectionSignature | null = null;
+
+  /** The button was dismissed while `current` was selected. */
+  suppress(current: SelectionSignature | null): void {
+    this.suppressed = current;
+  }
+
+  /** The document selection is now `current`; an actual change ends suppression. */
+  noteSelectionChange(current: SelectionSignature | null): void {
+    if (this.suppressed && !selectionSignaturesEqual(current, this.suppressed)) {
+      this.suppressed = null;
+    }
+  }
+
+  /** Whether showing the button for `current` would undo a dismissal. */
+  suppresses(current: SelectionSignature | null): boolean {
+    return this.suppressed !== null && selectionSignaturesEqual(current, this.suppressed);
+  }
+}

--- a/tests/chat-panel-copy-dismiss.test.ts
+++ b/tests/chat-panel-copy-dismiss.test.ts
@@ -1,0 +1,243 @@
+// @vitest-environment happy-dom
+//
+// #377 regression tests for the floating selection-Copy button's dismissal
+// wiring: these drive a real ChatPanel through document-level mousedown /
+// mouseup / selectionchange events and the button's own click flow. The
+// document selection and client rects are stubbed (happy-dom has no layout),
+// which is exactly the seam the production code reads through.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatPanel } from "../app/src/renderer/chat/chat-panel.js";
+
+interface FakeSelection {
+  isCollapsed: boolean;
+  rangeCount: number;
+  anchorNode: Node | null;
+  anchorOffset: number;
+  focusNode: Node | null;
+  focusOffset: number;
+  getRangeAt: (i: number) => unknown;
+  removeAllRanges: () => void;
+}
+
+const COLLAPSED: FakeSelection = {
+  isCollapsed: true,
+  rangeCount: 0,
+  anchorNode: null,
+  anchorOffset: 0,
+  focusNode: null,
+  focusOffset: 0,
+  getRangeAt: () => {
+    throw new Error("no range");
+  },
+  removeAllRanges: () => {},
+};
+
+let currentSelection: FakeSelection = COLLAPSED;
+
+function makeSelection(container: HTMLElement, text: string): FakeSelection {
+  const node = document.createTextNode(text);
+  container.appendChild(node);
+  const range = {
+    commonAncestorContainer: node,
+    getBoundingClientRect: () => ({
+      top: 100,
+      bottom: 120,
+      left: 100,
+      right: 300,
+      width: 200,
+      height: 20,
+    }),
+    cloneContents: () => {
+      const frag = document.createDocumentFragment();
+      frag.appendChild(document.createTextNode(text));
+      return frag;
+    },
+  };
+  return {
+    isCollapsed: false,
+    rangeCount: 1,
+    anchorNode: node,
+    anchorOffset: 0,
+    focusNode: node,
+    focusOffset: text.length,
+    getRangeAt: () => range,
+    removeAllRanges: vi.fn(),
+  };
+}
+
+function setup(): { container: HTMLElement; btn: HTMLButtonElement } {
+  const container = document.createElement("div");
+  // happy-dom has no layout: give the chat scrollport a real viewport band so
+  // computeCopyButtonPlacement sees the selection as visible inside it.
+  container.getBoundingClientRect = () =>
+    ({ top: 0, bottom: 700, left: 0, right: 900 }) as DOMRect;
+  document.body.appendChild(container);
+  new ChatPanel(container);
+  const btn = document.querySelector<HTMLButtonElement>(".chat-copy-btn")!;
+  expect(btn).not.toBeNull();
+  return { container, btn };
+}
+
+function fire(target: EventTarget, type: string): void {
+  target.dispatchEvent(new MouseEvent(type, { bubbles: true }));
+}
+
+function selectionchange(): void {
+  document.dispatchEvent(new Event("selectionchange"));
+}
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+  currentSelection = COLLAPSED;
+  vi.spyOn(window, "getSelection").mockImplementation(
+    () => currentSelection as unknown as Selection,
+  );
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("copy button dismissal on click-elsewhere (#377)", () => {
+  it("stays dismissed after a click that leaves the selection intact (chrome / input / scrollbar)", () => {
+    const { container, btn } = setup();
+    currentSelection = makeSelection(container, "hello world");
+    selectionchange();
+    expect(btn.hidden).toBe(false);
+
+    // Click on something non-selectable: mousedown hides, no selectionchange
+    // fires, and the mouseup re-validation used to bring the button back.
+    fire(document.body, "mousedown");
+    expect(btn.hidden).toBe(true);
+    fire(document.body, "mouseup");
+    expect(btn.hidden).toBe(true);
+
+    // Later re-validations (scroll, textarea-internal selectionchange) must
+    // not resurrect it either while the selection is unchanged.
+    selectionchange();
+    expect(btn.hidden).toBe(true);
+  });
+
+  it("re-shows for a genuinely new selection after a dismissal", () => {
+    const { container, btn } = setup();
+    currentSelection = makeSelection(container, "first");
+    selectionchange();
+    fire(document.body, "mousedown");
+    fire(document.body, "mouseup");
+    expect(btn.hidden).toBe(true);
+
+    currentSelection = makeSelection(container, "second");
+    selectionchange();
+    expect(btn.hidden).toBe(false);
+  });
+
+  it("re-shows when the same text is re-selected via a drag (collapse lifts suppression)", () => {
+    const { container, btn } = setup();
+    const sel = makeSelection(container, "same text");
+    currentSelection = sel;
+    selectionchange();
+    fire(document.body, "mousedown");
+    fire(document.body, "mouseup");
+    expect(btn.hidden).toBe(true);
+
+    // Drag over the same text again: mousedown, the browser collapses the
+    // selection, the drag rebuilds the identical range, mouseup.
+    fire(document.body, "mousedown");
+    currentSelection = COLLAPSED;
+    selectionchange();
+    currentSelection = sel;
+    selectionchange();
+    fire(document.body, "mouseup");
+    expect(btn.hidden).toBe(false);
+  });
+});
+
+describe("copy button dismissal after clicking it (#377)", () => {
+  function stubClipboard(ok: boolean): ReturnType<typeof vi.fn> {
+    const writeText = ok
+      ? vi.fn().mockResolvedValue(undefined)
+      : vi.fn().mockRejectedValue(new Error("denied"));
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    return writeText;
+  }
+
+  it("shows a confirmation beat then dismisses and clears the selection", async () => {
+    const writeText = stubClipboard(true);
+    const { container, btn } = setup();
+    const sel = currentSelection = makeSelection(container, "copy me");
+    selectionchange();
+
+    fire(btn, "mousedown"); // on the button itself: must not dismiss
+    expect(btn.hidden).toBe(false);
+    btn.click();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(writeText).toHaveBeenCalledWith("copy me");
+    expect(btn.textContent).toContain("Copied");
+    expect(btn.hidden).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1200);
+    expect(btn.hidden).toBe(true);
+    expect(sel.removeAllRanges).toHaveBeenCalled();
+  });
+
+  it("dismisses honestly when the clipboard write is refused, keeping the selection", async () => {
+    stubClipboard(false);
+    const { container, btn } = setup();
+    const sel = currentSelection = makeSelection(container, "copy me");
+    selectionchange();
+
+    btn.click();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(btn.textContent).toContain("Copy failed");
+
+    await vi.advanceTimersByTimeAsync(1200);
+    expect(btn.hidden).toBe(true);
+    expect(sel.removeAllRanges).not.toHaveBeenCalled();
+
+    // The surviving selection stays dismissed on later re-validation...
+    selectionchange();
+    expect(btn.hidden).toBe(true);
+    // ...but a new selection shows the button again.
+    currentSelection = makeSelection(container, "another");
+    selectionchange();
+    expect(btn.hidden).toBe(false);
+  });
+
+  it("does not let the stale confirmation timer clobber a newer selection", async () => {
+    stubClipboard(true);
+    const { container, btn } = setup();
+    const first = currentSelection = makeSelection(container, "first");
+    selectionchange();
+    btn.click();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(btn.textContent).toContain("Copied");
+
+    // During the beat the user selects something else.
+    const second = (currentSelection = makeSelection(container, "second"));
+    selectionchange();
+    expect(btn.hidden).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1200);
+    expect(btn.hidden).toBe(false); // still up for the new selection
+    expect(btn.textContent).toContain("Copy"); // label restored
+    expect(second.removeAllRanges).not.toHaveBeenCalled();
+    expect(first.removeAllRanges).not.toHaveBeenCalled();
+  });
+
+  it("hides instead of lingering when the selection vanished before the click lands", () => {
+    stubClipboard(true);
+    const { container, btn } = setup();
+    currentSelection = makeSelection(container, "gone soon");
+    selectionchange();
+    expect(btn.hidden).toBe(false);
+
+    currentSelection = COLLAPSED;
+    btn.click();
+    expect(btn.hidden).toBe(true);
+  });
+});

--- a/tests/chat-panel-copy-dismiss.test.ts
+++ b/tests/chat-panel-copy-dismiss.test.ts
@@ -229,6 +229,57 @@ describe("copy button dismissal after clicking it (#377)", () => {
     expect(first.removeAllRanges).not.toHaveBeenCalled();
   });
 
+  it("does not clear a re-selection of the identical range made during the beat", async () => {
+    stubClipboard(true);
+    const { container, btn } = setup();
+    const sel = (currentSelection = makeSelection(container, "same range"));
+    selectionchange();
+    btn.click();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(btn.textContent).toContain("Copied");
+
+    // Within the beat the user collapses and re-selects the exact same text:
+    // identical signature, but a NEW selection the timer must not clear.
+    currentSelection = COLLAPSED;
+    selectionchange();
+    currentSelection = sel;
+    selectionchange();
+    expect(btn.hidden).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1200);
+    expect(btn.hidden).toBe(false);
+    expect(sel.removeAllRanges).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress a re-selected identical range when a slow copy fails", async () => {
+    let reject: (e: Error) => void = () => {};
+    const writeText = vi.fn().mockImplementation(
+      () => new Promise((_res, rej) => (reject = rej)),
+    );
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    const { container, btn } = setup();
+    const sel = (currentSelection = makeSelection(container, "same range"));
+    selectionchange();
+    btn.click();
+
+    // While the clipboard write is still pending, collapse and re-select the
+    // identical range. The late failure must not suppress this new selection.
+    currentSelection = COLLAPSED;
+    selectionchange();
+    currentSelection = sel;
+    selectionchange();
+
+    reject(new Error("denied"));
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1200);
+    expect(btn.hidden).toBe(false);
+    selectionchange();
+    expect(btn.hidden).toBe(false);
+  });
+
   it("hides instead of lingering when the selection vanished before the click lands", () => {
     stubClipboard(true);
     const { container, btn } = setup();

--- a/tests/copy-button.test.ts
+++ b/tests/copy-button.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   computeCopyButtonPlacement,
+  CopyButtonDismissal,
+  selectionSignaturesEqual,
   type CopyButtonInput,
+  type SelectionSignature,
 } from "../app/src/renderer/chat/copy-button.js";
 
 const VIEWPORT = { width: 1000, height: 800 };
@@ -134,5 +137,89 @@ describe("computeCopyButtonPlacement", () => {
       top: 124,
       left: 304,
     });
+  });
+});
+
+// #377: clicking anywhere outside the button must dismiss it for good, even
+// when the click leaves the document selection intact (non-selectable UI
+// chrome, the chat input, a scrollbar). Node identity stands in for real DOM
+// nodes -- the signature only ever compares by reference.
+function sig(node: unknown, a = 0, f = 5): SelectionSignature {
+  return { anchorNode: node, anchorOffset: a, focusNode: node, focusOffset: f };
+}
+
+describe("selectionSignaturesEqual", () => {
+  const node = {};
+
+  it("treats two nulls as equal and null vs a signature as different", () => {
+    expect(selectionSignaturesEqual(null, null)).toBe(true);
+    expect(selectionSignaturesEqual(null, sig(node))).toBe(false);
+    expect(selectionSignaturesEqual(sig(node), null)).toBe(false);
+  });
+
+  it("compares nodes by identity and offsets by value", () => {
+    expect(selectionSignaturesEqual(sig(node), sig(node))).toBe(true);
+    expect(selectionSignaturesEqual(sig(node), sig({}))).toBe(false);
+    expect(selectionSignaturesEqual(sig(node, 0, 5), sig(node, 0, 6))).toBe(false);
+    expect(selectionSignaturesEqual(sig(node, 1, 5), sig(node, 0, 5))).toBe(false);
+  });
+});
+
+describe("CopyButtonDismissal", () => {
+  const r1 = sig({});
+  const r2 = sig({});
+
+  it("suppresses nothing until a dismissal happens", () => {
+    const d = new CopyButtonDismissal();
+    expect(d.suppresses(r1)).toBe(false);
+    expect(d.suppresses(null)).toBe(false);
+  });
+
+  it("keeps the button dismissed when a click leaves the selection untouched (non-selectable chrome)", () => {
+    const d = new CopyButtonDismissal();
+    d.suppress(r1);
+    // No selectionchange fires at all -- mouseup re-validation must not re-show.
+    expect(d.suppresses(r1)).toBe(true);
+  });
+
+  it("keeps the button dismissed when only a text control's internal selection changes (chat input click)", () => {
+    const d = new CopyButtonDismissal();
+    d.suppress(r1);
+    // Chromium fires document selectionchange for textarea caret moves, but the
+    // document selection itself is unchanged.
+    d.noteSelectionChange(r1);
+    expect(d.suppresses(r1)).toBe(true);
+  });
+
+  it("does not suppress a different selection", () => {
+    const d = new CopyButtonDismissal();
+    d.suppress(r1);
+    expect(d.suppresses(r2)).toBe(false);
+  });
+
+  it("lifts suppression when the selection collapses, so re-selecting the same text shows again", () => {
+    const d = new CopyButtonDismissal();
+    d.suppress(r1);
+    // Drag re-select: browser collapses the selection on mousedown-in-text...
+    d.noteSelectionChange(null);
+    // ...then the drag rebuilds the exact same range.
+    d.noteSelectionChange(r1);
+    expect(d.suppresses(r1)).toBe(false);
+  });
+
+  it("lifts suppression when the selection actually changes (new drag or keyboard extension)", () => {
+    const d = new CopyButtonDismissal();
+    d.suppress(r1);
+    d.noteSelectionChange(r2);
+    expect(d.suppresses(r2)).toBe(false);
+    expect(d.suppresses(r1)).toBe(false);
+  });
+
+  it("clears any prior suppression when dismissing with no selection", () => {
+    const d = new CopyButtonDismissal();
+    d.suppress(r1);
+    d.suppress(null);
+    expect(d.suppresses(r1)).toBe(false);
+    expect(d.suppresses(null)).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #377

The chat's floating selection-Copy button had two missing dismissal paths (reported on v0.5.1, macOS/arm64):

1. **Click-elsewhere didn't dismiss.** `mousedown` outside the button hid it, but the `mouseup` re-validation brought it straight back whenever the click left the document selection intact -- which is most clicks that don't land on selectable text: non-selectable UI chrome, the chat input (Chromium keeps the document selection and only moves the textarea's internal caret), scrollbars. So in practice the button only went away when you selected a *different* piece of text -- exactly the reported symptom.

2. **Clicking the button could leave it up forever.** Dismissal lived only in `navigator.clipboard.writeText(...).then(...)` with no rejection handler, so an unavailable/refused clipboard write meant no feedback and no dismissal (and a vanished selection hit an early return that also left it visible).

### The fix

- New DOM-free `CopyButtonDismissal` state in `copy-button.ts` (same pure-helper pattern as `computeCopyButtonPlacement` from #299/#339): dismissing records the selection's signature (anchor/focus node + offsets), and the button may only re-show once the document selection actually changes. The collapse at the start of a drag lifts suppression, so re-selecting the same text still shows the button; a click that leaves the selection untouched stays dismissed.
- The click path now goes through the existing never-throws `copyToClipboard` helper (from `update-banner.ts`): success keeps the current "✓ Copied" beat then hides and clears the selection; failure shows an honest "✗ Copy failed" beat, dismisses, and keeps the selection so Cmd/Ctrl+C still works.
- The confirmation-beat timer re-validates instead of unconditionally hiding: it snapshots what was copied at click time and only clears the selection if it's still the live one, so a newer selection made during the beat is neither cleared nor suppressed. A selection epoch (bumped on collapse) distinguishes a re-selected identical range from the original.

### Tests

- 9 new unit tests for the pure dismissal state (`tests/copy-button.test.ts`).
- New `tests/chat-panel-copy-dismiss.test.ts` (happy-dom) drives a real `ChatPanel` through the reported repro -- document-level `mousedown`/`mouseup`/`selectionchange` plus the button click flow with a stubbed clipboard and fake timers. 6 of the initial 7 fail against the pre-fix code.
- Full suite: 1315 passing; root typecheck and `app` tsc clean.

Two adversarial review passes were run over the diff; findings on stale-timer clobbering, live-`Selection` capture, and the identical-range re-selection race were fixed (second and third commits). Not addressed on purpose: a clipboard promise that never settles (Chromium clipboard writes settle promptly; the wrapper already catches sync throws and API absence) and overlapping in-flight copies relabeling each other (needs two full click cycles within the milliseconds a write takes to settle; worst case is a sub-1.2s label glitch since the timers re-validate).

**Not live-eyeballed**: this is renderer/UI behavior; the wiring tests stub the document selection and client rects (happy-dom has no layout), and the Chromium selection semantics they encode (textarea clicks firing `selectionchange` without touching the document selection, chrome clicks firing nothing) should get a quick human eyeball on macOS before merge.

