### PR TITLE
Add FAQ + a 'Built on Galaxy' grounding section to the docs site

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -105,6 +105,10 @@ const faqs = [
     a: `The notebook is the project. Instead of decisions living in disposable chat, every plan, parameter table, and result is written to a durable, git-tracked <code>notebook.md</code> you can inspect, edit, and diff. Multi-step plans are drafted and approved — with the exact parameters shown — before anything runs.`,
   },
   {
+    q: 'Does this replace the Galaxy interface?',
+    a: `No — it's an additive way to work with Galaxy, not a replacement, and that's the point. Galaxy stays the substrate: every heavy step runs as a real Galaxy job or workflow invocation, so the analysis itself lands in your Galaxy history — fully reproducible, re-runnable, and shareable like any other Galaxy work. On top of that, Loom keeps a durable record of the <em>reasoning</em> — the plans, parameter choices, and interpretation — in <code>notebook.md</code> as it happens. So <strong>both halves are transparent and reproducible</strong>: the conversation and decisions in the notebook <em>and</em> the actual analysis in Galaxy. You can always open Galaxy and re-run exactly what the agent did — it's still Galaxy.`,
+  },
+  {
     q: 'Can I drive Galaxy from Claude Desktop or another agent — not just Orbit?',
     a: `Yes. <a href="${url('/docs/galaxy-mcp')}">Galaxy MCP</a> (<code>uvx galaxy-mcp</code>) is a standalone Model Context Protocol server — point any MCP-capable client (Claude Desktop, Orbit, others) at a Galaxy instance and it can search and run tools, drive workflows, and manage histories. Orbit and Loom use it under the hood.`,
   },

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -87,6 +87,24 @@ const mcpConfig = `{
   }
 }`;
 
+const grounded = [
+  {
+    title: 'Real, versioned tools',
+    body: "The agent works from Galaxy's actual catalog — thousands of containerized, version-pinned tools — through Galaxy MCP. What it runs is installed and reproducible, not a name it made up.",
+    icon: '<rect x="4" y="4" width="7" height="7" rx="1"/><rect x="13" y="4" width="7" height="7" rx="1"/><rect x="4" y="13" width="7" height="7" rx="1"/><rect x="13" y="13" width="7" height="7" rx="1"/>',
+  },
+  {
+    title: 'Community workflows, not reinvented',
+    body: 'When a curated IWC workflow fits the task, the agent finds and runs it instead of assembling a pipeline from scratch — decades of best-practice, tested methods as the default.',
+    icon: '<circle cx="6" cy="6" r="2.5"/><circle cx="18" cy="6" r="2.5"/><circle cx="12" cy="18" r="2.5"/><path d="M6 8.5v2a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2v-2M12 12.5v3"/>',
+  },
+  {
+    title: 'Reproducible by contract',
+    body: "Every step executes as a real Galaxy job or workflow invocation, with Galaxy's provenance, tool versions, and containers behind it — re-runnable and shareable in Galaxy, by construction.",
+    icon: '<path d="M12 3 4 6v6c0 5 3.5 8 8 9 4.5-1 8-4 8-9V6l-8-3Z"/><path d="m9 12 2 2 4-4"/>',
+  },
+];
+
 const faqs = [
   {
     q: 'Why two names — Orbit and Loom?',
@@ -107,6 +125,10 @@ const faqs = [
   {
     q: 'Does this replace the Galaxy interface?',
     a: `No — it's an additive way to work with Galaxy, not a replacement, and that's the point. Galaxy stays the substrate: every heavy step runs as a real Galaxy job or workflow invocation, so the analysis itself lands in your Galaxy history — fully reproducible, re-runnable, and shareable like any other Galaxy work. On top of that, Loom keeps a durable record of the <em>reasoning</em> — the plans, parameter choices, and interpretation — in <code>notebook.md</code> as it happens. So <strong>both halves are transparent and reproducible</strong>: the conversation and decisions in the notebook <em>and</em> the actual analysis in Galaxy. You can always open Galaxy and re-run exactly what the agent did — it's still Galaxy.`,
+  },
+  {
+    q: "Won't the AI just hallucinate tools and parameters?",
+    a: `That's the failure mode Galaxy grounding is built to avoid. Instead of inventing a pipeline from text, the agent works through Galaxy MCP against your server's real tool catalog and the curated <strong>IWC</strong> workflow collection — so the tools it runs actually exist, are version-pinned, and are containerized. It drafts the plan with the exact tools and parameters for you to approve <em>before</em> anything runs, and the run itself is a real Galaxy job with full provenance. The output is grounded in Galaxy's contracts, not a plausible-looking guess.`,
   },
   {
     q: 'Can I drive Galaxy from Claude Desktop or another agent — not just Orbit?',
@@ -280,6 +302,34 @@ const faqs = [
         Galaxy histories remain the computational truth. <code>notebook.md</code> is the durable
         working record — <strong>Galaxy is the substrate, and Loom is one live authoring shell.</strong>
       </p>
+    </div>
+  </section>
+
+  <!-- ======================================================== GROUNDED -->
+  <section id="grounded" class="grounded">
+    <div class="wrap">
+      <div class="section-head">
+        <span class="eyebrow" style="color: var(--color-galaxy-primary)">Grounded, not guessing</span>
+        <h2>Built on Galaxy's tools, workflows, and contracts</h2>
+        <p class="section-sub">
+          Generic AI invents plausible-looking pipelines — fake tool names, wrong parameters,
+          workflows that won't run. Orbit builds on Galaxy's contracts instead, so what the
+          agent proposes is real, versioned, and reproducible.
+        </p>
+      </div>
+      <div class="grounded-grid">
+        {
+          grounded.map((g) => (
+            <div class="feat card gold-hover">
+              <div class="feat__icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" set:html={g.icon} />
+              </div>
+              <h4>{g.title}</h4>
+              <p>{g.body}</p>
+            </div>
+          ))
+        }
+      </div>
     </div>
   </section>
 
@@ -521,6 +571,10 @@ loom</code></pre>
   .method__foot strong { color: #fff; }
   .method__foot code { background: color-mix(in srgb, #fff 10%, transparent); color: var(--color-galaxy-gold); }
 
+  /* ---- grounded (built on Galaxy) ---- */
+  .grounded { background: var(--color-light-bg); padding: clamp(4rem, 8vw, 6.5rem) 0; }
+  .grounded-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.2rem; }
+
   /* ---- code card ---- */
   .codecard { background: #1b2030; border: 1px solid rgba(255, 255, 255, 0.1); border-radius: 0.7rem; overflow: hidden; box-shadow: 0 30px 60px -30px rgba(0, 0, 0, 0.6); margin: 0; }
   .codecard__hd { display: flex; align-items: center; gap: 0.6rem; padding: 0.55rem 0.8rem; background: rgba(255, 255, 255, 0.03); border-bottom: 1px solid rgba(255, 255, 255, 0.07); }
@@ -598,11 +652,11 @@ loom</code></pre>
     .hero__wrap { grid-template-columns: 1fr; }
     .hero__lede { max-width: 46ch; }
     .method__grid, .mcp__grid, .docs-cta__inner { grid-template-columns: 1fr; }
-    .pillars, .feat-grid, .install__grid { grid-template-columns: 1fr; }
+    .pillars, .feat-grid, .install__grid, .grounded-grid { grid-template-columns: 1fr; }
     .docs-cta__cards { grid-template-columns: 1fr; }
   }
   @media (min-width: 641px) and (max-width: 960px) {
-    .feat-grid, .install__grid { grid-template-columns: repeat(2, 1fr); }
+    .feat-grid, .install__grid, .grounded-grid { grid-template-columns: repeat(2, 1fr); }
     .pillars { grid-template-columns: repeat(3, 1fr); }
   }
 </style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -86,6 +86,41 @@ const mcpConfig = `{
     }
   }
 }`;
+
+const faqs = [
+  {
+    q: 'Why two names — Orbit and Loom?',
+    a: `<strong>Loom is the brain; Orbit is the shell.</strong> Loom is the agent runtime — the system-prompt context, Galaxy routing and invocation tracking, the skills system, and the RPC contract — and you can run it straight from a terminal with <code>loom</code>. <strong>Orbit</strong> is the Electron desktop app that wraps that same brain in a chat + notebook + activity layout. Same brain, two ways to observe it; future shells (a Galaxy-embedded UI, a hosted mode) talk to it over the same RPC contract. The names trace the cosmology: the cosmic web weaves galaxies along filaments of dark matter — Loom weaves your research record the same way, and Orbit is the electron shell you observe it from.`,
+  },
+  {
+    q: 'Do I need a Galaxy account to try it?',
+    a: `No — Loom is useful for local exploration and planning before you connect anything. But Galaxy is the primary execution path: add a Galaxy URL and API key and the agent surveys the workflow registry and tool catalog while drafting plans, then routes the heavy steps to Galaxy and tracks each invocation in the notebook.`,
+  },
+  {
+    q: 'Which AI models can I use?',
+    a: `Bring your own. Anthropic, OpenAI, Google (Gemini), Mistral, Groq, xAI, DeepSeek, local Ollama, or any OpenAI-compatible endpoint — with live token, cost, and context-window meters in the footer. You supply the key; nothing is locked to one vendor.`,
+  },
+  {
+    q: 'How is this different from just chatting with an AI about my analysis?',
+    a: `The notebook is the project. Instead of decisions living in disposable chat, every plan, parameter table, and result is written to a durable, git-tracked <code>notebook.md</code> you can inspect, edit, and diff. Multi-step plans are drafted and approved — with the exact parameters shown — before anything runs.`,
+  },
+  {
+    q: 'Can I drive Galaxy from Claude Desktop or another agent — not just Orbit?',
+    a: `Yes. <a href="${url('/docs/galaxy-mcp')}">Galaxy MCP</a> (<code>uvx galaxy-mcp</code>) is a standalone Model Context Protocol server — point any MCP-capable client (Claude Desktop, Orbit, others) at a Galaxy instance and it can search and run tools, drive workflows, and manage histories. Orbit and Loom use it under the hood.`,
+  },
+  {
+    q: 'Is it open source? What does it cost?',
+    a: `Loom, Orbit, and Galaxy MCP are open source (MIT). There's no license fee — you pay only for your own model usage (your API key) and whatever Galaxy compute your account uses.`,
+  },
+  {
+    q: 'What platforms does Orbit run on?',
+    a: `macOS (Apple Silicon; signed &amp; notarized), Linux (<code>.deb</code> / <code>.rpm</code> / <code>.zip</code>), and Windows. The Windows build is remote-only (Galaxy execution, no local shell) and currently ships as a <code>.zip</code> while a signed installer is finalized. Prefer the terminal? The <code>loom</code> CLI runs anywhere Node 22.19+ does.`,
+  },
+  {
+    q: 'Is it ready for everyday use?',
+    a: `Orbit and Loom are in active development — think capable beta. The core loop (plan, route to Galaxy, track invocations, record the notebook) works today; end-to-end validation against live Galaxy servers is ongoing. Galaxy credentials are stored in your OS keychain in Orbit, and local execution is confined to your working directory by default.`,
+  },
+];
 ---
 
 <Base>
@@ -303,6 +338,29 @@ loom</code></pre>
     </div>
   </section>
 
+  <!-- ============================================================ FAQ -->
+  <section id="faq" class="faq">
+    <div class="wrap">
+      <div class="section-head">
+        <span class="eyebrow" style="color: var(--color-galaxy-primary)">FAQ</span>
+        <h2>Questions, answered</h2>
+      </div>
+      <div class="faq-list">
+        {
+          faqs.map((f, i) => (
+            <details class="faq-item" open={i === 0}>
+              <summary class="faq-q">
+                <span>{f.q}</span>
+                <svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9 6 6 6-6" /></svg>
+              </summary>
+              <div class="faq-a" set:html={f.a} />
+            </details>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
   <!-- =========================================================== DOCS -->
   <section class="docs-cta bg-space grain">
     <div class="wrap docs-cta__inner">
@@ -492,6 +550,35 @@ loom</code></pre>
   .icard__btn { justify-content: center; text-align: center; font-size: 0.86rem; margin-bottom: 0.7rem; }
   .icard__hint { font-size: 0.8rem; color: var(--color-galaxy-grey); }
   .icard__hint code { font-family: var(--font-mono); background: #fff; padding: 0.05em 0.3em; border-radius: 0.25rem; font-size: 0.86em; }
+
+  /* ---- faq ---- */
+  .faq { padding: clamp(4rem, 8vw, 6.5rem) 1.5rem; }
+  .faq-list { max-width: 48rem; margin: 0 auto; display: flex; flex-direction: column; gap: 0.7rem; }
+  .faq-item {
+    background: #fff;
+    border: 1px solid color-mix(in srgb, var(--color-galaxy-primary) 12%, transparent);
+    border-radius: 0.7rem; overflow: hidden;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  }
+  .faq-item[open] {
+    border-color: color-mix(in srgb, var(--color-galaxy-gold) 45%, transparent);
+    box-shadow: 0 12px 30px -18px rgba(0, 0, 0, 0.2);
+  }
+  .faq-q {
+    display: flex; align-items: center; justify-content: space-between; gap: 1rem;
+    cursor: pointer; list-style: none;
+    padding: 1.05rem 1.3rem;
+    font-weight: 700; font-size: 1.02rem; color: var(--color-galaxy-dark);
+  }
+  .faq-q::-webkit-details-marker { display: none; }
+  .faq-q:hover { color: var(--color-galaxy-primary); }
+  .faq-chevron { width: 1.15rem; height: 1.15rem; flex: none; color: var(--color-galaxy-primary); transition: transform 0.2s ease; }
+  .faq-item[open] .faq-chevron { transform: rotate(180deg); }
+  .faq-a { padding: 0 1.3rem 1.2rem; color: var(--color-galaxy-grey); line-height: 1.65; font-size: 0.97rem; }
+  .faq-a :global(a) { color: var(--color-galaxy-primary); text-decoration: underline; text-decoration-color: color-mix(in srgb, var(--color-galaxy-primary) 40%, transparent); text-underline-offset: 2px; }
+  .faq-a :global(a:hover) { color: var(--color-galaxy-gold-dark); }
+  .faq-a :global(code) { font-family: var(--font-mono); background: var(--color-light-bg); padding: 0.1em 0.35em; border-radius: 0.3rem; font-size: 0.86em; }
+  .faq-a :global(strong) { color: var(--color-galaxy-dark); }
 
   /* ---- docs cta ---- */
   .docs-cta { position: relative; color: #fff; padding: clamp(3.5rem, 6vw, 5rem) 0; overflow: hidden; }


### PR DESCRIPTION
Two landing-page additions:

**"Built on Galaxy's tools, workflows, and contracts"** section (after How-it-works) — makes the strongest differentiator explicit: the agent works from Galaxy's real, version-pinned tool catalog and curated IWC workflows through Galaxy MCP, and every run is a real Galaxy job/invocation with full provenance. Three points: real versioned tools, community workflows (not reinvented), reproducible by contract.

**FAQ section** (native `<details>` accordion, no JS) — 10 questions led by *why there are two names, Orbit and Loom*, plus *does this replace Galaxy?* (additive; both the reasoning and the computation are reproducible) and *won't the AI hallucinate tools?* (grounded in Galaxy's real catalog via MCP). Do-I-need-Galaxy, which models, how it differs from plain chat, MCP from other clients, open-source/cost, platforms, and an honest "is it ready for everyday use."

All answers grounded in the source audit. Build + typecheck clean; live-previewed.