### PR TITLE
Reframe the hero tagline: lead with grounded Galaxy execution

### DIFF
--- a/site/src/lib/site.ts
+++ b/site/src/lib/site.ts
@@ -22,4 +22,4 @@ export const links = {
 
 export const SITE_TITLE = 'Agentic Science with Galaxy';
 export const SITE_DESC =
-  'Point an AI agent at your data. It plans, runs real bioinformatics on Galaxy, and keeps the whole analysis fully reproducible and transparent. Meet Orbit, Loom, and Galaxy MCP.';
+  "An AI co-scientist for Galaxy: plan and iterate on best-practice analyses, run them on Galaxy's tools and workflows, all fully reproducible and transparent. Meet Orbit, Loom, and Galaxy MCP.";

--- a/site/src/lib/site.ts
+++ b/site/src/lib/site.ts
@@ -22,4 +22,4 @@ export const links = {
 
 export const SITE_TITLE = 'Agentic Science with Galaxy';
 export const SITE_DESC =
-  "An AI co-scientist for Galaxy: plan and iterate on best-practice analyses, run them on Galaxy's tools and workflows, all fully reproducible and transparent. Meet Orbit, Loom, and Galaxy MCP.";
+  "Plan, refine, and execute best-practice analyses, run on Galaxy's tools and workflows — every step reproducible and transparent. Meet Orbit, Loom, and Galaxy MCP.";

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -171,8 +171,8 @@ const faqs = [
           <span class="hero__accent">with Galaxy</span>
         </h1>
         <p class="hero__lede reveal d3">
-          Point an AI agent at your data. It plans, runs real bioinformatics on
-          <strong>Galaxy</strong>, and keeps the whole analysis
+          An <strong>AI co-scientist</strong> for Galaxy. Plan and iterate on
+          best-practice analyses, run them on Galaxy's tools and workflows — all
           <strong>fully reproducible and transparent</strong>.
         </p>
         <div class="hero__cta reveal d4">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -171,9 +171,8 @@ const faqs = [
           <span class="hero__accent">with Galaxy</span>
         </h1>
         <p class="hero__lede reveal d3">
-          An <strong>AI co-scientist</strong> for Galaxy. Plan and iterate on
-          best-practice analyses, run them on Galaxy's tools and workflows — all
-          <strong>fully reproducible and transparent</strong>.
+          Plan, refine, and execute best-practice analyses, run on Galaxy's tools
+          and workflows — every step <strong>reproducible and transparent</strong>.
         </p>
         <div class="hero__cta reveal d4">
           <a href={links.releases} class="btn btn-gold">Get Orbit</a>


### PR DESCRIPTION
Replaces the old fire-and-forget hero ("Point an AI agent at your data…") with a grounded, collaborative framing.

**Final lede:** *"Plan, refine, and execute best-practice analyses, run on Galaxy's tools and workflows — every step reproducible and transparent."* (meta/OG description matched.)

The branch first tried an "AI co-scientist" lede, but a second-opinion pass (codex) landed on: co-scientist is an overused AI label that oversells partnership and undersells the actual differentiator — grounded execution on Galaxy's real tools and IWC workflows. So the hero leads with that; "co-scientist" stays as the Orbit section heading (supporting description). Two commits show the evolution.