### PR TITLE
Make Galaxy MCP reconnect robust on resume / long idle

### DIFF
--- a/extensions/loom/context.ts
+++ b/extensions/loom/context.ts
@@ -264,6 +264,25 @@ once — don't badger.
 
 Galaxy is connected.
 
+### If a Galaxy tool reports it's not connected
+
+The live Galaxy MCP connection is per-session and does **not** survive a resume
+or a long idle period, even though the credentials above stay configured. So a
+\`galaxy_*\` tool can come back "not connected" / "connection closed" / with a
+transport timeout at any time -- most often on the first Galaxy action after
+resuming this project. That does **not** mean Galaxy is unavailable; it means
+this session's connection needs to be re-established.
+
+When it happens -- and before you ever tell the user Galaxy is disconnected:
+1. Call \`galaxy_connect()\` first to re-bind this session. Do NOT report a
+   disconnection you haven't tried to fix.
+2. If \`galaxy_connect()\` itself fails with a transport error (connection
+   closed / timed out, not an auth error), tell the user to run
+   \`/mcp reconnect galaxy\` (no restart needed), then retry.
+
+Never report "Galaxy is disconnected" as a final answer without attempting
+\`galaxy_connect()\` in the same turn.
+
 ### Resuming existing Galaxy work ("pick up where I left off")
 
 If the user asks to connect to, catch up on, or resume work they did in

--- a/extensions/loom/galaxy-transport-error.ts
+++ b/extensions/loom/galaxy-transport-error.ts
@@ -1,0 +1,54 @@
+// Mid-session, the MCP client SDK can lose its stdio transport to the
+// galaxy-mcp subprocess. After that every galaxy_* call comes back as
+// "Failed to call tool: <transport error>", and the adapter never self-heals
+// because it still thinks the connection is up. The fix on the user's side is
+// to reconnect the MCP server (/mcp reconnect galaxy), not to re-authenticate
+// Galaxy -- so we detect that specific failure and surface an actionable hint.
+//
+// Crucially this must NOT match galaxy-mcp's own "Not connected to Galaxy.
+// Authenticate via OAuth or run connect()..." error, which is an auth problem
+// that /mcp reconnect won't fix.
+
+const TRANSPORT_ERROR_PATTERNS: RegExp[] = [
+  /not connected(?!\s+to\s+galaxy)/i, // bare SDK "Not connected"; exclude the verbose auth error
+  /connection closed/i, // -32000
+  /-32000/,
+  /request timed out/i, // -32001
+  /-32001/,
+];
+
+export const GALAXY_RECONNECT_NUDGE =
+  "Galaxy MCP connection dropped mid-session. Run /mcp reconnect galaxy to restore it (no restart needed).";
+
+export function isGalaxyTransportError(
+  toolName: string | undefined,
+  text: string | undefined,
+): boolean {
+  if (!toolName || !toolName.startsWith("galaxy_")) return false;
+  if (!text) return false;
+  return TRANSPORT_ERROR_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export interface TransportNudgeDecision {
+  showNudge: boolean;
+  armed: boolean;
+}
+
+// Decide whether to surface the reconnect nudge for one galaxy tool result,
+// given whether we're currently "armed". Fire once per outage, then disarm so a
+// retry loop doesn't spam; re-arm after any healthy galaxy result so a later
+// outage nudges again.
+export function transportNudgeDecision(
+  armed: boolean,
+  toolName: string | undefined,
+  text: string | undefined,
+): TransportNudgeDecision {
+  if (isGalaxyTransportError(toolName, text)) {
+    return { showNudge: armed, armed: false };
+  }
+  if (toolName?.startsWith("galaxy_")) {
+    // A galaxy result that isn't a transport error means the pipe is alive.
+    return { showNudge: false, armed: true };
+  }
+  return { showNudge: false, armed };
+}

--- a/extensions/loom/index.ts
+++ b/extensions/loom/index.ts
@@ -30,6 +30,7 @@ import { registerExecGuard } from "./exec-guard";
 import { registerSandbox } from "./sandbox";
 import { isLocalExecDisabled } from "./local-exec";
 import { registerSecretRedaction } from "./secret-redaction";
+import { GALAXY_RECONNECT_NUDGE, transportNudgeDecision } from "./galaxy-transport-error";
 import * as fs from "fs";
 import { getState, getNotebookPath, getNotebookWidgetMode, setNotebookWidgetMode } from "./state";
 import {
@@ -357,6 +358,11 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
   // ─────────────────────────────────────────────────────────────────────────────
   const toolStartTimes = new Map<string, number>();
 
+  // Armed = a reconnect nudge is allowed to fire. We fire once when the MCP
+  // transport drops, then disarm so a galaxy retry loop doesn't spam the user,
+  // and re-arm after any healthy galaxy result.
+  let transportNudgeArmed = true;
+
   pi.on("tool_execution_start", async (event, ctx) => {
     if (event.toolName?.startsWith("galaxy_")) {
       const label = event.toolName.replace(/^galaxy_/, "").replace(/_/g, " ");
@@ -413,7 +419,26 @@ export default function galaxyAnalystExtension(pi: ExtensionAPI): void {
     }
   });
 
-  pi.on("tool_result", async (event, _ctx) => {
+  pi.on("tool_result", async (event, ctx) => {
+    // Surface an actionable hint when a galaxy_* call fails because the MCP
+    // transport died mid-session (bare "Not connected" / -32000 / -32001) --
+    // the user can recover with /mcp reconnect galaxy, no restart needed. This
+    // is the deterministic backstop for the connection-liveness steer in
+    // buildGalaxyContextBlock: even a model that ignores the steer produces the
+    // recovery incantation for the user. hasUI-guard + try/catch mirror the
+    // galaxy poller notifier -- a headless/stale ctx must not throw here.
+    try {
+      const firstContent = event.content?.[0];
+      const resultText = firstContent && "text" in firstContent ? firstContent.text : undefined;
+      const decision = transportNudgeDecision(transportNudgeArmed, event.toolName, resultText);
+      transportNudgeArmed = decision.armed;
+      if (decision.showNudge && ctx.hasUI) {
+        ctx.ui.notify(GALAXY_RECONNECT_NUDGE, "warning");
+      }
+    } catch {
+      /* stale/headless context -- a dropped reconnect hint is fine */
+    }
+
     if (event.toolName === "galaxy_connect") {
       try {
         const firstContent = event.content?.[0];

--- a/tests/galaxy-reconnect-steer-context.test.ts
+++ b/tests/galaxy-reconnect-steer-context.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("../extensions/loom/config", () => ({
+  loadConfig: () => ({ executionMode: "hybrid" }),
+}));
+
+import { buildGalaxyContextBlock } from "../extensions/loom/context";
+
+let prev: Record<string, string | undefined>;
+
+beforeEach(() => {
+  prev = { url: process.env.GALAXY_URL, key: process.env.GALAXY_API_KEY };
+  process.env.GALAXY_URL = "https://galaxy.test";
+  process.env.GALAXY_API_KEY = "k";
+});
+
+afterEach(() => {
+  process.env.GALAXY_URL = prev.url;
+  process.env.GALAXY_API_KEY = prev.key;
+});
+
+describe("buildGalaxyContextBlock reconnect steer", () => {
+  it("steers the model to call galaxy_connect() before reporting a disconnection", () => {
+    const block = buildGalaxyContextBlock();
+    // The whole point of Scott's report: never dead-end on "disconnected".
+    expect(block).toContain("galaxy_connect()");
+    expect(block).toMatch(/never report.*disconnected/i);
+  });
+
+  it("names the /mcp reconnect galaxy fallback for a dead transport", () => {
+    const block = buildGalaxyContextBlock();
+    expect(block).toContain("/mcp reconnect galaxy");
+  });
+
+  it("explains the connection does not survive resume/idle", () => {
+    const block = buildGalaxyContextBlock();
+    expect(block).toMatch(/does \*\*not\*\* survive a resume/i);
+  });
+
+  it("does not add reconnect guidance when Galaxy is not connected", () => {
+    delete process.env.GALAXY_URL;
+    delete process.env.GALAXY_API_KEY;
+    const block = buildGalaxyContextBlock();
+    expect(block).not.toContain("/mcp reconnect galaxy");
+  });
+});

--- a/tests/galaxy-transport-error.test.ts
+++ b/tests/galaxy-transport-error.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  GALAXY_RECONNECT_NUDGE,
+  isGalaxyTransportError,
+  transportNudgeDecision,
+} from "../extensions/loom/galaxy-transport-error.js";
+
+describe("isGalaxyTransportError", () => {
+  it("matches the bare SDK 'Not connected' on a galaxy_* tool", () => {
+    expect(
+      isGalaxyTransportError("galaxy_get_histories", "Failed to call tool: Not connected"),
+    ).toBe(true);
+  });
+
+  it("matches the -32001 request-timeout transport error", () => {
+    expect(
+      isGalaxyTransportError(
+        "galaxy_download_dataset",
+        "Failed to call tool: MCP error -32001: Request timed out",
+      ),
+    ).toBe(true);
+  });
+
+  it("matches the -32000 connection-closed transport error", () => {
+    expect(
+      isGalaxyTransportError(
+        "galaxy_get_history_contents",
+        "Failed to call tool: MCP error -32000: Connection closed",
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT match galaxy-mcp's own verbose auth error (needs galaxy_connect, not /mcp reconnect)", () => {
+    expect(
+      isGalaxyTransportError(
+        "galaxy_get_histories",
+        "Error: Not connected to Galaxy. Authenticate via OAuth or run connect() with your Galaxy URL and API key.",
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores non-galaxy tools even with a matching message", () => {
+    expect(isGalaxyTransportError("bash", "Failed to call tool: Not connected")).toBe(false);
+  });
+
+  it("ignores healthy galaxy results", () => {
+    expect(
+      isGalaxyTransportError("galaxy_get_histories", '{"histories": [], "success": true}'),
+    ).toBe(false);
+  });
+
+  it("handles missing tool name / text", () => {
+    expect(isGalaxyTransportError(undefined, "Not connected")).toBe(false);
+    expect(isGalaxyTransportError("galaxy_get_histories", undefined)).toBe(false);
+  });
+});
+
+describe("transportNudgeDecision", () => {
+  it("fires the nudge once on the first transport error and disarms", () => {
+    const d = transportNudgeDecision(
+      true,
+      "galaxy_get_histories",
+      "Failed to call tool: Not connected",
+    );
+    expect(d.showNudge).toBe(true);
+    expect(d.armed).toBe(false);
+  });
+
+  it("suppresses repeat nudges while disarmed (no spam during the retry loop)", () => {
+    const d = transportNudgeDecision(
+      false,
+      "galaxy_get_histories",
+      "Failed to call tool: Not connected",
+    );
+    expect(d.showNudge).toBe(false);
+    expect(d.armed).toBe(false);
+  });
+
+  it("re-arms after a healthy galaxy call so a later outage nudges again", () => {
+    const d = transportNudgeDecision(false, "galaxy_get_histories", '{"success": true}');
+    expect(d.showNudge).toBe(false);
+    expect(d.armed).toBe(true);
+  });
+
+  it("leaves state untouched for unrelated (non-galaxy) results", () => {
+    expect(transportNudgeDecision(true, "bash", "anything")).toEqual({
+      showNudge: false,
+      armed: true,
+    });
+    expect(transportNudgeDecision(false, "read", "anything")).toEqual({
+      showNudge: false,
+      armed: false,
+    });
+  });
+
+  it("exposes an actionable nudge message pointing at /mcp reconnect galaxy", () => {
+    expect(GALAXY_RECONNECT_NUDGE).toMatch(/\/mcp reconnect galaxy/);
+  });
+});


### PR DESCRIPTION
## What / why

Scott hit a bad failure mode: after leaving an Orbit project idle for >1 day and coming back, Galaxy MCP was "disconnected, cached tools only", and the agent kept **reporting** that as a final answer instead of trying to reconnect. He eventually recovered only by explicitly telling it to try -- proving the reconnect works; the model just never attempted it.

Two things compound:

1. **"Creds exist" is treated as "connected."** Every `--continue` resume is a freshly spawned brain (`app/src/main/agent.ts`), so the live galaxy-mcp binding is a clean slate -- but the model replays the transcript and believes it's still connected, and the status logic keys off `GALAXY_URL && GALAXY_API_KEY`, not liveness.
2. **Nothing prompts a reconnect on resume unless creds *changed*.** The startup greeting (the only thing that says "call `galaxy_connect()`") is suppressed on resume, and the sole resume-time nudge (`galaxy-cred-drift.ts`) fires only on credential *drift*. Scott's creds never changed, so it stayed silent.

Architectural constraint that shapes the fix: **Loom's extension can't reconnect MCP itself.** pi has no MCP support -- it's all in the third-party `pi-mcp-adapter`, whose reconnect/status primitives are private to that extension's closure (no events, no programmatic `/mcp reconnect`, no forced tool invocation). Our only levers are nudging the model and surfacing hints. So this PR makes the *model* reliably attempt the reconnect rather than dead-ending.

## Changes

- **Behavior steer** (`context.ts`, connected-state block): the live connection is per-session and doesn't survive resume/idle; call `galaxy_connect()` before ever reporting a disconnection; fall back to `/mcp reconnect galaxy` only if `galaxy_connect` itself hits a transport error. Never report "disconnected" as a final answer without trying first.
- **Deterministic reactive hint** (`galaxy-transport-error.ts` + `index.ts` tool_result hook): when a `galaxy_*` call fails with a genuine transport error (bare "Not connected" / -32000 / -32001 -- explicitly excluding galaxy-mcp's own auth error), toast the user the recovery incantation. Fires once per outage, re-arms after a healthy result, `hasUI`-guarded. This is the backstop for models that ignore the steer. (Revives the unmerged `fix/199` work.)

## Tests

16 new tests (transport-error classifier + arm/disarm state machine, and the steer's presence/absence in the context block). Full root suite green (1180 passing), root + app typecheck clean.

## Not in scope

- A *forced* `galaxy_connect()` turn on every resume (would add a model turn to every resume; galaxy-mcp's own "run connect()" error already self-heals the common creds-unbound case).
- Honest liveness in the footer indicator -- already tracked as #362.

Issue for Scott's report to be linked once filed.