### PR TITLE
Fix routing-tag accuracy in the site Concepts doc

### DIFF
--- a/site/src/content/docs/concepts.md
+++ b/site/src/content/docs/concepts.md
@@ -25,26 +25,39 @@ inspectable record of *how you got there*.
 
 ## Plans and routing
 
-When you ask for a plan, the agent drafts a `## Plan X:` section. Each plan header
-carries a routing tag, and each step is tagged too:
+When you explicitly ask for a multi-step plan, the agent drafts a `## Plan X:`
+section. The plan header carries a single routing tag that summarizes how the
+whole plan runs:
 
-- `[galaxy]` — runs on Galaxy (an IWC workflow matches, or the heavy tool lives on Galaxy). This is the primary execution path.
-- `[local]` — runs on your machine.
-- `[hybrid]` — a mix.
+- `[galaxy]` — the primary path: steps run on Galaxy's tools and workflows. The
+  default whenever a matching Galaxy tool or workflow exists.
+- `[remote]` — the entire plan is a single Galaxy workflow invocation, because an
+  existing workflow matches it end to end.
+- `[hybrid]` — a mix: some steps run locally, some on Galaxy.
+- `[local]` — runs on your machine, reserved for personal-scale or ad-hoc work.
 
-Steps use markdown checkboxes and stable anchors:
+Individual steps don't repeat those bracket tags. Each step is a checklist item
+that records its execution route, its tool, and the verification that must pass
+before it can be marked done — all on indented sub-bullets:
 
 ```markdown
 ## Plan A: chrM Variant Calling [hybrid]
 
 ### Steps
-- [x] 1. QC FASTQ {#plan-a-step-1} — fastp trim + per-base QC
+- [x] 1. QC FASTQs {#plan-a-step-1} — fastp adapter trim + per-base QC
   - Routing: local
-- [ ] 3. Read alignment {#plan-a-step-3} — bwa mem, 4 samples
-  - Routing: Galaxy (bwa-mem2/2.2.1)
+  - Tool: fastp
+  - Verification: fastp report exists with per-base quality metrics
+- [ ] 2. Align to chrM {#plan-a-step-2} — BWA-MEM, 4 samples, sorted BAM out
+  - Routing: galaxy
+  - Tool: bwa_mem
+  - Verification: poll the Galaxy invocation to a terminal state, inspect the BAMs
 ```
 
-`- [ ]` is pending, `- [x]` is verified-done, `- [!]` is failed.
+Anchors like `{#plan-a-step-2}` are used where the model provider supports them,
+so invocation records can point back to a step. `- [ ]` is pending, `- [x]` is
+verified-done, `- [!]` is failed — and a step only becomes `- [x]` once the
+verification evidence is written into the notebook, never on job completion alone.
 
 ## The approval sequence
 
@@ -57,31 +70,39 @@ markdown, and manual override is allowed when you explicitly ask for it.
 
 ## Live invocation tracking
 
-While a Galaxy step runs, a `loom-invocation` fenced YAML block in the notebook
-tracks the invocation. A polling tool reads those blocks, queries Galaxy, and
-updates them in place as jobs finish or fail.
+When the agent invokes a Galaxy workflow it records a `loom-invocation` fenced
+block in the notebook and hands control back immediately — the job runs on
+Galaxy's infrastructure in the background. A polling tool reads those blocks,
+queries Galaxy, and updates them in place as jobs finish or fail, notifying you
+when the invocation reaches a terminal state.
 
-```yaml
+```loom-invocation
 invocation_id: f2db4a1c9e8b7654
 galaxy_server_url: https://usegalaxy.org
 notebook_anchor: plan-a-step-3
 label: BWA-MEM alignment (chrM, 4 samples)
-status: in_progress      # in_progress | completed | failed
+submitted_at: 2026-04-25T15:30:00Z
+status: in_progress
 completed_jobs: 1
 total_jobs: 4
 ```
 
-Small structured blocks like this handle the parts that need stable identity and
-programmatic updates, while the rest of the notebook stays plain, readable
-markdown.
+`status` advances `in_progress → completed` (or `failed`) on its own. A
+`completed` invocation still isn't a finished step: the agent inspects the output
+datasets and writes that evidence into the notebook before flipping the plan
+checkbox to `- [x]`. Small structured blocks like this handle the parts that need
+stable identity and programmatic updates, while the rest of the notebook stays
+plain, readable markdown.
 
 ## Git-tracked notebooks
 
-When Loom creates the analysis directory it `git init`s it and auto-commits every
-notebook change. That gives you a full undo history, timestamped reproducibility
-evidence, branchable exploration, and a notebook you can share on GitHub — for
-free. (If you start Loom inside a repo you already manage, auto-commit is opt-in,
-so it never touches your history without asking.)
+When Loom starts in a directory that isn't already a git repo, it runs `git init`,
+drops a bioinformatics-friendly `.gitignore` (large FASTQ/BAM/VCF files and the
+per-session activity logs stay out of history), and auto-commits every notebook
+change. That gives you a full undo history, timestamped reproducibility evidence,
+branchable exploration, and a notebook you can share on GitHub — for free. (If you
+start Loom inside a repo you already manage, auto-commit is opt-in, so it never
+touches your history without asking.)
 
 ## Skills
 


### PR DESCRIPTION
The Concepts page (`site/src/content/docs/concepts.md`) had inherited a stale routing-tag description, so I reconciled it against the live system prompt in `extensions/loom/context.ts` (with a codex review pass on top).

What changed:
- **Routing tags** -- the page listed only `[galaxy]`/`[local]`/`[hybrid]` and dropped `[remote]` entirely. Now lists all four header tags (`[galaxy]`, `[remote]`, `[hybrid]`, `[local]`) with `[galaxy]` as the default and the galaxy-vs-remote distinction spelled out. Also fixed the per-step format: steps record `Routing:`/`Tool:`/`Verification:` sub-bullets, they don't carry bracket tags.
- **`loom-invocation` example** -- was a plain ` ```yaml ` block missing the required `submitted_at` field. Now uses the real ` ```loom-invocation ` fence with `submitted_at`, and notes that a `completed` invocation still needs output verification before the step checkbox flips to `- [x]`.
- Surfaced that Galaxy jobs run in the **background** (record the invocation, auto-poll, notify at terminal state).
- Corrected the git-init trigger wording.

Docs-only. Builds clean -- all 6 pages render. Companion to the agent-docs drift cleanup (same root cause, different files).
