### PR TITLE
Add [galaxy] to the routing-tag docs

### DIFF
--- a/docs/agent/galaxy-routing.md
+++ b/docs/agent/galaxy-routing.md
@@ -1,11 +1,14 @@
 # Galaxy integration and routing
 
-Three operating modes are an _outcome_ of the plan you draft, not a
+Four routing modes are an _outcome_ of the plan you draft, not a
 configuration setting:
 
+- **galaxy** — steps run on Galaxy's tools and workflows; the default
+  when a matching Galaxy tool or workflow exists
+- **hybrid** — some steps local, some on Galaxy
 - **local** — every step runs locally
-- **hybrid** — some local, some Galaxy
-- **remote** — entire plan is one Galaxy workflow invocation
+- **remote** — entire plan is one Galaxy workflow invocation (an IWC
+  workflow matches it end to end)
 
 The agent makes the routing decision **per plan, during drafting**,
 once Galaxy is connected. The mode follows from those step-by-step

--- a/docs/agent/notebook-schema.md
+++ b/docs/agent/notebook-schema.md
@@ -50,8 +50,9 @@ Question: how do mtDNA variants distribute across tissues in this dataset?
 
 Conventions:
 
-- `## Plan X: <Title> [routing]` — routing tag is `[local]`, `[hybrid]`,
-  or `[remote]`. Future tooling greps for these literals.
+- `## Plan X: <Title> [routing]` — routing tag is `[galaxy]`, `[hybrid]`,
+  `[local]`, or `[remote]`. `[galaxy]` is the default when a matching Galaxy
+  tool/workflow exists. Future tooling greps for these literals.
 - `{#plan-x-step-N}` anchors so invocation YAML can reference steps.
 - Every step needs a concrete `Verification:` sub-bullet describing the
   evidence required before completion.

--- a/shared/loom-config.d.ts
+++ b/shared/loom-config.d.ts
@@ -47,7 +47,7 @@ export interface LoomConfig {
    * Execution mode gate. Independent of whether Galaxy credentials are
    * configured.
    * - \`cloud\` (default): agent decides per-plan whether each step runs
-   *   locally or on Galaxy. Plan routing tags (\`[local]\`/\`[hybrid]\`/\`[remote]\`)
+   *   locally or on Galaxy. Plan routing tags (\`[galaxy]\`/\`[hybrid]\`/\`[local]\`/\`[remote]\`)
    *   describe the resulting mix.
    * - \`local\`: project is sandboxed to local execution. The agent must not
    *   propose Galaxy steps even if Galaxy MCP is registered.


### PR DESCRIPTION
The plan routing enum in a few agent docs still listed only `[local]`/`[hybrid]`/`[remote]` -- they predate the fix that made `[galaxy]` a first-class routing tag (and the default) in `context.ts` and `init-gate.ts`. This brings them back in line with what the runtime actually parses and prompts.

- `docs/agent/notebook-schema.md` -- routing enum now `[galaxy]`/`[hybrid]`/`[local]`/`[remote]`, with `[galaxy]` noted as the default.
- `docs/agent/galaxy-routing.md` -- "three operating modes" reframed to four (adds `galaxy`, clarifies galaxy vs remote).
- `shared/loom-config.d.ts` -- the `executionMode` JSDoc lists `[galaxy]` too.

Docs/comments only -- no code path reads these, so no behavior change. The runtime prompt (`context.ts`) and the parser/gate (`init-gate.ts`) were already correct; this is just the surrounding docs catching up.

Found while fixing the same drift on the Agentic Science site's Concepts page (companion PR).
