### PR TITLE
Deemphasize notebook.md in the hero tagline

### DIFF
--- a/site/src/lib/site.ts
+++ b/site/src/lib/site.ts
@@ -22,4 +22,4 @@ export const links = {
 
 export const SITE_TITLE = 'Agentic Science with Galaxy';
 export const SITE_DESC =
-  'Point an AI agent at your data. It plans, runs real bioinformatics on Galaxy, and writes a reproducible notebook you can trust. Meet Orbit, Loom, and Galaxy MCP.';
+  'Point an AI agent at your data. It plans, runs real bioinformatics on Galaxy, and keeps the whole analysis fully reproducible and transparent. Meet Orbit, Loom, and Galaxy MCP.';

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -172,8 +172,8 @@ const faqs = [
         </h1>
         <p class="hero__lede reveal d3">
           Point an AI agent at your data. It plans, runs real bioinformatics on
-          <strong>Galaxy</strong>, and writes a reproducible
-          <span class="mono-inline">notebook.md</span> you can inspect, diff, and trust.
+          <strong>Galaxy</strong>, and keeps the whole analysis
+          <strong>fully reproducible and transparent</strong>.
         </p>
         <div class="hero__cta reveal d4">
           <a href={links.releases} class="btn btn-gold">Get Orbit</a>


### PR DESCRIPTION
Leads the hero with the outcome instead of the artifact. Was: *"…writes a reproducible notebook.md you can inspect, diff, and trust."* Now: *"…runs real bioinformatics on Galaxy, and keeps the whole analysis fully reproducible and transparent."* Same change to the meta/OG description. notebook.md is still covered in the demo, concepts doc, and FAQ.