### PR TITLE
Link the docs site from the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Loom & Orbit
 
+> [!TIP]
+> **📖 See the docs & live demos → [galaxyproject.github.io/loom](https://galaxyproject.github.io/loom/)**
+> — *Agentic Science with Galaxy*: an overview of Orbit, Loom, and Galaxy MCP, an animated walkthrough of real analyses, and getting-started guides.
+
 An AI research harness for [Galaxy](https://galaxyproject.org) bioinformatics, built on [Pi.dev](https://pi.dev).
 
 Loom turns a working directory into a co-scientist project: ad-hoc exploration, plans, executed steps, interpretations, and follow-up plans all accumulate as markdown in a single, durable, git-tracked `notebook.md`. The agent reads and writes that notebook directly; there is no parallel structured-state store. When Galaxy is configured the agent surveys the workflow registry and tool catalog while drafting plans and routes individual steps to Galaxy or local execution as appropriate.


### PR DESCRIPTION
Follow-up to #382. Adds a highlighted `[!TIP]` callout at the very top of the README pointing to the new docs site at https://galaxyproject.github.io/loom/ — an overview of Orbit, Loom, and Galaxy MCP with the animated walkthrough and getting-started guides. (This commit missed the #382 merge.)